### PR TITLE
fix: allow worktree setup from current branch

### DIFF
--- a/src/features/worktree/worktree-setup.ts
+++ b/src/features/worktree/worktree-setup.ts
@@ -8,7 +8,6 @@ import {resolveEnvContext} from '../env/env-files.js';
 import {addGitWorktree, isGitRepository, listGitWorktrees} from '../../core/platform/git.js';
 import type {Printer} from '../../core/output/printer.js';
 import {withProgress} from '../../core/output/printer.js';
-import {assertPrimaryCheckoutGuardrail} from './worktree-guardrails.js';
 import {runWorktreeEnv} from './worktree-env.js';
 import {resolveWorktreeContext, resolveWorktreeTarget} from './worktree-paths.js';
 import {assertSafeMainEnvClone, resolveBtrfsConfig} from './worktree-state.js';
@@ -42,7 +41,6 @@ export async function runWorktreeSetup(options: {
   }
 
   const context = resolveWorktreeContext(config.repoRoot);
-  await assertPrimaryCheckoutGuardrail(context, 'create another worktree from the wrong checkout root');
 
   if (options.withEnv ?? false) {
     const mainConfig = loadConfig({cwd: context.mainRepoRoot, env: process.env});

--- a/templates/ai/project/skills/issue-engineering/SKILL.md
+++ b/templates/ai/project/skills/issue-engineering/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: issue-engineering
-description: "Use when resolving any GitHub issue end-to-end: intake, isolated worktree, reproduction, fix, validation, PR, and cleanup. Single skill for issue resolution."
+description: 'Use when resolving any GitHub issue end-to-end: intake, isolated worktree, reproduction, fix, validation, PR, and cleanup. Single skill for issue resolution.'
 ---
 
 # Issue Engineering
@@ -11,15 +11,15 @@ Single guide for the full issue lifecycle. These guardrails are **non-negotiable
 
 ## Hard Guardrails
 
-| Rule | Do not do | Do |
-|---|---|---|
-| **Isolation** | Work in `main` | `ldev worktree setup --name issue-NUM --with-env` |
-| **Worktree creation** | `git worktree add` | `ldev worktree setup --name issue-NUM --with-env` — never use git directly; `ldev` adds env isolation on top |
-| **Cleanup** | `rm -rf .worktrees/NUM` | `ldev worktree clean issue-NUM --force` |
-| **Discovery** | Broad code search when the issue already has a URL | `ldev portal inventory page --url <URL>` first |
-| **Playwright** | Connect to production without local verification | Local first; production only on explicit request |
-| **Closure** | Clean the worktree before a PR exists | PR first, cleanup second |
-| **Worktree state** | Stop `main` without asking | If the guardrail says `main` is running without Btrfs, ask for confirmation before running `ldev stop` in `main` |
+| Rule                  | Do not do                                            | Do                                                                                                               |
+| --------------------- | ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| **Isolation**         | Work from the repo root as the active issue checkout | `ldev worktree setup --name issue-NUM --with-env`                                                                |
+| **Worktree creation** | `git worktree add`                                   | `ldev worktree setup --name issue-NUM --with-env` — never use git directly; `ldev` adds env isolation on top     |
+| **Cleanup**           | `rm -rf .worktrees/NUM`                              | `ldev worktree clean issue-NUM --force`                                                                          |
+| **Discovery**         | Broad code search when the issue already has a URL   | `ldev portal inventory page --url <URL>` first                                                                   |
+| **Playwright**        | Connect to production without local verification     | Local first; production only on explicit request                                                                 |
+| **Closure**           | Clean the worktree before a PR exists                | PR first, cleanup second                                                                                         |
+| **Worktree state**    | Stop `main` without asking                           | If the guardrail says `main` is running without Btrfs, ask for confirmation before running `ldev stop` in `main` |
 
 ---
 
@@ -36,6 +36,10 @@ ldev start
 ldev status --json
 ```
 
+If the current branch already contains the intended base work, `ldev worktree setup`
+can branch from that current HEAD by default. Use `--base <ref>` only when you want
+the new worktree to start from a different ref explicitly.
+
 ## Phase 0 — Intake (Optional if the issue is already clear)
 
 Extended reference: `references/intake.md`
@@ -47,11 +51,13 @@ gh issue view NUM --json title,body,labels,comments
 ```
 
 For each URL in the body:
+
 ```bash
 ldev portal inventory page --url <URL> --json
 ```
 
 If there are no exact URLs:
+
 ```bash
 ldev portal inventory sites --json
 ldev portal inventory pages --site /<site> --json
@@ -99,6 +105,7 @@ ldev logs --since 5m --no-follow
 ```
 
 Required gate:
+
 - If `pwd` or `git rev-parse --show-toplevel` does not point to `.worktrees/issue-NUM`, stop.
 - In that case: **ESCALATE**. Do not improvise work from the main checkout.
 - If `ldev status --json` is not healthy enough to reproduce locally, stop and fix runtime readiness before discovery.
@@ -106,6 +113,7 @@ Required gate:
 If the unsafe state-copy guardrail appears (`main` running without Btrfs), stop and ask the user before stopping `main`. Do not do it automatically.
 
 If the worktree database becomes inconsistent:
+
 ```bash
 ldev stop
 ldev env restore
@@ -122,6 +130,7 @@ until you have run `ldev start` + `ldev status --json` from the worktree.
 ## Phase 2 — Discovery and Reproduction
 
 Extended references:
+
 - `references/playwright-liferay.md`
 - `references/resource-origin.md` when the runtime URL, shared structure, and template source do not obviously belong to the same site
 
@@ -156,12 +165,12 @@ Discovery anti-patterns:
 
 ## Phase 3 — Resolution
 
-| Change type | Skill | Deploy |
-|---|---|---|
-| CSS / Theme | `developing-liferay` | `ldev deploy theme` |
-| Structures / Templates / ADTs | `developing-liferay` | `ldev resource import-structure` / `import-template` / `import-adt` |
-| Java / OSGi | `developing-liferay` | `ldev deploy module <name>` |
-| Data migration | `migrating-journal-structures` | — |
+| Change type                   | Skill                          | Deploy                                                              |
+| ----------------------------- | ------------------------------ | ------------------------------------------------------------------- |
+| CSS / Theme                   | `developing-liferay`           | `ldev deploy theme`                                                 |
+| Structures / Templates / ADTs | `developing-liferay`           | `ldev resource import-structure` / `import-template` / `import-adt` |
+| Java / OSGi                   | `developing-liferay`           | `ldev deploy module <name>`                                         |
+| Data migration                | `migrating-journal-structures` | —                                                                   |
 
 Make surgical changes. Do not touch code outside the fix surface.
 If validation is blocked by an unrelated runtime failure, stop the functional fix there, open or link a separate runtime issue, and do not silently fold that stabilization work into the original issue.
@@ -219,6 +228,7 @@ gh issue comment NUM --body "Fix in PR #<NUM>. [link to evidence]"
 ```
 
 Required PR body:
+
 - First line: `Closes #NUM` or `Fixes #NUM`
 - What the fix does
 - How to verify it step by step
@@ -241,13 +251,13 @@ ldev worktree clean issue-NUM --force
 
 ## Pipeline Troubleshooting
 
-| Symptom | Action |
-|---|---|
-| Port already in use in `ldev start` | `ldev status --json` — another worktree is active |
-| Unstable env / inconsistent DB | `ldev stop` → `ldev env restore` → `ldev start` |
-| Playwright: browser not installed | `node "$(npm root -g)/@playwright/cli/node_modules/playwright/cli.js" install chromium` |
-| Playwright: session-busy | Sequence commands, do not run them in parallel |
-| Blocked and unable to close | Comment on the issue with verified findings and what is still needed to unblock |
+| Symptom                             | Action                                                                                  |
+| ----------------------------------- | --------------------------------------------------------------------------------------- |
+| Port already in use in `ldev start` | `ldev status --json` — another worktree is active                                       |
+| Unstable env / inconsistent DB      | `ldev stop` → `ldev env restore` → `ldev start`                                         |
+| Playwright: browser not installed   | `node "$(npm root -g)/@playwright/cli/node_modules/playwright/cli.js" install chromium` |
+| Playwright: session-busy            | Sequence commands, do not run them in parallel                                          |
+| Blocked and unable to close         | Comment on the issue with verified findings and what is still needed to unblock         |
 
 ## Auxiliary Resources
 

--- a/templates/ai/project/skills/issue-engineering/references/worktree-env.md
+++ b/templates/ai/project/skills/issue-engineering/references/worktree-env.md
@@ -16,6 +16,10 @@ ldev start
 ldev status --json
 ```
 
+When you run `ldev worktree setup` from a non-`main` branch in the primary checkout,
+the new worktree branches from that current HEAD by default. Pass `--base <ref>` to
+override the starting ref when needed.
+
 `ldev start` returns as soon as Docker reports the container healthy (Tomcat up). Liferay still needs time to finish deploying bundles from the cache. Wait for the startup sequence to complete before using the portal:
 
 ```bash

--- a/tests/integration/worktree.integration.test.ts
+++ b/tests/integration/worktree.integration.test.ts
@@ -39,6 +39,36 @@ describe('worktree integration', () => {
     ).toBe(true);
   }, 15000);
 
+  test('worktree setup from a feature branch uses the current branch HEAD as default base', async () => {
+    const repoRoot = await createWorktreeRepoFixture();
+
+    await fs.writeFile(path.join(repoRoot, 'feature.txt'), 'from-feature-branch\n');
+    expect((await runProcess('git', ['checkout', '-b', 'feat/source-base'], {cwd: repoRoot})).exitCode).toBe(0);
+    expect((await runProcess('git', ['add', 'feature.txt'], {cwd: repoRoot})).exitCode).toBe(0);
+    expect((await runProcess('git', ['commit', '-m', 'feat: add feature marker'], {cwd: repoRoot})).exitCode).toBe(0);
+
+    const featureHead = (await runProcess('git', ['rev-parse', 'HEAD'], {cwd: repoRoot})).stdout.trim();
+
+    const result = await runWorktreeSetup({
+      cwd: repoRoot,
+      name: 'issue-from-feature',
+      printer: silentPrinter,
+    });
+
+    expect(result.ok).toBe(true);
+    expect((await runProcess('git', ['branch', '--show-current'], {cwd: repoRoot})).stdout.trim()).toBe(
+      'feat/source-base',
+    );
+    expect(
+      (
+        await runProcess('git', ['rev-parse', 'HEAD'], {cwd: path.join(repoRoot, '.worktrees', 'issue-from-feature')})
+      ).stdout.trim(),
+    ).toBe(featureHead);
+    expect(await fs.readFile(path.join(repoRoot, '.worktrees', 'issue-from-feature', 'feature.txt'), 'utf8')).toBe(
+      'from-feature-branch\n',
+    );
+  }, 15000);
+
   test('worktree env derives isolated compose settings from the main env', async () => {
     const repoRoot = await createWorktreeRepoFixture();
     await runWorktreeSetup({


### PR DESCRIPTION
## Summary
- allow `ldev worktree setup` to run from the primary checkout even when the current branch is not `main`
- preserve the existing runtime guardrail for `worktree start`
- document in the AI issue-engineering guidance that worktree setup now defaults to the current `HEAD` unless `--base` is provided
- add an integration test that verifies a worktree created from a feature branch uses that branch `HEAD` as its default base

## Root cause
`ldev worktree setup` already supported `--base <ref>`, but a shared guardrail still blocked setup whenever the primary checkout was on a non-`main` branch. That prevented a valid and already-supported flow: creating a new worktree from the current branch state.

## Validation
- `npm ci`
- `npx vitest run tests/unit/worktree-guardrails.test.ts`
- `npx vitest run --config vitest.integration.config.ts tests/integration/worktree.integration.test.ts`
- `npx prettier --check src/features/worktree/worktree-setup.ts tests/integration/worktree.integration.test.ts templates/ai/project/skills/issue-engineering/SKILL.md templates/ai/project/skills/issue-engineering/references/worktree-env.md`
- pre-push `verify:push` hook: lint, format check, typecheck, unit tests, build, smoke tests
