### PR TITLE
fix: use user endpoint for portal check

### DIFF
--- a/src/features/liferay/liferay-health.ts
+++ b/src/features/liferay/liferay-health.ts
@@ -4,7 +4,7 @@ import {createOAuthTokenClient, type OAuthTokenClient} from '../../core/http/aut
 import {createLiferayApiClient, type LiferayApiClient} from '../../core/http/client.js';
 import {authedGet} from './inventory/liferay-inventory-shared.js';
 
-const DEFAULT_HEALTH_PATH = '/o/headless-admin-site/v1.0/sites?pageSize=1';
+const HEALTH_PATH = '/o/headless-admin-user/v1.0/my-user-account';
 
 export type LiferayHealthResult = {
   ok: true;
@@ -15,6 +15,7 @@ export type LiferayHealthResult = {
   checkedPath: string;
   status: number;
   permissionDenied: boolean;
+  probeUnavailable: boolean;
 };
 
 type HealthDependencies = {
@@ -39,6 +40,7 @@ export async function runLiferayHealth(
     checkedPath: health.checkedPath,
     status: health.status,
     permissionDenied: health.permissionDenied,
+    probeUnavailable: health.probeUnavailable,
   };
 }
 
@@ -46,34 +48,45 @@ export async function performLiferayHealthCheck(
   config: AppConfig,
   accessToken: string,
   apiClient?: LiferayApiClient,
-): Promise<{status: number; checkedPath: string; permissionDenied: boolean}> {
+): Promise<{status: number; checkedPath: string; permissionDenied: boolean; probeUnavailable: boolean}> {
   const client = apiClient ?? createLiferayApiClient();
-  const response = await authedGet(config, client, accessToken, DEFAULT_HEALTH_PATH);
+  const response = await authedGet(config, client, accessToken, HEALTH_PATH);
+
+  if (response.ok) {
+    return {
+      status: response.status,
+      checkedPath: HEALTH_PATH,
+      permissionDenied: false,
+      probeUnavailable: false,
+    };
+  }
 
   if (response.status === 403) {
     return {
       status: response.status,
-      checkedPath: DEFAULT_HEALTH_PATH,
+      checkedPath: HEALTH_PATH,
       permissionDenied: true,
+      probeUnavailable: false,
     };
   }
 
-  if (!response.ok) {
-    throw new CliError(`health check failed with status=${response.status}.`, {
-      code: 'LIFERAY_HEALTH_ERROR',
-    });
+  if (response.status === 404) {
+    return {
+      status: response.status,
+      checkedPath: HEALTH_PATH,
+      permissionDenied: false,
+      probeUnavailable: true,
+    };
   }
 
-  return {
-    status: response.status,
-    checkedPath: DEFAULT_HEALTH_PATH,
-    permissionDenied: false,
-  };
+  throw new CliError(`health check failed with status=${response.status}.`, {
+    code: 'LIFERAY_HEALTH_ERROR',
+  });
 }
 
 export function formatLiferayHealth(result: LiferayHealthResult): string {
   const lines = [
-    result.permissionDenied ? 'HEALTH_PARTIAL' : 'HEALTH_OK',
+    result.permissionDenied || result.probeUnavailable ? 'HEALTH_PARTIAL' : 'HEALTH_OK',
     `baseUrl=${result.baseUrl}`,
     `clientId=${result.clientId}`,
     `checkedPath=${result.checkedPath}`,
@@ -84,7 +97,13 @@ export function formatLiferayHealth(result: LiferayHealthResult): string {
 
   if (result.permissionDenied) {
     lines.push(
-      'note=OAuth token retrieval succeeded, but the default site inventory probe was denied by this runtime. Portal auth is working; inventory and other API workflows may still require broader API scopes.',
+      'note=OAuth token retrieval succeeded, but the available health probes were denied by this runtime. Portal auth is working; inventory and other API workflows may still require broader API scopes.',
+    );
+  }
+
+  if (result.probeUnavailable) {
+    lines.push(
+      'note=OAuth token retrieval succeeded, but the health probe endpoints returned 404 on this runtime. Portal auth is working; this environment does not expose the default probe paths consistently.',
     );
   }
 

--- a/tests/smoke/liferay-auth-smoke.test.ts
+++ b/tests/smoke/liferay-auth-smoke.test.ts
@@ -50,8 +50,8 @@ describe('liferay auth smoke', () => {
             status: 200,
           });
         }
-        if (url.includes('/o/headless-admin-site/v1.0/sites?pageSize=1')) {
-          return new Response('{"items":[{"id":20121,"friendlyUrlPath":"/guest","name":"Guest"}],"lastPage":1}', {
+        if (url.includes('/o/headless-admin-user/v1.0/my-user-account')) {
+          return new Response('{"id":20123,"name":"Test User"}', {
             status: 200,
           });
         }

--- a/tests/unit/liferay-check.test.ts
+++ b/tests/unit/liferay-check.test.ts
@@ -34,8 +34,8 @@ describe('liferay check', () => {
     const apiClient = createLiferayApiClient({
       fetchImpl: async (input) => {
         const url = String(input);
-        if (url.includes('/o/headless-admin-site/v1.0/sites?pageSize=1')) {
-          return new Response('{"items":[{"id":20121,"friendlyUrlPath":"/guest","name":"Guest"}],"lastPage":1}', {
+        if (url.includes('/o/headless-admin-user/v1.0/my-user-account')) {
+          return new Response('{"id":20123,"name":"Test User"}', {
             status: 200,
           });
         }
@@ -52,15 +52,16 @@ describe('liferay check', () => {
       clientId: 'client-id',
       tokenType: 'Bearer',
       expiresIn: 3600,
-      checkedPath: '/o/headless-admin-site/v1.0/sites?pageSize=1',
+      checkedPath: '/o/headless-admin-user/v1.0/my-user-account',
       status: 200,
       permissionDenied: false,
+      probeUnavailable: false,
     });
     expect(formatLiferayHealth(result)).toContain('HEALTH_OK');
     expect(formatLiferayHealth(result)).toContain('status=200');
   });
 
-  test('reports partial health when the default probe is denied', async () => {
+  test('reports partial health when the user probe is denied', async () => {
     const apiClient = createLiferayApiClient({
       fetchImpl: async () => new Response('forbidden', {status: 403}),
     });
@@ -69,7 +70,22 @@ describe('liferay check', () => {
 
     expect(result.permissionDenied).toBe(true);
     expect(result.status).toBe(403);
+    expect(result.probeUnavailable).toBe(false);
     expect(formatLiferayHealth(result)).toContain('HEALTH_PARTIAL');
     expect(formatLiferayHealth(result)).toContain('status=403');
+  });
+
+  test('reports partial health when the user probe is unavailable on the runtime', async () => {
+    const apiClient = createLiferayApiClient({
+      fetchImpl: async () => new Response('not found', {status: 404}),
+    });
+
+    const result = await runLiferayHealth(CONFIG, {apiClient, tokenClient: TOKEN_CLIENT});
+
+    expect(result.permissionDenied).toBe(false);
+    expect(result.probeUnavailable).toBe(true);
+    expect(result.status).toBe(404);
+    expect(formatLiferayHealth(result)).toContain('HEALTH_PARTIAL');
+    expect(formatLiferayHealth(result)).toContain('status=404');
   });
 });


### PR DESCRIPTION
## Summary

Use `GET /o/headless-admin-user/v1.0/my-user-account` as the `ldev portal check` health probe instead of the fragile site inventory endpoint.

## Why

The previous probe depended on `/o/headless-admin-site/v1.0/sites?pageSize=1`, which returns `404` on at least some runtimes even when portal auth is working correctly. That made `portal check` fail against usable environments.

This change switches the probe to a more stable authenticated user endpoint and keeps partial-health handling for `403` and `404` responses.

Fixes #17.

## Validation

- `npm run test:unit -- tests/unit/liferay-check.test.ts`
- `npm run test:smoke -- tests/smoke/liferay-auth-smoke.test.ts`
- `npm run build`
- `git push -u origin codex/fix-portal-check-health-probe` (`verify:push` hook passed: lint, format:check, typecheck, test:unit, build, test:smoke)
