### PR TITLE
fix: improve ADT lookup and docs consistency

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -41,6 +41,7 @@ export default defineConfig({
           {text: 'Fix an OSGi Bundle', link: '/workflows/fix-osgi-bundle'},
           {text: 'Reproduce a Production Issue', link: '/workflows/reproduce-production-issue'},
           {text: 'PaaS to Local Migration', link: '/workflows/paas-to-local-migration'},
+          {text: 'Shrink Local Content', link: '/workflows/shrink-local-content'},
           {text: 'Explore a Portal', link: '/workflows/explore-portal'},
           {text: 'Export and Import Resources', link: '/workflows/export-import-resources'},
           {text: 'Resource Migration Pipeline', link: '/workflows/resource-migration-pipeline'},

--- a/docs/commands/discovery.md
+++ b/docs/commands/discovery.md
@@ -27,7 +27,7 @@ Real text-mode example:
 ```text
 HEALTH_OK
 baseUrl=http://localhost:8081
-checkedPath=/o/headless-admin-site/v1.0/sites?pageSize=1
+checkedPath=/o/headless-admin-user/v1.0/my-user-account
 status=200
 tokenType=Bearer
 expiresIn=600

--- a/docs/commands/resources.md
+++ b/docs/commands/resources.md
@@ -9,7 +9,7 @@ description: Minimal reference for exporting, importing, and migrating Liferay r
 
 ```bash
 ldev resource structure --site /global --key MY_STRUCTURE
-ldev resource template --site /global --key MY_TEMPLATE
+ldev resource template --site /global --id MY_TEMPLATE
 ldev resource adts --site /global
 ldev resource adt --site /global --display-style ddmTemplate_33994
 ldev resource fragments --site /global
@@ -19,7 +19,7 @@ Real examples:
 
 ```bash
 ldev resource structure --key BASIC-WEB-CONTENT
-ldev resource template --id BASIC-WEB-CONTENT
+ldev resource template --site /global --id MY_TEMPLATE
 ```
 
 ## Export

--- a/docs/workflows/paas-to-local-migration.md
+++ b/docs/workflows/paas-to-local-migration.md
@@ -74,7 +74,7 @@ Once you know which folders are oversized, run a dry-run prune:
 ldev portal content prune --group-id 2710030 --root-folder 15588732 --keep 100 --dry-run
 ```
 
-Apply only after checking the dry-run summary.
+Apply only after checking the dry-run summary. If this becomes a repeated step in your local incident workflow, use the dedicated [Shrink Local Content](/workflows/shrink-local-content) guide.
 
 ## 5. Diagnose and fix locally
 

--- a/scripts/smoke-test-solo-dxp.sh
+++ b/scripts/smoke-test-solo-dxp.sh
@@ -280,10 +280,6 @@ main() {
     bash -lc "cd \"$PROJECT_DIR\" && $LDEV resource template --id BASIC-WEB-CONTENT"
 
   run_check \
-    "resource adt-types passed" \
-    bash -lc "cd \"$PROJECT_DIR\" && $LDEV resource adt-types"
-
-  run_check \
     "resource export-structures passed" \
     bash -lc "cd \"$PROJECT_DIR\" && $LDEV resource export-structures --all-sites"
 

--- a/src/commands/resource/resource-command-builder.ts
+++ b/src/commands/resource/resource-command-builder.ts
@@ -672,7 +672,7 @@ export function buildResourceCommand(options: ResourceCommandOptions): Command {
     resource
       .command('adt')
       .description('Inspect one ADT in detail')
-      .option('--site <site>', 'Site friendly URL or numeric ID', '/global')
+      .option('--site <site>', 'Site friendly URL or numeric ID; omit to search accessible sites')
       .option('--display-style <displayStyle>', 'Runtime display style like ddmTemplate_19690804')
       .option('--id <id>', 'Numeric template id')
       .option('--key <key>', 'ADT template key')

--- a/src/features/liferay/resource/liferay-resource-get-adt.ts
+++ b/src/features/liferay/resource/liferay-resource-get-adt.ts
@@ -2,8 +2,10 @@ import {CliError} from '../../../core/errors.js';
 import type {AppConfig} from '../../../core/config/load-config.js';
 import type {OAuthTokenClient} from '../../../core/http/auth.js';
 import type {LiferayApiClient} from '../../../core/http/client.js';
+import {runLiferayInventorySitesIncludingGlobal} from '../inventory/liferay-inventory-sites.js';
 import {ADT_WIDGET_DIR_BY_TYPE} from './liferay-resource-paths.js';
 import {runLiferayResourceListAdts} from './liferay-resource-list-adts.js';
+import {resolveResourceSite} from './liferay-resource-shared.js';
 
 type ResourceDependencies = {
   apiClient?: LiferayApiClient;
@@ -38,18 +40,43 @@ export async function runLiferayResourceGetAdt(
   dependencies?: ResourceDependencies,
 ): Promise<LiferayResourceAdtResult> {
   const identifier = resolveIdentifier(options);
-  const rows = await runLiferayResourceListAdts(
-    config,
-    {
-      site: options.site ?? '/global',
-      widgetType: options.widgetType,
-      className: options.className,
-      includeScript: true,
-    },
-    dependencies,
-  );
+  const searchedSites = await collectSearchSites(config, options.site, dependencies);
+  const matches: Array<LiferayResourceAdtResult & {siteId?: number; siteName?: string}> = [];
 
-  const matches = rows.filter((row) => matchesAdt(row, identifier));
+  for (const site of searchedSites) {
+    const rows = await runLiferayResourceListAdts(
+      config,
+      {
+        site: site.siteFriendlyUrl,
+        widgetType: options.widgetType,
+        className: options.className,
+        includeScript: true,
+      },
+      dependencies,
+    );
+
+    for (const row of rows) {
+      if (!matchesAdt(row, identifier)) {
+        continue;
+      }
+
+      matches.push({
+        siteId: site.siteId,
+        siteName: site.siteName,
+        siteFriendlyUrl: site.siteFriendlyUrl,
+        widgetType: row.widgetType,
+        directory: ADT_WIDGET_DIR_BY_TYPE[row.widgetType] ?? row.widgetType.replaceAll('-', '_'),
+        className: row.className,
+        templateId: String(row.templateId),
+        displayStyle: `ddmTemplate_${row.templateId}`,
+        templateKey: row.templateKey,
+        displayName: row.displayName,
+        adtName: row.adtName,
+        classNameId: row.classNameId,
+        script: row.script ?? '',
+      });
+    }
+  }
 
   if (matches.length === 0) {
     throw new CliError(`ADT not found: ${identifier}`, {
@@ -58,30 +85,34 @@ export async function runLiferayResourceGetAdt(
   }
 
   if (matches.length > 1) {
-    throw new CliError(`ADT ambiguo para ${identifier}. Usa --widget-type o --class-name para acotar la busqueda.`, {
-      code: 'LIFERAY_RESOURCE_ERROR',
-      details: matches.map((row) => ({
-        widgetType: row.widgetType,
-        templateId: row.templateId,
-        templateKey: row.templateKey,
-        adtName: row.adtName,
-      })),
-    });
+    throw new CliError(
+      `ADT is ambiguous for ${identifier}. Use --site, --widget-type, or --class-name to narrow the search.`,
+      {
+        code: 'LIFERAY_RESOURCE_ERROR',
+        details: matches.map((row) => ({
+          site: row.siteFriendlyUrl,
+          widgetType: row.widgetType,
+          templateId: row.templateId,
+          templateKey: row.templateKey,
+          adtName: row.adtName,
+        })),
+      },
+    );
   }
 
   const match = matches[0]!;
   return {
-    siteFriendlyUrl: options.site ?? '/global',
+    siteFriendlyUrl: match.siteFriendlyUrl,
     widgetType: match.widgetType,
-    directory: ADT_WIDGET_DIR_BY_TYPE[match.widgetType] ?? match.widgetType.replaceAll('-', '_'),
+    directory: match.directory,
     className: match.className,
-    templateId: String(match.templateId),
-    displayStyle: `ddmTemplate_${match.templateId}`,
+    templateId: match.templateId,
+    displayStyle: match.displayStyle,
     templateKey: match.templateKey,
     displayName: match.displayName,
     adtName: match.adtName,
     classNameId: match.classNameId,
-    script: match.script ?? '',
+    script: match.script,
   };
 }
 
@@ -142,4 +173,22 @@ function matchesAdt(
     identifier === row.adtName ||
     identifier === `ddmTemplate_${row.templateId}`
   );
+}
+
+async function collectSearchSites(
+  config: AppConfig,
+  requestedSite: string | undefined,
+  dependencies?: ResourceDependencies,
+): Promise<Array<{siteId: number; siteFriendlyUrl: string; siteName: string}>> {
+  if (requestedSite?.trim()) {
+    const site = await resolveResourceSite(config, requestedSite, dependencies);
+    return [{siteId: site.id, siteFriendlyUrl: site.friendlyUrlPath, siteName: site.name}];
+  }
+
+  const sites = await runLiferayInventorySitesIncludingGlobal(config, undefined, dependencies);
+  return sites.map((site) => ({
+    siteId: site.groupId,
+    siteFriendlyUrl: site.siteFriendlyUrl,
+    siteName: site.name,
+  }));
 }

--- a/tests/unit/liferay-resource-get-adt.test.ts
+++ b/tests/unit/liferay-resource-get-adt.test.ts
@@ -94,4 +94,74 @@ describe('liferay resource adt', () => {
     expect(formatLiferayResourceAdt(result)).toContain('RESOURCE_ADT');
     expect(formatLiferayResourceAdt(result)).toContain('directory=search_result_summary');
   });
+
+  test('searches accessible sites when --site is omitted', async () => {
+    const apiClient = createLiferayApiClient({
+      fetchImpl: async (input) => {
+        const url = String(input);
+
+        if (url.includes('/o/headless-admin-site/v1.0/sites?page=1&pageSize=200')) {
+          return new Response(
+            '{"items":[{"id":30100,"friendlyUrlPath":"/guest","nameCurrentValue":"Guest"}],"lastPage":1}',
+            {status: 200},
+          );
+        }
+        if (url.includes('/by-friendly-url-path/global')) {
+          return new Response('{"id":20121,"friendlyUrlPath":"/global","name":"Global"}', {status: 200});
+        }
+        if (url.includes('/by-friendly-url-path/guest')) {
+          return new Response('{"id":30100,"friendlyUrlPath":"/guest","name":"Guest"}', {status: 200});
+        }
+        if (url.includes('/api/jsonws/group/get-group?groupId=20121')) {
+          return new Response('{"companyId":10157}', {status: 200});
+        }
+        if (url.includes('/api/jsonws/group/get-group?groupId=30100')) {
+          return new Response('{"companyId":10157}', {status: 200});
+        }
+        if (
+          url.includes(
+            '/api/jsonws/classname/fetch-class-name?value=com.liferay.portlet.display.template.PortletDisplayTemplate',
+          )
+        ) {
+          return new Response('{"classNameId":2001}', {status: 200});
+        }
+        if (
+          url.includes(
+            '/api/jsonws/classname/fetch-class-name?value=com.liferay.portal.search.web.internal.result.display.context.SearchResultSummaryDisplayContext',
+          )
+        ) {
+          return new Response('{"classNameId":3001}', {status: 200});
+        }
+        if (
+          url.includes(
+            '/api/jsonws/ddm.ddmtemplate/get-templates?companyId=10157&groupId=20121&classNameId=3001&resourceClassNameId=2001&status=0',
+          )
+        ) {
+          return new Response('[]', {status: 200});
+        }
+        if (
+          url.includes(
+            '/api/jsonws/ddm.ddmtemplate/get-templates?companyId=10157&groupId=30100&classNameId=3001&resourceClassNameId=2001&status=0',
+          )
+        ) {
+          return new Response(
+            '[{"templateId":50901,"templateKey":"GUEST_SEARCH_RESULTS","nameCurrentValue":"Guest Search Results","classNameId":3001,"script":"<#-- guest -->"}]',
+            {status: 200},
+          );
+        }
+
+        throw new Error(`Unexpected URL ${url}`);
+      },
+    });
+
+    const result = await runLiferayResourceGetAdt(
+      CONFIG,
+      {displayStyle: 'ddmTemplate_50901', widgetType: 'search-results'},
+      {apiClient, tokenClient: TOKEN_CLIENT},
+    );
+
+    expect(result.siteFriendlyUrl).toBe('/guest');
+    expect(result.templateId).toBe('50901');
+    expect(result.script).toBe('<#-- guest -->');
+  });
 });


### PR DESCRIPTION
## What changed

- fixed `ldev resource adt` so omitting `--site` searches `/global` plus accessible sites instead of silently defaulting to `/global`
- removed the stale `resource adt-types` call from the manual solo smoke script
- corrected resource command docs and content-prune workflow navigation in the docs site
- updated the `portal check` documentation example to the current health probe path

## Why

`resource adt` had become too narrow after replacing the old resolver flow. Without an explicit `--site`, it only searched `/global`, which made valid ADTs in other accessible sites look missing. The docs also had a few inconsistencies after the command and docs rework.

## Impact

- `ldev resource adt` is more useful by default and still asks the user to disambiguate when multiple matches exist
- the manual smoke script no longer calls a removed command
- the content-prune workflow is reachable from the sidebar and linked from the migration flow
- command examples now match the current CLI behavior

## Validation

- `npm test -- --run tests/unit/liferay-resource-get-adt.test.ts tests/smoke/liferay-resource-smoke.test.ts tests/smoke/help.test.ts`
- `npm run docs:check-links`
- `git push -u origin codex/fix-mejor` (triggered `verify:push`, including lint, format, typecheck, unit tests, build, and smoke tests)
