### PR TITLE
docs: add OAuth overview to docs

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -51,6 +51,7 @@ export default defineConfig({
         text: 'Core Concepts',
         items: [
           {text: 'Environments', link: '/core-concepts/environments'},
+          {text: 'OAuth', link: '/core-concepts/oauth'},
           {text: 'Discovery', link: '/core-concepts/discovery'},
           {text: 'Operations Model', link: '/core-concepts/operations'},
           {text: 'Structured Output', link: '/core-concepts/structured-output'},

--- a/docs/commands/discovery.md
+++ b/docs/commands/discovery.md
@@ -75,3 +75,7 @@ Create or refresh the OAuth app used by `ldev`.
 ```bash
 ldev oauth install --write-env
 ```
+
+Use this once after the portal is ready so API-backed commands can authenticate. The local credentials are written to `.liferay-cli.local.yml`.
+
+See [OAuth](/core-concepts/oauth) for the full model.

--- a/docs/core-concepts/oauth.md
+++ b/docs/core-concepts/oauth.md
@@ -1,0 +1,89 @@
+---
+title: OAuth
+description: How OAuth fits into ldev, what `ldev oauth install --write-env` does, and where credentials are stored.
+---
+
+# OAuth
+
+OAuth is a core part of how `ldev` talks to Liferay.
+
+Many `ldev` commands work through Liferay APIs rather than through the UI. That includes:
+
+- portal discovery
+- portal checks
+- resource export and import
+- inventory and page inspection
+- MCP and agent-friendly API access
+
+That means `ldev` needs a valid OAuth2 client for the current portal.
+
+## The normal user flow
+
+Once the portal is up and the setup wizard is complete, install OAuth once:
+
+```bash
+ldev oauth install --write-env
+```
+
+That command creates or refreshes the managed OAuth app used by `ldev`, then writes the read-write client credentials into:
+
+- `.liferay-cli.local.yml`
+
+After that, commands such as these can authenticate directly against the portal APIs:
+
+```bash
+ldev portal check
+ldev portal inventory sites
+ldev liferay auth check
+```
+
+## Where credentials live
+
+For OAuth credentials, the preferred local destination is:
+
+- `.liferay-cli.local.yml`
+
+This file is local-only and should not be committed.
+
+`ldev` still supports `docker/.env` as a legacy fallback for some runtime values and older setups, but OAuth credentials written by `ldev oauth install --write-env` go to `.liferay-cli.local.yml`.
+
+## Resolution order
+
+For the portal URL and OAuth credentials, `ldev` resolves configuration in this order:
+
+1. shell environment variables
+2. `.liferay-cli.local.yml`
+3. `docker/.env` as a legacy fallback
+4. built-in defaults
+
+For shared project defaults such as paths, `ldev` uses:
+
+1. `.liferay-cli.yml`
+2. `.liferay-cli.local.yml` when overriding those values locally
+
+## Why there are two install paths
+
+`ldev oauth install` supports two project shapes:
+
+- `ldev-native`: deploy the bundled OAuth installer and invoke its Gogo command directly
+- Liferay Workspace: deploy the same bundle and bootstrap via a temporary OSGi config
+
+The user-facing contract is the same in both cases:
+
+- install or refresh the managed OAuth app
+- verify that the credentials work when possible
+- persist local credentials for the CLI
+
+## When OAuth is not ready yet
+
+If the portal setup wizard is not complete, or the local portal is not reachable yet, OAuth-based commands will fail or stay pending.
+
+Start with:
+
+```bash
+ldev doctor
+ldev oauth install --write-env
+ldev portal check
+```
+
+If that still fails, see [Troubleshooting](/troubleshooting#oauth-authentication).

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -90,6 +90,10 @@ ldev oauth install --write-env
 ldev portal check
 ```
 
+`ldev` uses OAuth2 for portal discovery, resource operations, and other API-backed commands. `--write-env` writes the local credentials into `.liferay-cli.local.yml`.
+
+See [OAuth](/core-concepts/oauth) for the model and [Configuration](/reference/configuration) for precedence.
+
 ## 6. Prepare the repo for agents
 
 If you want coding agents to work through `ldev`, bootstrap the managed AI assets:

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -8,8 +8,9 @@ description: Configuration files, precedence, and secret handling for ldev envir
 `ldev` resolves configuration from these sources, highest priority first:
 
 1. shell environment variables
-2. `docker/.env`
-3. `.liferay-cli.yml`
+2. `.liferay-cli.local.yml`
+3. `docker/.env` as a legacy fallback for runtime and some connection values
+4. `.liferay-cli.yml`
 
 ## Main files
 
@@ -23,21 +24,25 @@ Local runtime values such as:
 - `LCP_PROJECT`
 - `LCP_ENVIRONMENT`
 
+`ldev` may also read `LIFERAY_CLI_URL` and OAuth variables from here as a legacy fallback, but this is not the preferred destination for `ldev oauth install --write-env`.
+
 ### `.liferay-cli.yml`
 
-Version-controlled project defaults such as resource paths.
+Version-controlled project defaults such as resource paths and shared non-secret defaults.
 
 Keep secrets out of this file.
 
 ### `.liferay-cli.local.yml`
 
-Local credentials written by:
+Local credentials and local-only overrides written by:
 
 ```bash
 ldev oauth install --write-env
 ```
 
 Do not commit it.
+
+This is the preferred file for local OAuth credentials.
 
 ## Useful environment variables
 
@@ -48,4 +53,6 @@ export REPO_ROOT=/path/to/project
 
 ## Secret handling
 
-Keep OAuth credentials and other secrets in local env files or your shell environment. Do not store them in committed project config.
+Keep OAuth credentials and other secrets in `.liferay-cli.local.yml` or your shell environment. Do not store them in committed project config.
+
+See [OAuth](/core-concepts/oauth) for the user-facing OAuth model.


### PR DESCRIPTION
## Summary

This adds a small but explicit OAuth introduction to the user docs and aligns the configuration reference with how `ldev` actually resolves local credentials.

## What Changed

- add a new core-concepts page explaining why OAuth is a key part of `ldev`
- document what `ldev oauth install --write-env` does and where it writes credentials
- link the new OAuth explanation from quickstart and command docs
- fix the configuration reference so `.liferay-cli.local.yml` is documented as the preferred local OAuth credential file
- clarify that `docker/.env` is still a legacy fallback, not the preferred destination for OAuth credentials

## Why

OAuth is fundamental to `ldev` because portal discovery, health checks, resource operations, and other API-backed commands depend on it. The current docs mention `ldev oauth install --write-env` in several places, but they do not explain the model clearly enough and the config reference was out of sync with the real precedence used by the CLI.

## Validation

- `npm run docs:build`
- `git push -u origin docs/oauth-intro` (pre-push `verify:push` passed: lint, format:check, typecheck, test:unit, build, test:smoke)
