### PR TITLE
fix: align workspace elasticsearch and oauth scaffold behavior

### DIFF
--- a/templates/docker/liferay-configs-full/osgi/configs/com.liferay.portal.search.elasticsearch7.configuration.ElasticsearchConfiguration.config
+++ b/templates/docker/liferay-configs-full/osgi/configs/com.liferay.portal.search.elasticsearch7.configuration.ElasticsearchConfiguration.config
@@ -1,2 +1,5 @@
+# ES modo remoto — contenedor Docker independiente (elasticsearch:7.x + plugins Liferay)
 operationMode="REMOTE"
 networkHostAddresses=["http://elasticsearch:9200"]
+authenticationEnabled=B"false"
+httpSSLEnabled=B"false"

--- a/templates/liferay/gitignore
+++ b/templates/liferay/gitignore
@@ -27,3 +27,6 @@ yarn.lock
 
 # Local DXP activation keys must never be committed
 configs/dockerenv/osgi/modules/activation-key-*.xml
+
+# Workspace OAuth bootstrap config is generated locally by ldev oauth install
+configs/dockerenv/osgi/configs/dev.mordonez.ldev.oauth2.app.configuration.LdevOAuth2AppConfiguration.config

--- a/tests/integration/env-compose-profiles.integration.test.ts
+++ b/tests/integration/env-compose-profiles.integration.test.ts
@@ -52,6 +52,21 @@ describe('env compose profiles (ldev setup --with)', () => {
         ),
       ),
     ).toBe(true);
+    const copiedConfig = await fs.readFile(
+      path.join(
+        repoRoot,
+        'liferay',
+        'configs',
+        'dockerenv',
+        'osgi',
+        'configs',
+        'com.liferay.portal.search.elasticsearch7.configuration.ElasticsearchConfiguration.config',
+      ),
+      'utf8',
+    );
+    expect(copiedConfig).toContain('networkHostAddresses=["http://elasticsearch:9200"]');
+    expect(copiedConfig).toContain('authenticationEnabled=B"false"');
+    expect(copiedConfig).toContain('httpSSLEnabled=B"false"');
   }, 20_000);
 
   test('DXP + ES + PostgreSQL: setup --with elasticsearch --with postgres persists COMPOSE_FILE with full stack', async () => {
@@ -94,7 +109,13 @@ async function createEnvRepoFixture(): Promise<string> {
       'configs',
       'com.liferay.portal.search.elasticsearch7.configuration.ElasticsearchConfiguration.config',
     ),
-    'operationMode="REMOTE"\nnetworkHostAddresses=["http://elasticsearch:9200"]\n',
+    [
+      'operationMode="REMOTE"',
+      'networkHostAddresses=["http://elasticsearch:9200"]',
+      'authenticationEnabled=B"false"',
+      'httpSSLEnabled=B"false"',
+      '',
+    ].join('\n'),
   );
   await fs.writeFile(
     path.join(repoRoot, 'liferay', 'configs', 'dockerenv', 'portal-ext.properties'),

--- a/tests/integration/oauth-workspace.integration.test.ts
+++ b/tests/integration/oauth-workspace.integration.test.ts
@@ -82,6 +82,8 @@ describe('oauth workspace integration', () => {
     );
     expect(osgiConfig).toContain('enabled=B"true"');
     expect(osgiConfig).toContain('externalReferenceCode="ldev"');
+    expect(osgiConfig).toContain('clientId=');
+    expect(osgiConfig).toContain('clientSecret=');
     expect(osgiConfig).toContain('scopeAliases=[');
     expect(osgiConfig).toContain('"custom.scope.everything.write"');
     expect(osgiConfig).toContain('"Liferay.Object.Admin.REST.everything.write"');


### PR DESCRIPTION
## What changed

This fixes two onboarding/scaffold inconsistencies for workspace-based projects.

- restore the full Elasticsearch remote configuration in `templates/docker/liferay-configs-full` so `ldev setup --with elasticsearch` copies the same baseline expected by the workspace scaffold
- ignore the generated workspace OAuth bootstrap OSGi config so `ldev oauth install` does not leave noisy local state in `git status`
- strengthen integration coverage to assert the copied Elasticsearch config content and the actual workspace OAuth bootstrap config shape

## Why

Projects created or onboarded with `ldev` could drift from the intended Elasticsearch baseline, and workspace OAuth bootstrap could leave a generated OSGi config looking like an unexpected project change.

## Impact

Workspace repos should now keep the expected Elasticsearch config after onboarding, and the OAuth bootstrap config is treated as local generated state instead of something to commit.

## Root cause

The Docker-side Elasticsearch config template had diverged from the main workspace baseline, and the workspace `.gitignore` did not exclude the temporary OAuth bootstrap config written by `ldev oauth install`.

## Validation

- `npm test -- --run tests/unit/oauth.test.ts`
- `npx vitest run --config vitest.integration.config.ts tests/integration/env-compose-profiles.integration.test.ts tests/integration/oauth-workspace.integration.test.ts`
- `git push -u origin codex/fix-workspace-elasticsearch-oauth-scaffold` ran the repository `verify:push` checks successfully
