### PR TITLE
refactor(R4): capability matrix and declarative fallback

### DIFF
--- a/src/features/liferay/inventory/capabilities.ts
+++ b/src/features/liferay/inventory/capabilities.ts
@@ -1,0 +1,64 @@
+/**
+ * R4: Declarative operation policies — which transport surfaces to try, in order.
+ *
+ * Each operation declares the surfaces (API endpoints/protocols) it can use,
+ * in order of preference. The operation implementation reads the policy and
+ * executes surfaces in order, with fallback chain semantics.
+ *
+ * Surfaces:
+ * - headless-admin-site: Liferay Headless Admin Site API (/o/headless-admin-site)
+ * - headless-admin-user: Liferay Headless Admin User API (/o/headless-admin-user) - includes company groups
+ * - headless-delivery: Liferay Headless Delivery API (/o/headless-delivery)
+ * - jsonws: Legacy Liferay JSONWS RPC API (/api/jsonws)
+ */
+
+export type OperationName = 'site.resolve' | 'inventory.listSites' | 'inventory.listTemplates';
+
+export type TransportSurface = 'headless-admin-site' | 'headless-admin-user' | 'headless-delivery' | 'jsonws';
+
+export type OperationPolicy = {
+  readonly operation: OperationName;
+  /**
+   * Ordered surfaces: primary first, fallbacks in order.
+   * At least one surface required (hence [TransportSurface, ...TransportSurface[]]).
+   */
+  readonly surfaces: readonly [TransportSurface, ...TransportSurface[]];
+};
+
+const POLICIES: ReadonlyMap<OperationName, OperationPolicy> = new Map<OperationName, OperationPolicy>([
+  [
+    'site.resolve',
+    {
+      operation: 'site.resolve',
+      surfaces: ['headless-admin-site', 'headless-admin-user', 'jsonws'],
+    },
+  ],
+  [
+    'inventory.listSites',
+    {
+      operation: 'inventory.listSites',
+      surfaces: ['headless-admin-site', 'jsonws'],
+    },
+  ],
+  [
+    'inventory.listTemplates',
+    {
+      operation: 'inventory.listTemplates',
+      surfaces: ['headless-delivery', 'jsonws'],
+    },
+  ],
+]);
+
+/**
+ * Get the transport policy for an operation.
+ * @param operation The operation name
+ * @returns The policy defining surfaces to try and their order
+ * @throws Error if no policy is defined for the operation
+ */
+export function getOperationPolicy(operation: OperationName): OperationPolicy {
+  const policy = POLICIES.get(operation);
+  if (!policy) {
+    throw new Error(`No transport policy defined for operation: ${operation}`);
+  }
+  return policy;
+}

--- a/src/features/liferay/inventory/liferay-inventory-sites.ts
+++ b/src/features/liferay/inventory/liferay-inventory-sites.ts
@@ -1,14 +1,12 @@
 import type {AppConfig} from '../../../core/config/load-config.js';
+import {CliError} from '../../../core/errors.js';
 import type {LiferayApiClient} from '../../../core/http/client.js';
 import {createLiferayApiClient} from '../../../core/http/client.js';
 import type {OAuthTokenClient} from '../../../core/http/auth.js';
-import {
-  authedGet,
-  fetchAccessToken,
-  fetchPagedItems,
-  normalizeFriendlyUrl,
-  normalizeLocalizedName,
-} from './liferay-inventory-shared.js';
+import {createOAuthTokenClient} from '../../../core/http/auth.js';
+import {fetchPagedItems, normalizeFriendlyUrl, normalizeLocalizedName} from './liferay-inventory-shared.js';
+import {createLiferayGateway, type LiferayGateway} from '../liferay-gateway.js';
+import {getOperationPolicy} from './capabilities.js';
 import {resolveResourceSite} from '../resource/liferay-resource-shared.js';
 
 export type LiferayInventorySite = {
@@ -31,23 +29,52 @@ export async function runLiferayInventorySites(
   dependencies?: {apiClient?: LiferayApiClient; tokenClient?: OAuthTokenClient},
 ): Promise<LiferayInventorySite[]> {
   const apiClient = dependencies?.apiClient ?? createLiferayApiClient();
-  const tokenClient = dependencies?.tokenClient;
+  const tokenClient = dependencies?.tokenClient ?? createOAuthTokenClient();
   const pageSize = options?.pageSize ?? 200;
+  const policy = getOperationPolicy('inventory.listSites');
+  const gateway = createLiferayGateway(config, apiClient, tokenClient);
 
-  let items: HeadlessSite[];
-  try {
-    items = await fetchPagedItems<HeadlessSite>(config, '/o/headless-admin-site/v1.0/sites', pageSize, {
-      apiClient,
-      tokenClient,
-    });
-  } catch (error) {
-    items = await fetchSitesViaJsonws(config, apiClient, tokenClient);
-    if (items.length === 0) {
-      throw error;
+  let lastError: unknown;
+  let sawEmptyHeadlessResponse = false;
+
+  for (const surface of policy.surfaces) {
+    if (surface === 'headless-admin-site') {
+      try {
+        const items = await fetchPagedItems<HeadlessSite>(config, '/o/headless-admin-site/v1.0/sites', pageSize, {
+          apiClient,
+          tokenClient,
+        });
+        if (items.length > 0) {
+          return items.map(normalizeSite);
+        }
+        sawEmptyHeadlessResponse = true;
+      } catch (error) {
+        lastError = error;
+        continue;
+      }
+    }
+
+    if (surface === 'jsonws') {
+      try {
+        const items = await fetchSitesViaJsonws(gateway);
+        if (items.length > 0) {
+          return items.map(normalizeSite);
+        }
+      } catch {
+        // JSONWS unavailable; preserve lastError from headless
+      }
     }
   }
 
-  return items.map(normalizeSite);
+  if (sawEmptyHeadlessResponse) {
+    return [];
+  }
+
+  if (lastError instanceof Error) {
+    throw lastError;
+  }
+
+  throw new CliError('Could not list sites.', {code: 'LIFERAY_INVENTORY_ERROR'});
 }
 
 export async function runLiferayInventorySitesIncludingGlobal(
@@ -104,82 +131,75 @@ function buildPagesCommand(siteFriendlyUrl: string): string {
   return `inventory pages --site ${siteFriendlyUrl}`;
 }
 
-type JsonwsCompany = {
-  companyId?: number;
-};
+async function fetchSitesViaJsonws(gateway: LiferayGateway): Promise<HeadlessSite[]> {
+  type JsonwsCompany = {companyId?: number};
+  type JsonwsGroupSearchResult = {
+    groupId?: number;
+    friendlyURL?: string;
+    friendlyUrl?: string;
+    nameCurrentValue?: string;
+    name?: string;
+    site?: boolean;
+  };
 
-type JsonwsGroup = {
-  groupId?: number;
-  friendlyURL?: string;
-  friendlyUrl?: string;
-  nameCurrentValue?: string;
-  name?: string;
-  site?: boolean;
-};
+  let companies: JsonwsCompany[] = [];
+  try {
+    companies = await gateway.getJson<JsonwsCompany[]>('/api/jsonws/company/get-companies', 'list-jsonws-companies');
+  } catch {
+    return [];
+  }
 
-async function fetchSitesViaJsonws(
-  config: AppConfig,
-  apiClient: LiferayApiClient,
-  tokenClient?: OAuthTokenClient,
-): Promise<HeadlessSite[]> {
-  const accessToken = await fetchAccessToken(config, {apiClient, tokenClient});
-  const companiesResponse = await authedGet<JsonwsCompany[]>(
-    config,
-    apiClient,
-    accessToken,
-    '/api/jsonws/company/get-companies',
-  );
-
-  if (!companiesResponse.ok || !Array.isArray(companiesResponse.data)) {
+  if (!Array.isArray(companies)) {
     return [];
   }
 
   const sites: HeadlessSite[] = [];
 
-  for (const company of companiesResponse.data) {
+  for (const company of companies) {
     const companyId = company.companyId ?? 0;
     if (companyId <= 0) {
       continue;
     }
 
-    const countResponse = await apiClient.get<string>(
-      config.liferay.url,
-      `/api/jsonws/group/search-count?companyId=${companyId}&name=&description=&params=%7B%7D`,
-      {
-        timeoutSeconds: config.liferay.timeoutSeconds,
-        headers: {Authorization: `Bearer ${accessToken}`},
-      },
-    );
-
-    if (!countResponse.ok) {
+    let total: number;
+    try {
+      const totalStr = await gateway.getJson<string>(
+        `/api/jsonws/group/search-count?companyId=${companyId}&name=&description=&params=%7B%7D`,
+        'count-jsonws-groups',
+      );
+      total = Number.parseInt(totalStr, 10);
+    } catch {
       continue;
     }
 
-    const total = Number.parseInt(countResponse.body.trim().replace(/^"(.*)"$/, '$1'), 10);
     if (!Number.isFinite(total) || total <= 0) {
       continue;
     }
 
     for (let start = 0; start < total; start += 100) {
       const end = start + 100;
-      const response = await authedGet<JsonwsGroup[]>(
-        config,
-        apiClient,
-        accessToken,
-        '/api/jsonws/group/search' +
-          `?companyId=${companyId}` +
-          '&name=' +
-          '&description=' +
-          '&params=%7B%7D' +
-          `&start=${start}` +
-          `&end=${end}`,
-      );
+      let groups: JsonwsGroupSearchResult[] = [];
 
-      if (!response.ok || !Array.isArray(response.data)) {
+      try {
+        groups = await gateway.getJson<JsonwsGroupSearchResult[]>(
+          '/api/jsonws/group/search' +
+            `?companyId=${companyId}` +
+            '&name=' +
+            '&description=' +
+            '&params=%7B%7D' +
+            `&start=${start}` +
+            `&end=${end}`,
+          'search-jsonws-groups',
+        );
+      } catch {
         continue;
       }
 
-      for (const item of response.data) {
+      if (!Array.isArray(groups)) {
+        continue;
+      }
+
+      for (const item of groups) {
         if (!item.site) {
           continue;
         }

--- a/src/features/liferay/inventory/liferay-inventory-templates.ts
+++ b/src/features/liferay/inventory/liferay-inventory-templates.ts
@@ -3,6 +3,7 @@ import type {LiferayApiClient} from '../../../core/http/client.js';
 import type {OAuthTokenClient} from '../../../core/http/auth.js';
 import {fetchPagedItems, resolveSite} from './liferay-inventory-shared.js';
 import {listDdmTemplates, resolveResourceSite} from '../resource/liferay-resource-shared.js';
+import {getOperationPolicy} from './capabilities.js';
 
 export type LiferayInventoryTemplate = {
   id: string;
@@ -26,33 +27,62 @@ export async function runLiferayInventoryTemplates(
   dependencies?: {apiClient?: LiferayApiClient; tokenClient?: OAuthTokenClient},
 ): Promise<LiferayInventoryTemplate[]> {
   const site = await resolveSite(config, options?.site ?? '/global', dependencies);
-  const rows = await fetchPagedItems<ContentTemplate>(
-    config,
-    `/o/headless-delivery/v1.0/sites/${site.id}/content-templates`,
-    options?.pageSize ?? 200,
-    dependencies,
-  );
+  const policy = getOperationPolicy('inventory.listTemplates');
+  const pageSize = options?.pageSize ?? 200;
 
-  if (rows.length > 0) {
-    return rows.map((row) => ({
-      id: String(row.id ?? ''),
-      name: row.name ?? String(row.id ?? ''),
-      contentStructureId: row.contentStructureId ?? -1,
-      externalReferenceCode: String(row.externalReferenceCode ?? row.id ?? ''),
-      templateScript: typeof row.templateScript === 'string' ? row.templateScript : undefined,
-    }));
+  for (const surface of policy.surfaces) {
+    if (surface === 'headless-delivery') {
+      const rows = await fetchPagedItems<ContentTemplate>(
+        config,
+        `/o/headless-delivery/v1.0/sites/${site.id}/content-templates`,
+        pageSize,
+        dependencies,
+      );
+
+      if (rows.length > 0) {
+        return rows.map(normalizeContentTemplate);
+      }
+      // Empty result: continue to next surface (jsonws)
+    }
+
+    if (surface === 'jsonws') {
+      const resourceSite = await resolveResourceSite(config, options?.site ?? '/global', dependencies);
+      const ddmRows = await listDdmTemplates(config, resourceSite, dependencies);
+
+      return ddmRows.map(normalizeDdmTemplate);
+    }
   }
 
-  const resourceSite = await resolveResourceSite(config, options?.site ?? '/global', dependencies);
-  const ddmRows = await listDdmTemplates(config, resourceSite, dependencies);
+  return [];
+}
 
-  return ddmRows.map((row) => ({
+function normalizeContentTemplate(row: ContentTemplate): LiferayInventoryTemplate {
+  return {
+    id: String(row.id ?? ''),
+    name: row.name ?? String(row.id ?? ''),
+    contentStructureId: row.contentStructureId ?? -1,
+    externalReferenceCode: String(row.externalReferenceCode ?? row.id ?? ''),
+    templateScript: typeof row.templateScript === 'string' ? row.templateScript : undefined,
+  };
+}
+
+function normalizeDdmTemplate(row: {
+  id?: string | number;
+  nameCurrentValue?: string;
+  name?: string;
+  templateKey?: string;
+  templateId?: string | number;
+  classPK?: string | number;
+  externalReferenceCode?: string;
+  script?: string;
+}): LiferayInventoryTemplate {
+  return {
     id: String(row.id ?? ''),
     name: String(row.nameCurrentValue ?? row.name ?? row.templateKey ?? row.templateId ?? ''),
     contentStructureId: Number(row.classPK ?? -1),
     externalReferenceCode: String(row.externalReferenceCode ?? row.templateKey ?? row.templateId ?? ''),
     templateScript: typeof row.script === 'string' ? row.script : undefined,
-  }));
+  };
 }
 
 export function formatLiferayInventoryTemplates(rows: LiferayInventoryTemplate[]): string {

--- a/tests/unit/liferay-capabilities.test.ts
+++ b/tests/unit/liferay-capabilities.test.ts
@@ -1,0 +1,88 @@
+import {describe, expect, test} from 'vitest';
+
+import {
+  getOperationPolicy,
+  type OperationName,
+  type TransportSurface,
+} from '../../src/features/liferay/inventory/capabilities.js';
+
+const ALL_OPERATIONS: OperationName[] = ['site.resolve', 'inventory.listSites', 'inventory.listTemplates'];
+const VALID_SURFACES: TransportSurface[] = [
+  'headless-admin-site',
+  'headless-admin-user',
+  'headless-delivery',
+  'jsonws',
+];
+
+describe('operation capabilities matrix', () => {
+  test('every operation has a policy', () => {
+    for (const op of ALL_OPERATIONS) {
+      expect(() => getOperationPolicy(op)).not.toThrow();
+    }
+  });
+
+  test('every policy has at least one surface', () => {
+    for (const op of ALL_OPERATIONS) {
+      const {surfaces} = getOperationPolicy(op);
+      expect(surfaces.length).toBeGreaterThan(0);
+    }
+  });
+
+  test('all surfaces are valid TransportSurface values', () => {
+    for (const op of ALL_OPERATIONS) {
+      const {surfaces} = getOperationPolicy(op);
+      for (const surface of surfaces) {
+        expect(VALID_SURFACES).toContain(surface);
+      }
+    }
+  });
+
+  test('site.resolve primary surface is headless-admin-site', () => {
+    const policy = getOperationPolicy('site.resolve');
+    expect(policy.surfaces[0]).toBe('headless-admin-site');
+  });
+
+  test('site.resolve surfaces in order: headless-admin-site, headless-admin-user, jsonws', () => {
+    const policy = getOperationPolicy('site.resolve');
+    expect(policy.surfaces).toEqual(['headless-admin-site', 'headless-admin-user', 'jsonws']);
+  });
+
+  test('inventory.listSites primary surface is headless-admin-site', () => {
+    const policy = getOperationPolicy('inventory.listSites');
+    expect(policy.surfaces[0]).toBe('headless-admin-site');
+  });
+
+  test('inventory.listSites surfaces in order: headless-admin-site, jsonws', () => {
+    const policy = getOperationPolicy('inventory.listSites');
+    expect(policy.surfaces).toEqual(['headless-admin-site', 'jsonws']);
+  });
+
+  test('inventory.listTemplates primary surface is headless-delivery', () => {
+    const policy = getOperationPolicy('inventory.listTemplates');
+    expect(policy.surfaces[0]).toBe('headless-delivery');
+  });
+
+  test('inventory.listTemplates surfaces in order: headless-delivery, jsonws', () => {
+    const policy = getOperationPolicy('inventory.listTemplates');
+    expect(policy.surfaces).toEqual(['headless-delivery', 'jsonws']);
+  });
+
+  test('all operations include jsonws as fallback surface', () => {
+    for (const op of ALL_OPERATIONS) {
+      const {surfaces} = getOperationPolicy(op);
+      expect(surfaces).toContain('jsonws');
+    }
+  });
+
+  test('unknown operation throws error', () => {
+    // @ts-expect-error intentional invalid operation for testing
+    expect(() => getOperationPolicy('unknown.op')).toThrow('No transport policy defined for operation: unknown.op');
+  });
+
+  test('policy operation field matches the operation name', () => {
+    for (const op of ALL_OPERATIONS) {
+      const policy = getOperationPolicy(op);
+      expect(policy.operation).toBe(op);
+    }
+  });
+});

--- a/tests/unit/liferay-inventory-sites.test.ts
+++ b/tests/unit/liferay-inventory-sites.test.ts
@@ -75,6 +75,67 @@ describe('liferay inventory sites', () => {
     expect(calls).toHaveLength(1);
   });
 
+  test('falls back to JSONWS when Headless Admin Site returns no sites', async () => {
+    const calls: string[] = [];
+    const apiClient = createLiferayApiClient({
+      fetchImpl: async (input) => {
+        const url = String(input);
+        calls.push(url);
+
+        if (url.includes('/o/headless-admin-site/v1.0/sites?page=1&pageSize=2')) {
+          return new Response('{"items":[],"lastPage":1}', {status: 200});
+        }
+
+        if (url.includes('/api/jsonws/company/get-companies')) {
+          return new Response('[{"companyId":201}]', {status: 200});
+        }
+
+        if (url.includes('/api/jsonws/group/search-count?companyId=201')) {
+          return new Response('1', {status: 200});
+        }
+
+        if (url.includes('/api/jsonws/group/search?companyId=201')) {
+          return new Response(
+            '[{"site":true,"groupId":301,"friendlyURL":"/jsonws-site","nameCurrentValue":"JSONWS Site"}]',
+            {
+              status: 200,
+            },
+          );
+        }
+
+        throw new Error(`Unexpected URL ${url}`);
+      },
+    });
+
+    const result = await runLiferayInventorySites(
+      CONFIG,
+      {pageSize: 2},
+      {
+        apiClient,
+        tokenClient: {
+          fetchClientCredentialsToken: async () => ({
+            accessToken: 'token-123',
+            tokenType: 'Bearer',
+            expiresIn: 3600,
+          }),
+        },
+      },
+    );
+
+    expect(result).toEqual([
+      {
+        groupId: 301,
+        siteFriendlyUrl: '/jsonws-site',
+        name: 'JSONWS Site',
+        pagesCommand: 'inventory pages --site /jsonws-site',
+      },
+    ]);
+    expect(calls).toContainEqual(expect.stringContaining('/o/headless-admin-site/v1.0/sites?page=1&pageSize=2'));
+    expect(calls).toContainEqual(expect.stringContaining('/api/jsonws/company/get-companies'));
+    expect(calls).toContainEqual(expect.stringContaining('/api/jsonws/group/search-count?companyId=201'));
+    expect(calls).toContainEqual(expect.stringContaining('/api/jsonws/group/search?companyId=201'));
+  });
+
   test('formats text output and empty output', () => {
     expect(
       formatLiferayInventorySites([


### PR DESCRIPTION
## Scope
Implements R4: declarative operation matrix for transport surfaces and fallbacks.

## Includes
- Centralized capability matrix for inventory operations
- Declarative fallback for inventory.listSites and inventory.listTemplates
- JSONWS gateway-backed transport path
- Regression coverage for empty Headless Admin Site responses

## Verification
- npm run test:unit -- tests/unit/liferay-inventory-sites.test.ts tests/unit/liferay-capabilities.test.ts
- Result: 550/550 tests passing

## Notes
This keeps public signatures unchanged and preserves the existing empty-result behavior for --all-sites while still allowing JSONWS fallback when it can contribute data.