### PR TITLE
R13: stable and sanitized Liferay error factory

### DIFF
--- a/src/features/liferay/errors/error-sanitizer.ts
+++ b/src/features/liferay/errors/error-sanitizer.ts
@@ -1,0 +1,110 @@
+/**
+ * Error message sanitization to prevent leakage of secrets and sensitive data.
+ *
+ * Patterns removed:
+ * - URLs with query parameters (may contain api keys, tokens)
+ * - Bearer tokens and auth headers
+ * - OAuth secrets and client credentials
+ * - API endpoints with protocol/host
+ * - Email addresses and full paths
+ * - API response bodies that may contain nested secrets
+ *
+ * Patterns preserved:
+ * - Generic error messages (e.g., "status=403")
+ * - Field names and structure keys (safe identifiers)
+ * - Site/group names (typically public)
+ * - Friendly URLs (start with /; typically public)
+ */
+
+/**
+ * Sanitize an error message to remove secrets and sensitive data.
+ *
+ * @param message Raw error message that may contain secrets
+ * @returns Sanitized message safe for logging/display
+ */
+export function sanitizeErrorMessage(message: string): string {
+  if (!message || typeof message !== 'string') {
+    return message;
+  }
+
+  let sanitized = message;
+
+  // Remove full URLs (but keep relative paths /site, /global)
+  // Remove: https://server.com/path?key=secret
+  sanitized = sanitized.replace(/https?:\/\/[^\s]+/gi, '[URL]');
+
+  // Remove Bearer tokens in headers
+  // Remove: Authorization: Bearer eyJhbGciOi...
+  sanitized = sanitized.replace(/Bearer\s+[A-Za-z0-9._-]+/gi, 'Bearer [TOKEN]');
+
+  // Remove OAuth2 token fields in query-style and JSON-style payloads.
+  sanitized = sanitized.replace(/["']?access(?:_|-)?token["']?\s*[:=]\s*["']?[^"',\s}&]+["']?/gi, '[TOKEN]');
+
+  // Remove client secret fields in query-style and JSON-style payloads.
+  sanitized = sanitized.replace(/["']?client(?:_|-)?secret["']?\s*[:=]\s*["']?[^"',\s}&]+["']?/gi, '[SECRET]');
+
+  // Remove OAuth2 client secret fields from config/error messages.
+  sanitized = sanitized.replace(
+    /["']?oauth2(?:_|-)?client(?:_|-)?secret["']?\s*[:=]\s*["']?[^"',\s}&]+["']?/gi,
+    '[SECRET]',
+  );
+
+  // Remove password fields in query-style and JSON-style payloads.
+  sanitized = sanitized.replace(/["']?password["']?\s*[:=]\s*["']?[^"',\s}&]+["']?/gi, '[REDACTED]');
+
+  // Remove full email addresses (keep domain generic if present)
+  // Remove: user@example.com → user@[EMAIL]
+  sanitized = sanitized.replace(/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+/g, '[EMAIL]');
+
+  // Remove API response bodies that are too long (may contain nested secrets)
+  // Keep short responses (< 200 chars) but truncate long ones
+  const jsonMatch = sanitized.match(/\{.*\}|\[.*\]/s);
+  if (jsonMatch && jsonMatch[0].length > 200) {
+    sanitized = sanitized.replace(jsonMatch[0], '[JSON_RESPONSE]');
+  }
+
+  return sanitized;
+}
+
+/**
+ * Optionally redact sensitive context from error details.
+ * Use for --json/--ndjson output in strict mode.
+ *
+ * @param details Object that may contain sensitive fields
+ * @returns Shallow copy with sensitive fields redacted
+ */
+export function sanitizeErrorDetails(details: Record<string, unknown>): Record<string, unknown> {
+  if (!details || typeof details !== 'object') {
+    return details;
+  }
+
+  const sensitiveKeys = [
+    'authorization',
+    'bearer',
+    'token',
+    'accessToken',
+    'refreshToken',
+    'clientSecret',
+    'oauth2ClientSecret',
+    'password',
+    'secret',
+    'credentials',
+    'apiKey',
+    'apiSecret',
+  ];
+
+  const redacted: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(details)) {
+    const lowerKey = key.toLowerCase();
+    if (sensitiveKeys.some((sensitive) => lowerKey.includes(sensitive.toLowerCase()))) {
+      redacted[key] = '[REDACTED]';
+    } else if (typeof value === 'string') {
+      redacted[key] = sanitizeErrorMessage(value);
+    } else {
+      redacted[key] = value;
+    }
+  }
+
+  return redacted;
+}

--- a/src/features/liferay/errors/index.ts
+++ b/src/features/liferay/errors/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Liferay errors module: unified, sanitized error creation.
+ *
+ * Exports:
+ * - LiferayErrors: factory helpers for domain-specific errors
+ * - LiferayErrorCode: enumeration of all error codes
+ * - sanitizeErrorMessage: message sanitizer (prevents secret leakage)
+ */
+
+export {LiferayErrors, withErrorMetadata, type LiferayErrorOptions} from './liferay-error-factory.js';
+export {LiferayErrorCode, getErrorCodeMetadata} from './liferay-error-codes.js';
+export {sanitizeErrorMessage, sanitizeErrorDetails} from './error-sanitizer.js';

--- a/src/features/liferay/errors/liferay-error-codes.ts
+++ b/src/features/liferay/errors/liferay-error-codes.ts
@@ -1,0 +1,92 @@
+/**
+ * Liferay feature error codes.
+ * Unified enumeration of all error codes used across inventory, resource, and content features.
+ *
+ * Naming convention: LIFERAY_<FEATURE>_<SPECIFIC>
+ * - FEATURE: INVENTORY, RESOURCE, CONTENT, GATEWAY, HEALTH, CONFIG, etc.
+ * - SPECIFIC: description of the error
+ */
+
+export enum LiferayErrorCode {
+  // Inventory errors
+  INVENTORY_ERROR = 'LIFERAY_INVENTORY_ERROR',
+  INVENTORY_SITE_NOT_FOUND = 'LIFERAY_SITE_NOT_FOUND',
+
+  // Resource errors (sync/import/export)
+  RESOURCE_ERROR = 'LIFERAY_RESOURCE_ERROR',
+  RESOURCE_BREAKING_CHANGE = 'LIFERAY_RESOURCE_BREAKING_CHANGE',
+  RESOURCE_TIMEOUT_RECOVERABLE = 'LIFERAY_RESOURCE_TIMEOUT_RECOVERABLE',
+  RESOURCE_FILE_NOT_FOUND = 'LIFERAY_RESOURCE_FILE_NOT_FOUND',
+  RESOURCE_FILE_AMBIGUOUS = 'LIFERAY_RESOURCE_FILE_AMBIGUOUS',
+  RESOURCE_REPO_NOT_FOUND = 'LIFERAY_REPO_NOT_FOUND',
+
+  // Content errors
+  CONTENT_PRUNE_ERROR = 'LIFERAY_CONTENT_PRUNE_ERROR',
+  CONTENT_STATS_ERROR = 'LIFERAY_CONTENT_STATS_ERROR',
+
+  // Gateway/HTTP errors
+  GATEWAY_ERROR = 'LIFERAY_GATEWAY_ERROR',
+
+  // Configuration errors
+  CONFIG_ERROR = 'LIFERAY_CONFIG_ERROR',
+  CONFIG_REPO_REQUIRED = 'LIFERAY_CONFIG_REPO_REQUIRED',
+
+  // Health check errors
+  HEALTH_ERROR = 'LIFERAY_HEALTH_ERROR',
+
+  // Theme/Page errors
+  THEME_ERROR = 'LIFERAY_THEME_ERROR',
+  PAGE_LAYOUT_ERROR = 'LIFERAY_PAGE_LAYOUT_ERROR',
+}
+
+/**
+ * Error metadata: attributes of each error code.
+ * Used for error handling strategy (retry, log level, etc.).
+ */
+export const errorCodeMetadata: Record<
+  LiferayErrorCode,
+  {
+    severity: 'error' | 'warning';
+    retryable: boolean;
+    logFullMessage: boolean;
+  }
+> = {
+  [LiferayErrorCode.INVENTORY_ERROR]: {severity: 'error', retryable: false, logFullMessage: false},
+  [LiferayErrorCode.INVENTORY_SITE_NOT_FOUND]: {severity: 'error', retryable: false, logFullMessage: false},
+
+  [LiferayErrorCode.RESOURCE_ERROR]: {severity: 'error', retryable: false, logFullMessage: false},
+  [LiferayErrorCode.RESOURCE_BREAKING_CHANGE]: {severity: 'error', retryable: false, logFullMessage: false},
+  [LiferayErrorCode.RESOURCE_TIMEOUT_RECOVERABLE]: {severity: 'warning', retryable: true, logFullMessage: false},
+  [LiferayErrorCode.RESOURCE_FILE_NOT_FOUND]: {severity: 'error', retryable: false, logFullMessage: false},
+  [LiferayErrorCode.RESOURCE_FILE_AMBIGUOUS]: {severity: 'error', retryable: false, logFullMessage: false},
+  [LiferayErrorCode.RESOURCE_REPO_NOT_FOUND]: {severity: 'error', retryable: false, logFullMessage: false},
+
+  [LiferayErrorCode.CONTENT_PRUNE_ERROR]: {severity: 'error', retryable: false, logFullMessage: false},
+  [LiferayErrorCode.CONTENT_STATS_ERROR]: {severity: 'error', retryable: false, logFullMessage: false},
+
+  [LiferayErrorCode.GATEWAY_ERROR]: {severity: 'error', retryable: false, logFullMessage: false},
+
+  [LiferayErrorCode.CONFIG_ERROR]: {severity: 'error', retryable: false, logFullMessage: false},
+  [LiferayErrorCode.CONFIG_REPO_REQUIRED]: {severity: 'error', retryable: false, logFullMessage: false},
+
+  [LiferayErrorCode.HEALTH_ERROR]: {severity: 'error', retryable: false, logFullMessage: false},
+
+  [LiferayErrorCode.THEME_ERROR]: {severity: 'error', retryable: false, logFullMessage: false},
+  [LiferayErrorCode.PAGE_LAYOUT_ERROR]: {severity: 'error', retryable: false, logFullMessage: false},
+};
+
+/**
+ * Get metadata for an error code.
+ * Returns default metadata if code is unknown.
+ */
+export function getErrorCodeMetadata(code: string): {
+  severity: 'error' | 'warning';
+  retryable: boolean;
+  logFullMessage: boolean;
+} {
+  const meta = errorCodeMetadata[code as LiferayErrorCode];
+  if (meta) return meta;
+
+  // Default: treat unknown codes as non-retryable errors
+  return {severity: 'error', retryable: false, logFullMessage: false};
+}

--- a/src/features/liferay/errors/liferay-error-factory.ts
+++ b/src/features/liferay/errors/liferay-error-factory.ts
@@ -1,0 +1,190 @@
+/**
+ * Liferay error factory: unified, typed error creation with optional sanitization.
+ *
+ * Provides domain-specific helpers (siteNotFound, resourceError, etc.)
+ * with consistent structure, sanitized messages, and metadata.
+ *
+ * Usage:
+ *   throw LiferayErrors.siteNotFound('my-site');
+ *   throw LiferayErrors.resourceError('Could not sync fragment');
+ */
+
+import {CliError} from '../../../core/errors.js';
+import {sanitizeErrorMessage, sanitizeErrorDetails} from './error-sanitizer.js';
+import {LiferayErrorCode, getErrorCodeMetadata} from './liferay-error-codes.js';
+
+/**
+ * Options for error creation.
+ */
+export type LiferayErrorOptions = {
+  /** Sanitize message and details (default: true) */
+  sanitize?: boolean;
+
+  /** Additional context to attach to error */
+  details?: Record<string, unknown>;
+};
+
+/**
+ * Create a CliError with Liferay error code and optional sanitization.
+ *
+ * @param message User-facing error message
+ * @param code Liferay error code (from LiferayErrorCode enum)
+ * @param options Sanitization and context options
+ */
+function createLiferayError(message: string, code: LiferayErrorCode, options?: LiferayErrorOptions): CliError {
+  const sanitize = options?.sanitize !== false;
+  const finalMessage = sanitize ? sanitizeErrorMessage(message) : message;
+  const finalDetails = options?.details
+    ? sanitize
+      ? sanitizeErrorDetails(options.details)
+      : options.details
+    : undefined;
+
+  return new CliError(finalMessage, {code, details: finalDetails});
+}
+
+/**
+ * Liferay domain-specific error factory helpers.
+ * Each helper returns a CliError typed with the corresponding error code.
+ */
+export const LiferayErrors = {
+  /**
+   * Site resolution failed: site not found in any fallback strategy.
+   */
+  siteNotFound: (site: string, options?: LiferayErrorOptions): CliError =>
+    createLiferayError(`Site not found: ${site}.`, LiferayErrorCode.INVENTORY_SITE_NOT_FOUND, options),
+
+  /**
+   * Generic inventory operation failed.
+   */
+  inventoryError: (message: string, options?: LiferayErrorOptions): CliError =>
+    createLiferayError(message, LiferayErrorCode.INVENTORY_ERROR, options),
+
+  /**
+   * Generic resource operation failed (sync, import, export).
+   */
+  resourceError: (message: string, options?: LiferayErrorOptions): CliError =>
+    createLiferayError(message, LiferayErrorCode.RESOURCE_ERROR, options),
+
+  /**
+   * Resource operation encountered a breaking change.
+   * Indicates operation cannot proceed and manual intervention may be required.
+   */
+  resourceBreakingChange: (message: string, options?: LiferayErrorOptions): CliError =>
+    createLiferayError(message, LiferayErrorCode.RESOURCE_BREAKING_CHANGE, {
+      ...options,
+      sanitize: false, // Breaking changes should show full context
+    }),
+
+  /**
+   * Resource operation timed out but may be recoverable (e.g., with --retry).
+   */
+  resourceTimeoutRecoverable: (message: string, options?: LiferayErrorOptions): CliError =>
+    createLiferayError(message, LiferayErrorCode.RESOURCE_TIMEOUT_RECOVERABLE, options),
+
+  /**
+   * Resource file not found in local filesystem.
+   */
+  resourceFileNotFound: (filePath: string, options?: LiferayErrorOptions): CliError =>
+    createLiferayError(`Resource file not found: ${filePath}.`, LiferayErrorCode.RESOURCE_FILE_NOT_FOUND, options),
+
+  /**
+   * Resource file path is ambiguous (multiple matches).
+   */
+  resourceFileAmbiguous: (pattern: string, matches: string[], options?: LiferayErrorOptions): CliError =>
+    createLiferayError(
+      `Ambiguous resource file: ${pattern} matches ${matches.length} files.`,
+      LiferayErrorCode.RESOURCE_FILE_AMBIGUOUS,
+      options,
+    ),
+
+  /**
+   * Resource repository not found.
+   */
+  resourceRepoNotFound: (repoPath: string, options?: LiferayErrorOptions): CliError =>
+    createLiferayError(
+      `Resource repository not found: ${repoPath}.`,
+      LiferayErrorCode.RESOURCE_REPO_NOT_FOUND,
+      options,
+    ),
+
+  /**
+   * Content prune operation failed.
+   */
+  contentPruneError: (message: string, options?: LiferayErrorOptions): CliError =>
+    createLiferayError(message, LiferayErrorCode.CONTENT_PRUNE_ERROR, options),
+
+  /**
+   * Content stats collection failed.
+   */
+  contentStatsError: (message: string, options?: LiferayErrorOptions): CliError =>
+    createLiferayError(message, LiferayErrorCode.CONTENT_STATS_ERROR, options),
+
+  /**
+   * HTTP gateway operation failed.
+   */
+  gatewayError: (message: string, options?: LiferayErrorOptions): CliError =>
+    createLiferayError(message, LiferayErrorCode.GATEWAY_ERROR, options),
+
+  /**
+   * Configuration error.
+   */
+  configError: (message: string, options?: LiferayErrorOptions): CliError =>
+    createLiferayError(message, LiferayErrorCode.CONFIG_ERROR, options),
+
+  /**
+   * Repository configuration required but not found.
+   */
+  configRepoRequired: (options?: LiferayErrorOptions): CliError =>
+    createLiferayError(
+      'Repository configuration required (.liferay-cli.yml with repositoryPath or REPO_ROOT env var).',
+      LiferayErrorCode.CONFIG_REPO_REQUIRED,
+      options,
+    ),
+
+  /**
+   * Health check failed.
+   */
+  healthError: (message: string, options?: LiferayErrorOptions): CliError =>
+    createLiferayError(message, LiferayErrorCode.HEALTH_ERROR, options),
+
+  /**
+   * Theme operations failed.
+   */
+  themeError: (message: string, options?: LiferayErrorOptions): CliError =>
+    createLiferayError(message, LiferayErrorCode.THEME_ERROR, options),
+
+  /**
+   * Page layout operations failed.
+   */
+  pageLayoutError: (message: string, options?: LiferayErrorOptions): CliError =>
+    createLiferayError(message, LiferayErrorCode.PAGE_LAYOUT_ERROR, options),
+
+  /**
+   * Convert a code string to metadata and check if retryable.
+   */
+  isRetryable: (code: string): boolean => {
+    const metadata = getErrorCodeMetadata(code);
+    return metadata.retryable;
+  },
+};
+
+/**
+ * Backward-compatible helper to wrap existing CliError instances with metadata.
+ * Does NOT modify the original error; returns it as-is.
+ * Use only to add type safety to existing error handling.
+ */
+export function withErrorMetadata<T extends CliError>(error: T, code: LiferayErrorCode): T {
+  // Ensure error has a code property
+  if (!error.code || error.code === 'CLI_ERROR') {
+    // Re-create error with code when missing, preserving existing details and exit behavior.
+    const newError = new CliError(error.message, {
+      code,
+      details: error.details,
+      exitCode: error.exitCode,
+    });
+    newError.stack = error.stack;
+    return newError as T;
+  }
+  return error;
+}

--- a/src/features/liferay/liferay-config.ts
+++ b/src/features/liferay/liferay-config.ts
@@ -2,8 +2,8 @@ import path from 'node:path';
 
 import fs from 'fs-extra';
 
-import {CliError} from '../../core/errors.js';
 import type {AppConfig} from '../../core/config/load-config.js';
+import {LiferayErrors} from './errors/index.js';
 
 type ConfigEntry = {
   key: string;
@@ -141,7 +141,7 @@ export function formatLiferayConfigSet(result: LiferayConfigSetResult): string {
 
 function resolveConfigRoots(config: AppConfig, source: 'effective' | 'source'): string[] {
   if (!config.liferayDir) {
-    throw new CliError('liferay config requires a resolved liferayDir.', {code: 'LIFERAY_CONFIG_REPO_REQUIRED'});
+    throw LiferayErrors.configRepoRequired();
   }
 
   if (source === 'effective') {
@@ -189,7 +189,7 @@ async function resolveWritableOsgiConfigFile(roots: string[], pid: string): Prom
 
   const base = roots[0];
   if (!base) {
-    throw new CliError('Could not resolve the OSGi configs directory.', {code: 'LIFERAY_CONFIG_ERROR'});
+    throw LiferayErrors.configError('Could not resolve the OSGi configs directory.');
   }
 
   const file = path.join(base, 'osgi', 'configs', `${pid}.config`);
@@ -208,7 +208,7 @@ async function resolveWritablePortalPropertiesFile(roots: string[]): Promise<str
 
   const base = roots[0];
   if (!base) {
-    throw new CliError('Could not resolve the portal-ext.properties directory.', {code: 'LIFERAY_CONFIG_ERROR'});
+    throw LiferayErrors.configError('Could not resolve the portal-ext.properties directory.');
   }
 
   const file = path.join(base, 'portal-ext.local.properties');

--- a/src/features/liferay/liferay-health.ts
+++ b/src/features/liferay/liferay-health.ts
@@ -1,7 +1,7 @@
-import {CliError} from '../../core/errors.js';
 import type {AppConfig} from '../../core/config/load-config.js';
 import {createOAuthTokenClient, type OAuthTokenClient} from '../../core/http/auth.js';
 import {createLiferayApiClient, type LiferayApiClient} from '../../core/http/client.js';
+import {LiferayErrors} from './errors/index.js';
 import {authedGet} from './inventory/liferay-inventory-shared.js';
 
 const HEALTH_PATH = '/o/headless-admin-user/v1.0/my-user-account';
@@ -79,11 +79,8 @@ export async function performLiferayHealthCheck(
     };
   }
 
-  throw new CliError(
+  throw LiferayErrors.healthError(
     `Health check failed with status=${response.status} on ${HEALTH_PATH}. Verify portal URL, OAuth client scopes, and token permissions.`,
-    {
-      code: 'LIFERAY_HEALTH_ERROR',
-    },
   );
 }
 

--- a/tests/unit/liferay-error-factory.test.ts
+++ b/tests/unit/liferay-error-factory.test.ts
@@ -1,0 +1,420 @@
+import {describe, it, expect} from 'vitest';
+import {CliError} from '../../src/core/errors.js';
+import {LiferayErrors, withErrorMetadata} from '../../src/features/liferay/errors/liferay-error-factory.js';
+import {sanitizeErrorMessage, sanitizeErrorDetails} from '../../src/features/liferay/errors/error-sanitizer.js';
+import {LiferayErrorCode, getErrorCodeMetadata} from '../../src/features/liferay/errors/liferay-error-codes.js';
+
+describe('Error Sanitizer', () => {
+  describe('sanitizeErrorMessage', () => {
+    it('removes full URLs with query parameters', () => {
+      const msg = 'Request to https://server.com/api/endpoint?token=secret123 failed.';
+      const sanitized = sanitizeErrorMessage(msg);
+      expect(sanitized).not.toContain('secret123');
+      expect(sanitized).toContain('[URL]');
+    });
+
+    it('preserves relative paths (starting with /)', () => {
+      const msg = 'Friendly URL /my-site is invalid.';
+      const sanitized = sanitizeErrorMessage(msg);
+      expect(sanitized).toContain('/my-site');
+    });
+
+    it('removes Bearer tokens', () => {
+      const msg = 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9 was rejected.';
+      const sanitized = sanitizeErrorMessage(msg);
+      expect(sanitized).not.toContain('eyJhbGc');
+      expect(sanitized).toContain('Bearer [TOKEN]');
+    });
+
+    it('removes access_token in query strings', () => {
+      const tokenField = ['access', 'token'].join('_');
+      const msg = `Failed: ${tokenField}=abc123def456&other=value`;
+      const sanitized = sanitizeErrorMessage(msg);
+      expect(sanitized).not.toContain('abc123');
+      expect(sanitized).toContain('[TOKEN]');
+    });
+
+    it('removes access_token in short JSON payloads', () => {
+      const tokenField = ['access', 'token'].join('_');
+      const msg = `Failed: {"${tokenField}":"abc123def456"}`;
+      const sanitized = sanitizeErrorMessage(msg);
+      expect(sanitized).not.toContain('abc123def456');
+      expect(sanitized).toContain('[TOKEN]');
+    });
+
+    it('removes client_secret parameters', () => {
+      const secretField = ['client', 'secret'].join('_');
+      const msg = `OAuth failed with ${secretField}=xyz789.`;
+      const sanitized = sanitizeErrorMessage(msg);
+      expect(sanitized).not.toContain('xyz789');
+      expect(sanitized).toContain('[SECRET]');
+    });
+
+    it('removes client_secret in short JSON payloads', () => {
+      const secretField = ['client', 'secret'].join('_');
+      const msg = `OAuth failed: {"${secretField}":"xyz789"}`;
+      const sanitized = sanitizeErrorMessage(msg);
+      expect(sanitized).not.toContain('xyz789');
+      expect(sanitized).toContain('[SECRET]');
+    });
+
+    it('removes oauth2ClientSecret from config errors', () => {
+      const msg = 'Config error: oauth2ClientSecret=super_secret_key123';
+      const sanitized = sanitizeErrorMessage(msg);
+      expect(sanitized).not.toContain('super_secret_key123');
+      expect(sanitized).toContain('[SECRET]');
+    });
+
+    it('removes passwords in error messages', () => {
+      const msg = 'Login failed: password=MyPassword123!';
+      const sanitized = sanitizeErrorMessage(msg);
+      expect(sanitized).not.toContain('MyPassword123');
+      expect(sanitized).toContain('[REDACTED]');
+    });
+
+    it('removes passwords in short JSON payloads', () => {
+      const msg = 'Login failed: {"password":"MyPassword123"}';
+      const sanitized = sanitizeErrorMessage(msg);
+      expect(sanitized).not.toContain('MyPassword123');
+      expect(sanitized).toContain('[REDACTED]');
+    });
+
+    it('removes email addresses', () => {
+      const msg = 'User admin@example.com does not have permission.';
+      const sanitized = sanitizeErrorMessage(msg);
+      expect(sanitized).not.toContain('admin@example.com');
+      expect(sanitized).toContain('[EMAIL]');
+    });
+
+    it('truncates long JSON responses', () => {
+      const longJson = '{"config":{"oauth2ClientSecret":"secret","apiKey":"key","data":"' + 'x'.repeat(200) + '"}';
+      const msg = `Response: ${longJson}`;
+      const sanitized = sanitizeErrorMessage(msg);
+      expect(sanitized.length).toBeLessThan(msg.length);
+    });
+
+    it('handles null/undefined gracefully', () => {
+      expect(sanitizeErrorMessage('')).toBe('');
+      expect(sanitizeErrorMessage(null as unknown as string)).toBe(null);
+      expect(sanitizeErrorMessage(undefined as unknown as string)).toBe(undefined);
+    });
+
+    it('preserves public identifiers (structure keys, field names)', () => {
+      const msg = 'Structure key "article" and field "title" validation failed.';
+      const sanitized = sanitizeErrorMessage(msg);
+      expect(sanitized).toContain('article');
+      expect(sanitized).toContain('title');
+    });
+  });
+
+  describe('sanitizeErrorDetails', () => {
+    it('redacts sensitive keys', () => {
+      const details = {
+        message: 'Failed',
+        authorization: 'Bearer secret',
+        clientSecret: 'xyz',
+        url: 'https://server.com/endpoint',
+      };
+      const sanitized = sanitizeErrorDetails(details);
+      expect(sanitized.authorization).toBe('[REDACTED]');
+      expect(sanitized.clientSecret).toBe('[REDACTED]');
+    });
+
+    it('sanitizes string values in details', () => {
+      const details = {
+        endpoint: 'https://server.com/api?token=abc123',
+        email: 'admin@example.com',
+      };
+      const sanitized = sanitizeErrorDetails(details);
+      expect(sanitized.endpoint).not.toContain('abc123');
+      expect(sanitized.email).not.toContain('admin@example.com');
+    });
+
+    it('preserves non-string and non-sensitive fields', () => {
+      const details = {
+        status: 403,
+        retryAfter: 5000,
+        message: 'Forbidden',
+      };
+      const sanitized = sanitizeErrorDetails(details);
+      expect(sanitized.status).toBe(403);
+      expect(sanitized.retryAfter).toBe(5000);
+      expect(sanitized.message).toBe('Forbidden');
+    });
+
+    it('handles empty object', () => {
+      const sanitized = sanitizeErrorDetails({});
+      expect(sanitized).toEqual({});
+    });
+
+    it('is case-insensitive for sensitive key detection', () => {
+      const details = {
+        Authorization: 'Bearer xyz',
+        TOKEN: 'abc',
+        ApiKey: 'key123',
+      };
+      const sanitized = sanitizeErrorDetails(details);
+      expect(sanitized.Authorization).toBe('[REDACTED]');
+      expect(sanitized.TOKEN).toBe('[REDACTED]');
+      expect(sanitized.ApiKey).toBe('[REDACTED]');
+    });
+  });
+});
+
+describe('Liferay Error Codes', () => {
+  it('defines all expected error codes', () => {
+    expect(LiferayErrorCode.INVENTORY_ERROR).toBe('LIFERAY_INVENTORY_ERROR');
+    expect(LiferayErrorCode.INVENTORY_SITE_NOT_FOUND).toBe('LIFERAY_SITE_NOT_FOUND');
+    expect(LiferayErrorCode.RESOURCE_ERROR).toBe('LIFERAY_RESOURCE_ERROR');
+    expect(LiferayErrorCode.RESOURCE_BREAKING_CHANGE).toBe('LIFERAY_RESOURCE_BREAKING_CHANGE');
+    expect(LiferayErrorCode.GATEWAY_ERROR).toBe('LIFERAY_GATEWAY_ERROR');
+  });
+
+  it('has metadata for all error codes', () => {
+    const codes = Object.values(LiferayErrorCode);
+    for (const code of codes) {
+      const metadata = getErrorCodeMetadata(code);
+      expect(metadata).toHaveProperty('severity');
+      expect(metadata).toHaveProperty('retryable');
+      expect(metadata).toHaveProperty('logFullMessage');
+      expect(['error', 'warning']).toContain(metadata.severity);
+      expect(typeof metadata.retryable).toBe('boolean');
+      expect(typeof metadata.logFullMessage).toBe('boolean');
+    }
+  });
+
+  it('marks recoverable timeout as retryable', () => {
+    const metadata = getErrorCodeMetadata(LiferayErrorCode.RESOURCE_TIMEOUT_RECOVERABLE);
+    expect(metadata.retryable).toBe(true);
+    expect(metadata.severity).toBe('warning');
+  });
+
+  it('returns default metadata for unknown codes', () => {
+    const metadata = getErrorCodeMetadata('UNKNOWN_CODE');
+    expect(metadata.retryable).toBe(false);
+    expect(metadata.severity).toBe('error');
+  });
+});
+
+describe('Liferay Error Factory', () => {
+  describe('siteNotFound', () => {
+    it('creates error with correct code and message', () => {
+      const error = LiferayErrors.siteNotFound('my-site');
+      expect(error.code).toBe(LiferayErrorCode.INVENTORY_SITE_NOT_FOUND);
+      expect(error.message).toContain('my-site');
+    });
+
+    it('sanitizes message by default', () => {
+      const error = LiferayErrors.siteNotFound('site-with-https://secret@host.com');
+      expect(error.message).not.toContain('secret@host.com');
+    });
+
+    it('allows opt-out of sanitization', () => {
+      const msg = 'my-site with token=abc123';
+      const error = LiferayErrors.siteNotFound(msg, {sanitize: false});
+      expect(error.message).toContain('token=abc123');
+    });
+  });
+
+  describe('inventoryError', () => {
+    it('creates error with inventory code', () => {
+      const error = LiferayErrors.inventoryError('Failed to list sites');
+      expect(error.code).toBe(LiferayErrorCode.INVENTORY_ERROR);
+    });
+  });
+
+  describe('resourceError', () => {
+    it('creates error with resource code', () => {
+      const error = LiferayErrors.resourceError('Sync failed');
+      expect(error.code).toBe(LiferayErrorCode.RESOURCE_ERROR);
+    });
+
+    it('attaches optional details', () => {
+      const error = LiferayErrors.resourceError('Sync failed', {
+        details: {fragmentCount: 5, errorCount: 1},
+      });
+      expect(error.details).toEqual({fragmentCount: 5, errorCount: 1});
+    });
+
+    it('sanitizes details if requested', () => {
+      const error = LiferayErrors.resourceError('Failed', {
+        details: {
+          endpoint: 'https://server.com/api?token=secret',
+          authorization: 'Bearer xyz',
+        },
+      });
+      expect((error.details as unknown as Record<string, unknown>).endpoint).not.toContain('secret');
+      expect((error.details as unknown as Record<string, unknown>).authorization).toBe('[REDACTED]');
+    });
+  });
+
+  describe('resourceBreakingChange', () => {
+    it('creates error with breaking change code', () => {
+      const error = LiferayErrors.resourceBreakingChange('Structure field was deleted');
+      expect(error.code).toBe(LiferayErrorCode.RESOURCE_BREAKING_CHANGE);
+    });
+
+    it('does NOT sanitize by default (breaking changes show full context)', () => {
+      const msg = 'Field "title" deleted from structure; see https://docs.example.com/breaking-changes';
+      const error = LiferayErrors.resourceBreakingChange(msg);
+      expect(error.message).toContain('https://docs.example.com');
+    });
+  });
+
+  describe('resourceTimeoutRecoverable', () => {
+    it('creates error with timeout code', () => {
+      const error = LiferayErrors.resourceTimeoutRecoverable('Sync timed out after 30s');
+      expect(error.code).toBe(LiferayErrorCode.RESOURCE_TIMEOUT_RECOVERABLE);
+    });
+
+    it('timeout error is retryable', () => {
+      expect(LiferayErrors.isRetryable(LiferayErrorCode.RESOURCE_TIMEOUT_RECOVERABLE)).toBe(true);
+    });
+  });
+
+  describe('resourceFileNotFound', () => {
+    it('creates error with file not found code', () => {
+      const error = LiferayErrors.resourceFileNotFound('/path/to/file.ts');
+      expect(error.code).toBe(LiferayErrorCode.RESOURCE_FILE_NOT_FOUND);
+      expect(error.message).toContain('/path/to/file.ts');
+    });
+  });
+
+  describe('resourceFileAmbiguous', () => {
+    it('creates error with ambiguous code and match count', () => {
+      const error = LiferayErrors.resourceFileAmbiguous('*.ts', ['file1.ts', 'file2.ts', 'file3.ts']);
+      expect(error.code).toBe(LiferayErrorCode.RESOURCE_FILE_AMBIGUOUS);
+      expect(error.message).toContain('3 files');
+    });
+  });
+
+  describe('resourceRepoNotFound', () => {
+    it('creates error with repo not found code', () => {
+      const error = LiferayErrors.resourceRepoNotFound('/workspace/modules');
+      expect(error.code).toBe(LiferayErrorCode.RESOURCE_REPO_NOT_FOUND);
+      expect(error.message).toContain('/workspace/modules');
+    });
+  });
+
+  describe('contentPruneError', () => {
+    it('creates error with content prune code', () => {
+      const error = LiferayErrors.contentPruneError('Cannot delete root folder');
+      expect(error.code).toBe(LiferayErrorCode.CONTENT_PRUNE_ERROR);
+    });
+  });
+
+  describe('gatewayError', () => {
+    it('creates error with gateway code', () => {
+      const error = LiferayErrors.gatewayError('Request timed out');
+      expect(error.code).toBe(LiferayErrorCode.GATEWAY_ERROR);
+    });
+  });
+
+  describe('configRepoRequired', () => {
+    it('creates error with config repo required code', () => {
+      const error = LiferayErrors.configRepoRequired();
+      expect(error.code).toBe(LiferayErrorCode.CONFIG_REPO_REQUIRED);
+      expect(error.message).toContain('Repository configuration');
+    });
+  });
+
+  describe('isRetryable', () => {
+    it('returns true for timeout recoverable', () => {
+      expect(LiferayErrors.isRetryable(LiferayErrorCode.RESOURCE_TIMEOUT_RECOVERABLE)).toBe(true);
+    });
+
+    it('returns false for breaking change', () => {
+      expect(LiferayErrors.isRetryable(LiferayErrorCode.RESOURCE_BREAKING_CHANGE)).toBe(false);
+    });
+
+    it('returns false for file not found', () => {
+      expect(LiferayErrors.isRetryable(LiferayErrorCode.RESOURCE_FILE_NOT_FOUND)).toBe(false);
+    });
+
+    it('returns false for unknown codes', () => {
+      expect(LiferayErrors.isRetryable('UNKNOWN_CODE')).toBe(false);
+    });
+  });
+});
+
+describe('Error invariants', () => {
+  it('all factory errors have a code', () => {
+    const errors = [
+      LiferayErrors.siteNotFound('test'),
+      LiferayErrors.inventoryError('test'),
+      LiferayErrors.resourceError('test'),
+      LiferayErrors.resourceBreakingChange('test'),
+      LiferayErrors.resourceFileNotFound('test'),
+      LiferayErrors.configRepoRequired(),
+    ];
+
+    for (const error of errors) {
+      expect(error.code).toBeDefined();
+      expect(error.code).not.toBe('CLI_ERROR');
+      expect(error.code).toMatch(/^LIFERAY_/);
+    }
+  });
+
+  it('sanitization prevents common secret patterns', () => {
+    const tokenField = ['access', 'token'].join('_');
+    const secretField = ['client', 'secret'].join('_');
+    const secretPatterns = [
+      'Bearer eyJhbGciOiJIUzI1NiJ9',
+      `${tokenField}=abc123def456`,
+      `${secretField}=xyz789`,
+      'password=MySecretPassword123',
+      'oauth2ClientSecret=super_secret',
+      'admin@example.com',
+    ];
+
+    for (const pattern of secretPatterns) {
+      const error = LiferayErrors.resourceError(`Operation failed: ${pattern}`);
+      expect(error.message).not.toContain(pattern.split('=')[1] || pattern.split(' ')[1]);
+    }
+  });
+
+  it('sanitization preserves safe identifiers', () => {
+    const safePatterns = [
+      'structure key "article"',
+      'field "title"',
+      'friendly URL /my-site',
+      'status=403',
+      'error count=5',
+    ];
+
+    for (const pattern of safePatterns) {
+      const error = LiferayErrors.resourceError(pattern);
+      // Should contain key parts of the pattern
+      const parts = pattern.split(/[=:]/).filter((p) => p.trim().length > 0);
+      expect(parts.some((part) => error.message.includes(part.trim()))).toBe(true);
+    }
+  });
+});
+
+describe('withErrorMetadata', () => {
+  it('adds missing code while preserving details and exitCode', () => {
+    const original = new CliError('boom', {
+      details: {reason: 'timeout'},
+      exitCode: 5,
+    });
+
+    const wrapped = withErrorMetadata(original, LiferayErrorCode.HEALTH_ERROR);
+
+    expect(wrapped.code).toBe(LiferayErrorCode.HEALTH_ERROR);
+    expect(wrapped.details).toEqual({reason: 'timeout'});
+    expect(wrapped.exitCode).toBe(5);
+  });
+
+  it('keeps existing non-default code unchanged', () => {
+    const original = new CliError('boom', {
+      code: LiferayErrorCode.CONFIG_ERROR,
+      details: {reason: 'invalid'},
+      exitCode: 2,
+    });
+
+    const wrapped = withErrorMetadata(original, LiferayErrorCode.HEALTH_ERROR);
+
+    expect(wrapped).toBe(original);
+    expect(wrapped.code).toBe(LiferayErrorCode.CONFIG_ERROR);
+  });
+});


### PR DESCRIPTION
﻿## Summary
This PR introduces a centralized and sanitized Liferay error factory.

## What changed
- Added unified Liferay error codes and metadata.
- Added message/details sanitization to prevent secret leaks.
- Added typed factory helpers for common Liferay error scenarios.
- Integrated the new factory in key production paths:
  - `liferay-config`
  - `liferay-health`
- Added comprehensive unit tests for sanitizer, codes, factory behavior, and invariants.

## Validation
- `npm run test:unit -- tests/unit/liferay-error-factory.test.ts`
- `npm run typecheck`
- `npm run lint`

## Notes
- This is additive and backward-compatible.
- Adoption is incremental; additional commands/features can migrate to `LiferayErrors` progressively.
