### PR TITLE
R6: SyncEngine for template and ADT sync

### DIFF
--- a/src/features/liferay/resource/liferay-resource-sync-adt.ts
+++ b/src/features/liferay/resource/liferay-resource-sync-adt.ts
@@ -1,25 +1,17 @@
-import fs from 'fs-extra';
 import path from 'node:path';
 
 import {CliError} from '../../../core/errors.js';
 import type {AppConfig} from '../../../core/config/load-config.js';
-import {expectJsonSuccess} from '../liferay-http-shared.js';
+import type {ResourceSyncDependencies, ResourceSyncResult} from './liferay-resource-sync-shared.js';
+import {resolveResourceSite} from './liferay-resource-shared.js';
 import {
   ADT_CLASS_BY_WIDGET_TYPE,
   normalizeAdtWidgetType,
   runLiferayResourceListAdts,
 } from './liferay-resource-list-adts.js';
 import {resolveAdtFile, ADT_WIDGET_DIR_BY_TYPE} from './liferay-resource-paths.js';
-import {fetchAdtResourceClassNameId, fetchClassNameIdForValue, resolveResourceSite} from './liferay-resource-shared.js';
-import {
-  authedGetJson,
-  authedPostForm,
-  localizedMap,
-  normalizeSyncStatus,
-  sha256,
-  type ResourceSyncDependencies,
-  type ResourceSyncResult,
-} from './liferay-resource-sync-shared.js';
+import {syncArtifact} from './sync-engine.js';
+import {adtSyncStrategy} from './sync-strategies/adt-sync-strategy.js';
 
 export type LiferayResourceSyncAdtResult = ResourceSyncResult & {
   adtFile: string;
@@ -41,6 +33,7 @@ export async function runLiferayResourceSyncAdt(
   },
   dependencies?: ResourceSyncDependencies,
 ): Promise<LiferayResourceSyncAdtResult> {
+  // Resolve widget type and class name
   const resolvedWidget = normalizeAdtWidgetType(options.widgetType ?? inferAdtWidgetType(options.file ?? ''));
   const resolvedClassName = options.className?.trim() || ADT_CLASS_BY_WIDGET_TYPE[resolvedWidget];
   if (!resolvedWidget || !resolvedClassName) {
@@ -50,122 +43,59 @@ export async function runLiferayResourceSyncAdt(
   }
 
   const name = options.key?.trim() || inferAdtName(options.file ?? '');
-  const adtFile = await resolveAdtFile(config, name, resolvedWidget, options.file);
-  const script = await fs.readFile(adtFile, 'utf8');
-  const localSha = sha256(script);
+
+  // Resolve initial site
   let site = await resolveResourceSite(config, options.site ?? '/global', dependencies);
-  let existing = await findAdt(config, site.friendlyUrlPath, resolvedWidget, resolvedClassName, name, dependencies);
 
-  if (!existing && site.friendlyUrlPath !== '/global') {
-    const globalSite = await resolveResourceSite(config, '/global', dependencies);
-    const globalExisting = await findAdt(config, '/global', resolvedWidget, resolvedClassName, name, dependencies);
-    if (globalExisting) {
-      site = globalSite;
-      existing = globalExisting;
-    }
-  }
-
-  const classNameId = await fetchClassNameIdForValue(config, resolvedClassName, dependencies);
-  const resourceClassNameId = await fetchAdtResourceClassNameId(config, dependencies);
-
-  if (!existing) {
-    if (!options.createMissing) {
-      throw new CliError(`ADT '${name}' does not exist and create-missing is not enabled.`, {
-        code: 'LIFERAY_RESOURCE_ERROR',
-      });
-    }
-    if (options.checkOnly) {
-      return {
-        status: 'checked_missing',
-        id: '',
-        name,
-        extra: resolvedWidget,
-        adtFile,
-        widgetType: resolvedWidget,
-        siteId: site.id,
-        siteFriendlyUrl: site.friendlyUrlPath,
-      };
-    }
-
-    const created = await expectJsonSuccess(
-      await authedPostForm<Record<string, unknown>>(
-        config,
-        '/api/jsonws/ddm.ddmtemplate/add-template',
-        {
-          externalReferenceCode: name,
-          groupId: String(site.id),
-          classNameId: String(classNameId),
-          classPK: '0',
-          resourceClassNameId: String(resourceClassNameId),
-          nameMap: localizedMap(name),
-          descriptionMap: localizedMap(''),
-          type: 'display',
-          mode: '',
-          language: 'ftl',
-          script,
-        },
-        dependencies,
-      ),
-      'adt-create',
-      'LIFERAY_RESOURCE_ERROR',
-    );
-
-    return {
-      status: 'created',
-      id: String(created.data?.templateKey ?? created.data?.templateId ?? ''),
-      name,
-      extra: resolvedWidget,
-      adtFile,
-      widgetType: resolvedWidget,
-      siteId: site.id,
-      siteFriendlyUrl: site.friendlyUrlPath,
-    };
-  }
-
-  if (!options.checkOnly) {
-    const ddmTemplate = await authedGetJson<Record<string, unknown>>(
-      config,
-      `/api/jsonws/ddm.ddmtemplate/get-template?templateId=${existing.templateId}`,
-      'adt-ddm-get',
-      dependencies,
-    );
-    await expectJsonSuccess(
-      await authedPostForm(
-        config,
-        '/api/jsonws/ddm.ddmtemplate/update-template',
-        {
-          templateId: String(existing.templateId),
-          classPK: String(ddmTemplate.classPK ?? '0'),
-          nameMap: localizedMap(name),
-          descriptionMap: localizedMap(''),
-          type: 'display',
-          mode: '',
-          language: 'ftl',
-          script,
-          cacheable: 'false',
-        },
-        dependencies,
-      ),
-      'adt-update',
-      'LIFERAY_RESOURCE_ERROR',
-    );
-  }
-
-  const runtime = (
-    await runLiferayResourceListAdts(
-      config,
-      {site: site.friendlyUrlPath, widgetType: resolvedWidget, className: resolvedClassName, includeScript: true},
-      dependencies,
-    )
-  ).find((item) => String(item.templateId) === String(existing.templateId));
-  if (runtime?.script && sha256(runtime.script) !== localSha) {
-    throw new CliError(`Hash mismatch ADT '${name}'`, {code: 'LIFERAY_RESOURCE_ERROR'});
-  }
-
-  return {
-    status: normalizeSyncStatus(Boolean(options.checkOnly)),
-    id: String(existing.templateKey || existing.templateId),
+  // ADT-specific: global fallback
+  // Check if ADT exists in requested site, fall back to global if not found
+  const existsInSite = await findAdtInSite(
+    config,
+    site.friendlyUrlPath,
+    resolvedWidget,
+    resolvedClassName,
     name,
+    dependencies,
+  );
+  if (!existsInSite && site.friendlyUrlPath !== '/global') {
+    const globalSite = await resolveResourceSite(config, '/global', dependencies);
+    const existsInGlobal = await findAdtInSite(
+      config,
+      '/global',
+      resolvedWidget,
+      resolvedClassName,
+      name,
+      dependencies,
+    );
+    if (existsInGlobal) {
+      site = globalSite;
+    }
+  }
+
+  // Use SyncEngine with ADT strategy
+  const engineResult = await syncArtifact(
+    config,
+    site,
+    adtSyncStrategy,
+    {
+      checkOnly: options.checkOnly,
+      createMissing: options.createMissing,
+      strategyOptions: {
+        key: name,
+        widgetType: resolvedWidget,
+        className: resolvedClassName,
+        file: options.file,
+      },
+    },
+    dependencies,
+  );
+
+  // Resolve adtFile from strategy options
+  const adtFile = await resolveAdtFile(config, name, resolvedWidget, options.file);
+
+  // Return result with extended fields for backward compatibility
+  return {
+    ...engineResult,
     extra: resolvedWidget,
     adtFile,
     widgetType: resolvedWidget,
@@ -182,6 +112,9 @@ export function formatLiferayResourceSyncAdt(result: LiferayResourceSyncAdtResul
   ].join('\n');
 }
 
+/**
+ * Helper: Infer ADT widget type from file path directory.
+ */
 function inferAdtWidgetType(file: string): string {
   if (!file) {
     return '';
@@ -191,6 +124,9 @@ function inferAdtWidgetType(file: string): string {
   return match?.[0] ?? '';
 }
 
+/**
+ * Helper: Infer ADT name from file path basename.
+ */
 function inferAdtName(file: string): string {
   if (!file) {
     throw new CliError(
@@ -201,7 +137,11 @@ function inferAdtName(file: string): string {
   return path.basename(file, path.extname(file));
 }
 
-async function findAdt(
+/**
+ * Helper: Check if an ADT exists in a given site.
+ * Returns the ADT row if found, null if not found.
+ */
+async function findAdtInSite(
   config: AppConfig,
   site: string,
   widgetType: string,
@@ -209,7 +149,10 @@ async function findAdt(
   name: string,
   dependencies?: ResourceSyncDependencies,
 ) {
-  return (
-    await runLiferayResourceListAdts(config, {site, widgetType, className, includeScript: true}, dependencies)
-  ).find((item) => [item.templateKey, item.adtName, item.displayName].includes(name));
+  const adts = await runLiferayResourceListAdts(
+    config,
+    {site, widgetType, className, includeScript: true},
+    dependencies,
+  );
+  return adts.find((item) => [item.templateKey, item.adtName, item.displayName].includes(name)) ?? null;
 }

--- a/src/features/liferay/resource/liferay-resource-sync-template.ts
+++ b/src/features/liferay/resource/liferay-resource-sync-template.ts
@@ -1,24 +1,20 @@
-import fs from 'fs-extra';
+/**
+ * Liferay template synchronization.
+ *
+ * Syncs a local template file with remote Liferay instance.
+ * Uses generic SyncEngine with template-specific strategy.
+ *
+ * Public API maintained for backward compatibility:
+ * - runLiferayResourceSyncTemplate: main entry point
+ * - formatLiferayResourceSyncTemplate: format result for output
+ */
 
-import {CliError} from '../../../core/errors.js';
 import type {AppConfig} from '../../../core/config/load-config.js';
-import {expectJsonSuccess} from '../liferay-http-shared.js';
-import {runLiferayInventoryTemplates} from '../inventory/liferay-inventory-templates.js';
-import {runLiferayResourceGetTemplate} from './liferay-resource-get-template.js';
-import {fetchStructureByKey} from './liferay-resource-sync-structure-shared.js';
-import {resolveTemplateFile, resolveSiteToken} from './liferay-resource-paths.js';
-import {fetchStructureTemplateClassIds, resolveResourceSite} from './liferay-resource-shared.js';
-import {normalizeLiferayTemplateScript} from './liferay-resource-template-normalize.js';
-import {
-  authedGetJson,
-  authedPostForm,
-  ensureString,
-  localizedMap,
-  normalizeSyncStatus,
-  sha256,
-  type ResourceSyncDependencies,
-  type ResourceSyncResult,
-} from './liferay-resource-sync-shared.js';
+import type {ResourceSyncDependencies, ResourceSyncResult} from './liferay-resource-sync-shared.js';
+import {resolveResourceSite} from './liferay-resource-shared.js';
+import {resolveSiteToken, resolveTemplateFile} from './liferay-resource-paths.js';
+import {syncArtifact} from './sync-engine.js';
+import {templateSyncStrategy} from './sync-strategies/template-sync-strategy.js';
 
 export type LiferayResourceSyncTemplateResult = ResourceSyncResult & {
   templateFile: string;
@@ -26,6 +22,14 @@ export type LiferayResourceSyncTemplateResult = ResourceSyncResult & {
   siteFriendlyUrl: string;
 };
 
+/**
+ * Sync a template from local filesystem to remote Liferay instance.
+ *
+ * @param config App configuration with Liferay URL and credentials
+ * @param options Sync options (site, key, file, structure, flags)
+ * @param dependencies Optional DI for API client and token client
+ * @returns Sync result with status, id, file path, and site info
+ */
 export async function runLiferayResourceSyncTemplate(
   config: AppConfig,
   options: {
@@ -39,183 +43,44 @@ export async function runLiferayResourceSyncTemplate(
   dependencies?: ResourceSyncDependencies,
 ): Promise<LiferayResourceSyncTemplateResult> {
   const site = await resolveResourceSite(config, options.site ?? '/global', dependencies);
-  const siteToken = resolveSiteToken(site.friendlyUrlPath);
-  const templateFile = await resolveTemplateFile(config, siteToken, options.key, options.file);
-  const script = await fs.readFile(templateFile, 'utf8');
-  const normalizedLocalScript = normalizeLiferayTemplateScript(script);
-  const localSha = sha256(normalizedLocalScript);
-  const inventoryTemplates = await runLiferayInventoryTemplates(config, {site: site.friendlyUrlPath}, dependencies);
 
-  let structureIdFilter = '';
-  if (options.structureKey) {
-    const structure = await fetchStructureByKey(config, site.id, options.structureKey, dependencies);
-    structureIdFilter = String(structure.id ?? '');
-  }
-
-  const inventoryExisting = inventoryTemplates.find((item) => {
-    if (![item.id, item.externalReferenceCode, item.name].includes(options.key)) {
-      return false;
-    }
-    if (structureIdFilter !== '' && String(item.contentStructureId) !== structureIdFilter) {
-      return false;
-    }
-    return true;
-  });
-
-  const {classNameId, resourceClassNameId} = await fetchStructureTemplateClassIds(config, dependencies);
-  const directDdmTemplate =
-    (await tryGetDdmTemplateByKey(config, site.id, classNameId, options.key, dependencies)) ??
-    (inventoryExisting
-      ? await tryGetDdmTemplateByKey(config, site.id, classNameId, inventoryExisting.id, dependencies)
-      : null);
-
-  const existing =
-    directDdmTemplate && (structureIdFilter === '' || String(directDdmTemplate.classPK ?? '') === structureIdFilter)
-      ? directDdmTemplate
-      : null;
-
-  if (!existing && !inventoryExisting) {
-    if (!options.createMissing) {
-      throw new CliError(`Template '${options.key}' does not exist and create-missing is not enabled.`, {
-        code: 'LIFERAY_RESOURCE_ERROR',
-      });
-    }
-    if (options.checkOnly) {
-      return {
-        status: 'checked_missing',
-        id: '',
-        name: options.key,
-        extra: '',
-        templateFile,
-        siteId: site.id,
-        siteFriendlyUrl: site.friendlyUrlPath,
-      };
-    }
-    if (structureIdFilter === '') {
-      throw new CliError('To create a template, provide --structure-key.', {
-        code: 'LIFERAY_RESOURCE_ERROR',
-      });
-    }
-
-    const created = await authedPostForm<Record<string, unknown>>(
-      config,
-      '/api/jsonws/ddm.ddmtemplate/add-template',
-      {
-        externalReferenceCode: options.key,
-        groupId: String(site.id),
-        classNameId: String(classNameId),
-        classPK: structureIdFilter,
-        resourceClassNameId: String(resourceClassNameId),
-        nameMap: localizedMap(options.key),
-        descriptionMap: localizedMap(''),
-        type: 'display',
-        mode: '',
-        language: 'ftl',
-        script,
-      },
-      dependencies,
-    );
-    const success = await expectJsonSuccess(created, 'template-create', 'LIFERAY_RESOURCE_ERROR');
-    const id = String(success.data?.templateKey ?? success.data?.templateId ?? '');
-
-    return {
-      status: 'created',
-      id,
-      name: options.key,
-      extra: '',
-      templateFile,
-      siteId: site.id,
-      siteFriendlyUrl: site.friendlyUrlPath,
-    };
-  }
-
-  const existingKey = String(existing?.templateKey ?? existing?.templateId ?? inventoryExisting?.id ?? '');
-
-  if (!options.checkOnly) {
-    if (existing) {
-      const templateId = ensureString(existing.templateId, 'templateId');
-      const classPk = String(existing.classPK ?? '0');
-      await expectJsonSuccess(
-        await authedPostForm(
-          config,
-          '/api/jsonws/ddm.ddmtemplate/update-template',
-          {
-            templateId,
-            classPK: classPk,
-            nameMap: localizedMap(options.key),
-            descriptionMap: localizedMap(''),
-            type: 'display',
-            mode: '',
-            language: 'ftl',
-            script,
-            cacheable: 'false',
-          },
-          dependencies,
-        ),
-        'template-update',
-        'LIFERAY_RESOURCE_ERROR',
-      );
-    }
-  }
-
-  const runtime = await runLiferayResourceGetTemplate(
+  // Use SyncEngine with template strategy
+  const engineResult = await syncArtifact(
     config,
-    {site: site.friendlyUrlPath, id: existingKey || options.key},
+    site,
+    templateSyncStrategy,
+    {
+      checkOnly: options.checkOnly,
+      createMissing: options.createMissing,
+      strategyOptions: {
+        key: options.key,
+        file: options.file,
+        structureKey: options.structureKey,
+      },
+    },
     dependencies,
   );
-  const normalizedRuntimeScript = normalizeLiferayTemplateScript(runtime.templateScript);
-  if (normalizedRuntimeScript !== '' && sha256(normalizedRuntimeScript) !== localSha) {
-    throw new CliError(`Hash mismatch template '${options.key}'`, {code: 'LIFERAY_RESOURCE_ERROR'});
-  }
 
+  // Resolve templateFile from strategy for result
+  const siteToken = resolveSiteToken(site.friendlyUrlPath);
+  const templateFile = await resolveTemplateFile(config, siteToken, options.key, options.file);
+
+  // Return result with extended fields for backward compatibility
   return {
-    status: normalizeSyncStatus(Boolean(options.checkOnly)),
-    id: existingKey,
-    name: options.key,
-    extra: '',
+    ...engineResult,
     templateFile,
     siteId: site.id,
     siteFriendlyUrl: site.friendlyUrlPath,
   };
 }
 
+/**
+ * Format template sync result for console output.
+ */
 export function formatLiferayResourceSyncTemplate(result: LiferayResourceSyncTemplateResult): string {
   return [
     `${result.status}\t${result.name}\t${result.id}`,
     `site=${result.siteFriendlyUrl} (${result.siteId})`,
     `file=${result.templateFile}`,
   ].join('\n');
-}
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-function _matchesTemplate(item: Record<string, unknown>, identifier: string): boolean {
-  return [
-    String(item.templateId ?? ''),
-    String(item.templateKey ?? ''),
-    String(item.externalReferenceCode ?? ''),
-    String(item.nameCurrentValue ?? ''),
-    String(item.name ?? ''),
-  ].includes(identifier);
-}
-
-async function tryGetDdmTemplateByKey(
-  config: AppConfig,
-  siteId: number,
-  classNameId: number,
-  templateKey: string,
-  dependencies?: ResourceSyncDependencies,
-): Promise<Record<string, unknown> | null> {
-  try {
-    return await authedGetJson<Record<string, unknown>>(
-      config,
-      `/api/jsonws/ddm.ddmtemplate/get-template?groupId=${siteId}&classNameId=${classNameId}&templateKey=${encodeURIComponent(templateKey)}`,
-      'template-ddm-get',
-      dependencies,
-    );
-  } catch (error) {
-    if (error instanceof CliError && error.message.includes('status=404')) {
-      return null;
-    }
-    throw error;
-  }
 }

--- a/src/features/liferay/resource/sync-engine.ts
+++ b/src/features/liferay/resource/sync-engine.ts
@@ -1,0 +1,175 @@
+/**
+ * Generic sync engine for artifact synchronization.
+ *
+ * Extracts common sync flow:
+ * 1. resolveSite - locate target site
+ * 2. resolveLocalArtifact - find local file/resource
+ * 3. readLocal - read and normalize local content
+ * 4. findRemote - lookup remote existing artifact
+ * 5. upsert - create or update remote
+ * 6. verifyRemote - hash verification
+ *
+ * Strategies implement artifact-specific logic; engine orchestrates flow.
+ */
+
+import type {AppConfig} from '../../../core/config/load-config.js';
+import {CliError} from '../../../core/errors.js';
+import type {ResolvedSite} from '../inventory/liferay-site-resolver.js';
+import type {ResourceSyncDependencies, ResourceSyncResult} from './liferay-resource-sync-shared.js';
+
+/**
+ * Local artifact representation after reading.
+ */
+export type LocalArtifact<T = Record<string, unknown>> = {
+  /** Artifact identifier (key, id, name, etc.) */
+  id: string;
+  /** Normalized content for hashing */
+  normalizedContent: string;
+  /** SHA256 hash of normalized content */
+  contentHash: string;
+  /** Raw artifact data (file path, structured content, etc.) */
+  data: T;
+};
+
+/**
+ * Remote artifact representation after lookup.
+ */
+export type RemoteArtifact<T = Record<string, unknown>> = {
+  /** Artifact identifier in remote system */
+  id: string;
+  /** Artifact name/key as stored remotely */
+  name: string;
+  /** SHA256 of remote content (if verifiable) */
+  contentHash?: string;
+  /** Raw remote artifact data */
+  data: T;
+};
+
+/**
+ * Strategy for syncing a specific artifact type.
+ * Implement for templates, ADTs, structures, etc.
+ */
+export type SyncStrategy<Local = Record<string, unknown>, Remote = Record<string, unknown>> = {
+  /**
+   * Resolve local artifact from filesystem or config.
+   * @returns LocalArtifact or null if not found
+   */
+  resolveLocal(
+    config: AppConfig,
+    site: ResolvedSite,
+    options: Record<string, unknown>,
+  ): Promise<LocalArtifact<Local> | null>;
+
+  /**
+   * Find existing remote artifact.
+   * @returns RemoteArtifact or null if not found
+   */
+  findRemote(
+    config: AppConfig,
+    site: ResolvedSite,
+    localArtifact: LocalArtifact<Local>,
+    options: Record<string, unknown>,
+    dependencies?: ResourceSyncDependencies,
+  ): Promise<RemoteArtifact<Remote> | null>;
+
+  /**
+   * Create or update remote artifact.
+   * @returns RemoteArtifact with id and name after upsert
+   */
+  upsert(
+    config: AppConfig,
+    site: ResolvedSite,
+    localArtifact: LocalArtifact<Local>,
+    remoteArtifact: RemoteArtifact<Remote> | null,
+    options: Record<string, unknown>,
+    dependencies?: ResourceSyncDependencies,
+  ): Promise<RemoteArtifact<Remote>>;
+
+  /**
+   * Verify remote artifact matches local (hash check, etc.).
+   * Throw if verification fails.
+   */
+  verify(
+    config: AppConfig,
+    site: ResolvedSite,
+    localArtifact: LocalArtifact<Local>,
+    remoteArtifact: RemoteArtifact<Remote>,
+    dependencies?: ResourceSyncDependencies,
+  ): Promise<void>;
+};
+
+/**
+ * Options passed to SyncEngine.
+ */
+export type SyncEngineOptions = {
+  /** Dry-run mode: check without creating/updating */
+  checkOnly?: boolean;
+  /** Create artifact if it doesn't exist remotely */
+  createMissing?: boolean;
+  /** User-provided options (strategy-specific) */
+  strategyOptions?: Record<string, unknown>;
+};
+
+/**
+ * Generic sync engine result.
+ */
+export type SyncEngineResult = ResourceSyncResult;
+
+/**
+ * Orchestrate artifact synchronization using a strategy.
+ */
+export async function syncArtifact<Local = Record<string, unknown>, Remote = Record<string, unknown>>(
+  config: AppConfig,
+  site: ResolvedSite,
+  strategy: SyncStrategy<Local, Remote>,
+  options: SyncEngineOptions,
+  dependencies?: ResourceSyncDependencies,
+): Promise<SyncEngineResult> {
+  const strategyOpts = options.strategyOptions ?? {};
+
+  // 1. Resolve local artifact
+  const localArtifact = await strategy.resolveLocal(config, site, strategyOpts);
+  if (!localArtifact) {
+    throw new CliError('Local artifact not found', {code: 'LIFERAY_RESOURCE_FILE_NOT_FOUND'});
+  }
+
+  // 2. Find remote artifact
+  const remoteArtifact = await strategy.findRemote(config, site, localArtifact, strategyOpts, dependencies);
+
+  // 3. If missing and not allowed, preserve legacy sync semantics.
+  if (!remoteArtifact && !options.createMissing) {
+    throw new CliError(`Artifact '${localArtifact.id}' does not exist and create-missing is not enabled.`, {
+      code: 'LIFERAY_RESOURCE_ERROR',
+    });
+  }
+
+  // 4. If missing and check-only (only reachable when createMissing=true)
+  if (!remoteArtifact && options.checkOnly) {
+    return {
+      status: 'checked_missing',
+      id: '',
+      name: localArtifact.id,
+      extra: '',
+    };
+  }
+
+  // 5. Upsert
+  if (!options.checkOnly) {
+    await strategy.upsert(config, site, localArtifact, remoteArtifact, strategyOpts, dependencies);
+  }
+
+  // 6. Verify (always, even in check-only mode for hash validation)
+  const verifiedRemote = await strategy.findRemote(config, site, localArtifact, strategyOpts, dependencies);
+  if (verifiedRemote) {
+    await strategy.verify(config, site, localArtifact, verifiedRemote, dependencies);
+  }
+
+  const finalStatus = options.checkOnly ? 'checked' : remoteArtifact ? 'updated' : 'created';
+
+  return {
+    status: finalStatus,
+    id: verifiedRemote?.id ?? localArtifact.id,
+    name: localArtifact.id,
+    extra: '',
+  };
+}

--- a/src/features/liferay/resource/sync-strategies/adt-sync-strategy.ts
+++ b/src/features/liferay/resource/sync-strategies/adt-sync-strategy.ts
@@ -1,0 +1,231 @@
+/**
+ * Sync strategy for Liferay ADTs (Application Display Templates).
+ * Implements artifact-specific logic for ADT synchronization.
+ */
+
+import fs from 'fs-extra';
+
+import type {AppConfig} from '../../../../core/config/load-config.js';
+import {CliError} from '../../../../core/errors.js';
+import type {ResolvedSite} from '../../inventory/liferay-site-resolver.js';
+import {runLiferayResourceListAdts} from '../liferay-resource-list-adts.js';
+import {resolveAdtFile} from '../liferay-resource-paths.js';
+import {fetchAdtResourceClassNameId, fetchClassNameIdForValue} from '../liferay-resource-shared.js';
+import {
+  authedGetJson,
+  authedPostForm,
+  localizedMap,
+  sha256,
+  type ResourceSyncDependencies,
+} from '../liferay-resource-sync-shared.js';
+import {expectJsonSuccess} from '../../liferay-http-shared.js';
+import type {LocalArtifact, RemoteArtifact, SyncStrategy} from '../sync-engine.js';
+
+type AdtLocalData = {
+  filePath: string;
+};
+
+type AdtRemoteData = {
+  templateId: string;
+  templateKey?: string;
+  widgetType: string;
+  className: string;
+};
+
+type AdtSyncOptions = {
+  key: string;
+  widgetType: string;
+  className: string;
+  file?: string;
+};
+
+/**
+ * ADT sync strategy implementation.
+ * Note: Global-site fallback is handled by the facade before calling the engine.
+ * This strategy operates on a single pre-determined site.
+ */
+export const adtSyncStrategy: SyncStrategy<AdtLocalData, AdtRemoteData> = {
+  async resolveLocal(
+    config: AppConfig,
+    site: ResolvedSite,
+    options: Record<string, unknown>,
+  ): Promise<LocalArtifact<AdtLocalData> | null> {
+    const opts = options as AdtSyncOptions;
+
+    try {
+      const filePath = await resolveAdtFile(config, opts.key, opts.widgetType, opts.file);
+      const script = await fs.readFile(filePath, 'utf8');
+      // ADTs do not normalize like templates; use raw content for hashing
+      const contentHash = sha256(script);
+
+      return {
+        id: opts.key,
+        normalizedContent: script,
+        contentHash,
+        data: {filePath},
+      };
+    } catch (error) {
+      if (error instanceof CliError && error.code === 'LIFERAY_RESOURCE_FILE_NOT_FOUND') {
+        return null;
+      }
+      throw error;
+    }
+  },
+
+  async findRemote(
+    config: AppConfig,
+    site: ResolvedSite,
+    localArtifact: LocalArtifact<AdtLocalData>,
+    options: Record<string, unknown>,
+    dependencies?: ResourceSyncDependencies,
+  ): Promise<RemoteArtifact<AdtRemoteData> | null> {
+    const opts = options as AdtSyncOptions;
+
+    // List ADTs for this site, widget type, and class name
+    const adts = await runLiferayResourceListAdts(
+      config,
+      {
+        site: site.friendlyUrlPath,
+        widgetType: opts.widgetType,
+        className: opts.className,
+        includeScript: true,
+      },
+      dependencies,
+    );
+
+    // Match by key (templateKey, adtName, or displayName)
+    const existing = adts.find((item) => {
+      return [item.templateKey, item.adtName, item.displayName].includes(opts.key);
+    });
+
+    if (!existing) {
+      return null;
+    }
+
+    return {
+      id: String(((existing.templateKey ?? existing.templateId) as string | undefined) ?? ''),
+      name: opts.key,
+      data: {
+        templateId: String(existing.templateId),
+        templateKey: existing.templateKey as string | undefined,
+        widgetType: existing.widgetType,
+        className: existing.className,
+      },
+    };
+  },
+
+  async upsert(
+    config: AppConfig,
+    site: ResolvedSite,
+    localArtifact: LocalArtifact<AdtLocalData>,
+    remoteArtifact: RemoteArtifact<AdtRemoteData> | null,
+    options: Record<string, unknown>,
+    dependencies?: ResourceSyncDependencies,
+  ): Promise<RemoteArtifact<AdtRemoteData>> {
+    const opts = options as AdtSyncOptions;
+
+    if (!remoteArtifact) {
+      // Create new ADT
+      const classNameId = await fetchClassNameIdForValue(config, opts.className, dependencies);
+      const resourceClassNameId = await fetchAdtResourceClassNameId(config, dependencies);
+
+      const created = await expectJsonSuccess(
+        await authedPostForm<Record<string, unknown>>(
+          config,
+          '/api/jsonws/ddm.ddmtemplate/add-template',
+          {
+            externalReferenceCode: opts.key,
+            groupId: String(site.id),
+            classNameId: String(classNameId),
+            classPK: '0', // ADTs have no structure binding
+            resourceClassNameId: String(resourceClassNameId),
+            nameMap: localizedMap(opts.key),
+            descriptionMap: localizedMap(''),
+            type: 'display',
+            mode: '',
+            language: 'ftl',
+            script: localArtifact.normalizedContent,
+          },
+          dependencies,
+        ),
+        'adt-create',
+        'LIFERAY_RESOURCE_ERROR',
+      );
+
+      const createdId = String(created.data?.templateKey ?? created.data?.templateId ?? '');
+
+      return {
+        id: createdId,
+        name: opts.key,
+        data: {
+          templateId: createdId,
+          templateKey: created.data?.templateKey as string | undefined,
+          widgetType: opts.widgetType,
+          className: opts.className,
+        },
+      };
+    }
+
+    // Update existing ADT
+    const ddmTemplate = await authedGetJson<Record<string, unknown>>(
+      config,
+      `/api/jsonws/ddm.ddmtemplate/get-template?templateId=${remoteArtifact.data.templateId}`,
+      'adt-ddm-get',
+      dependencies,
+    );
+
+    await expectJsonSuccess(
+      await authedPostForm(
+        config,
+        '/api/jsonws/ddm.ddmtemplate/update-template',
+        {
+          templateId: remoteArtifact.data.templateId,
+          classPK: String(ddmTemplate.classPK ?? '0'),
+          nameMap: localizedMap(opts.key),
+          descriptionMap: localizedMap(''),
+          type: 'display',
+          mode: '',
+          language: 'ftl',
+          script: localArtifact.normalizedContent,
+          cacheable: 'false',
+        },
+        dependencies,
+      ),
+      'adt-update',
+      'LIFERAY_RESOURCE_ERROR',
+    );
+
+    return remoteArtifact;
+  },
+
+  async verify(
+    config: AppConfig,
+    site: ResolvedSite,
+    localArtifact: LocalArtifact<AdtLocalData>,
+    remoteArtifact: RemoteArtifact<AdtRemoteData>,
+    dependencies?: ResourceSyncDependencies,
+  ): Promise<void> {
+    // Re-list ADTs to verify the runtime script matches local
+    const adts = await runLiferayResourceListAdts(
+      config,
+      {
+        site: site.friendlyUrlPath,
+        widgetType: remoteArtifact.data.widgetType,
+        className: remoteArtifact.data.className,
+        includeScript: true,
+      },
+      dependencies,
+    );
+
+    const runtime = adts.find((item) => String(item.templateId) === String(remoteArtifact.data.templateId));
+
+    if (runtime?.script) {
+      const runtimeHash = sha256(runtime.script);
+      if (runtimeHash !== localArtifact.contentHash) {
+        throw new CliError(`Hash mismatch ADT '${remoteArtifact.name}'`, {
+          code: 'LIFERAY_RESOURCE_ERROR',
+        });
+      }
+    }
+  },
+};

--- a/src/features/liferay/resource/sync-strategies/template-sync-strategy.ts
+++ b/src/features/liferay/resource/sync-strategies/template-sync-strategy.ts
@@ -1,0 +1,281 @@
+/**
+ * Sync strategy for Liferay templates.
+ * Implements artifact-specific logic for template synchronization.
+ */
+
+import fs from 'fs-extra';
+
+import type {AppConfig} from '../../../../core/config/load-config.js';
+import {CliError} from '../../../../core/errors.js';
+import type {ResolvedSite} from '../../inventory/liferay-site-resolver.js';
+import {runLiferayInventoryTemplates} from '../../inventory/liferay-inventory-templates.js';
+import {runLiferayResourceGetTemplate} from '../liferay-resource-get-template.js';
+import {fetchStructureByKey} from '../liferay-resource-sync-structure-shared.js';
+import {resolveTemplateFile, resolveSiteToken} from '../liferay-resource-paths.js';
+import {fetchStructureTemplateClassIds} from '../liferay-resource-shared.js';
+import {normalizeLiferayTemplateScript} from '../liferay-resource-template-normalize.js';
+import {
+  authedGetJson,
+  authedPostForm,
+  ensureString,
+  localizedMap,
+  sha256,
+  type ResourceSyncDependencies,
+} from '../liferay-resource-sync-shared.js';
+import {expectJsonSuccess} from '../../liferay-http-shared.js';
+import type {LocalArtifact, RemoteArtifact, SyncStrategy} from '../sync-engine.js';
+
+type TemplateLocalData = {
+  filePath: string;
+};
+
+type TemplateRemoteData = {
+  templateId: string;
+  templateKey?: string;
+  externalReferenceCode?: string;
+  classPK?: string;
+  script?: string;
+};
+
+type TemplateSyncOptions = {
+  key: string;
+  file?: string;
+  structureKey?: string;
+};
+
+/**
+ * Template sync strategy implementation.
+ */
+export const templateSyncStrategy: SyncStrategy<TemplateLocalData, TemplateRemoteData> = {
+  async resolveLocal(
+    config: AppConfig,
+    site: ResolvedSite,
+    options: Record<string, unknown>,
+  ): Promise<LocalArtifact<TemplateLocalData> | null> {
+    const opts = options as TemplateSyncOptions;
+    const siteToken = resolveSiteToken(site.friendlyUrlPath);
+
+    try {
+      const filePath = await resolveTemplateFile(config, siteToken, opts.key, opts.file);
+      const script = await fs.readFile(filePath, 'utf8');
+      const normalizedContent = normalizeLiferayTemplateScript(script);
+
+      return {
+        id: opts.key,
+        normalizedContent,
+        contentHash: sha256(normalizedContent),
+        data: {filePath},
+      };
+    } catch (error) {
+      if (error instanceof CliError && error.code === 'LIFERAY_RESOURCE_FILE_NOT_FOUND') {
+        return null;
+      }
+      throw error;
+    }
+  },
+
+  async findRemote(
+    config: AppConfig,
+    site: ResolvedSite,
+    localArtifact: LocalArtifact<TemplateLocalData>,
+    options: Record<string, unknown>,
+    dependencies?: ResourceSyncDependencies,
+  ): Promise<RemoteArtifact<TemplateRemoteData> | null> {
+    const opts = options as TemplateSyncOptions;
+    const inventoryTemplates = await runLiferayInventoryTemplates(config, {site: site.friendlyUrlPath}, dependencies);
+
+    let structureIdFilter = '';
+    if (opts.structureKey) {
+      const structure = await fetchStructureByKey(config, site.id, opts.structureKey, dependencies);
+      structureIdFilter = String(structure.id ?? '');
+    }
+
+    const inventoryExisting = inventoryTemplates.find((item) => {
+      if (![item.id, item.externalReferenceCode, item.name].includes(opts.key)) {
+        return false;
+      }
+      if (structureIdFilter !== '' && String(item.contentStructureId) !== structureIdFilter) {
+        return false;
+      }
+      return true;
+    });
+
+    // Try direct DDM template lookup
+    const {classNameId} = await fetchStructureTemplateClassIds(config, dependencies);
+    const directDdmTemplate = await tryGetDdmTemplateByKey(
+      config,
+      site.id,
+      String(classNameId),
+      opts.key,
+      dependencies,
+    );
+
+    const existing = directDdmTemplate
+      ? structureIdFilter === '' || String(directDdmTemplate.classPK ?? '') === structureIdFilter
+        ? directDdmTemplate
+        : null
+      : null;
+
+    if (existing) {
+      return {
+        id: String(((existing.templateKey ?? existing.templateId) as string | undefined) ?? ''),
+        name: String(((existing.templateKey ?? existing.templateId) as string | undefined) ?? opts.key),
+        contentHash: localArtifact.contentHash, // Will verify in verify() step
+        data: {
+          templateId: ensureString(existing.templateId as string | undefined, 'templateId'),
+          templateKey: existing.templateKey as string | undefined,
+          externalReferenceCode: existing.externalReferenceCode as string | undefined,
+          classPK: String((existing.classPK as string | undefined) ?? ''),
+          script: existing.script as string | undefined,
+        },
+      };
+    }
+
+    // Check inventory as fallback
+    if (inventoryExisting) {
+      return {
+        id: String(inventoryExisting.id ?? ''),
+        name: inventoryExisting.name,
+        contentHash: localArtifact.contentHash,
+        data: {
+          templateId: inventoryExisting.id,
+          externalReferenceCode: inventoryExisting.externalReferenceCode,
+        },
+      };
+    }
+
+    return null;
+  },
+
+  async upsert(
+    config: AppConfig,
+    site: ResolvedSite,
+    localArtifact: LocalArtifact<TemplateLocalData>,
+    remoteArtifact: RemoteArtifact<TemplateRemoteData> | null,
+    options: Record<string, unknown>,
+    dependencies?: ResourceSyncDependencies,
+  ): Promise<RemoteArtifact<TemplateRemoteData>> {
+    const opts = options as TemplateSyncOptions;
+
+    if (!remoteArtifact) {
+      // Create new template
+      if (!opts.structureKey) {
+        throw new CliError('To create a template, provide --structure-key.', {
+          code: 'LIFERAY_RESOURCE_ERROR',
+        });
+      }
+
+      const {classNameId, resourceClassNameId} = await fetchStructureTemplateClassIds(config, dependencies);
+      const structure = await fetchStructureByKey(config, site.id, opts.structureKey, dependencies);
+
+      const created = await authedPostForm<Record<string, unknown>>(
+        config,
+        '/api/jsonws/ddm.ddmtemplate/add-template',
+        {
+          externalReferenceCode: opts.key,
+          groupId: String(site.id),
+          classNameId: String(classNameId),
+          classPK: String(structure.id ?? ''),
+          resourceClassNameId: String(resourceClassNameId),
+          nameMap: localizedMap(opts.key),
+          descriptionMap: localizedMap(''),
+          type: 'display',
+          mode: '',
+          language: 'ftl',
+          script: localArtifact.normalizedContent,
+        },
+        dependencies,
+      );
+
+      const success = await expectJsonSuccess(created, 'template-create', 'LIFERAY_RESOURCE_ERROR');
+      const createdId = String(success.data?.templateKey ?? success.data?.templateId ?? '');
+
+      return {
+        id: createdId,
+        name: opts.key,
+        data: {
+          templateId: createdId,
+          externalReferenceCode: opts.key,
+        },
+      };
+    }
+
+    // Update existing template
+    const templateId = ensureString(remoteArtifact.data.templateId, 'templateId');
+    const classPk = String(remoteArtifact.data.classPK ?? '0');
+
+    await expectJsonSuccess(
+      await authedPostForm(
+        config,
+        '/api/jsonws/ddm.ddmtemplate/update-template',
+        {
+          templateId,
+          classPK: classPk,
+          nameMap: localizedMap(opts.key),
+          descriptionMap: localizedMap(''),
+          type: 'display',
+          mode: '',
+          language: 'ftl',
+          script: localArtifact.normalizedContent,
+          cacheable: 'false',
+        },
+        dependencies,
+      ),
+      'template-update',
+      'LIFERAY_RESOURCE_ERROR',
+    );
+
+    return remoteArtifact;
+  },
+
+  async verify(
+    config: AppConfig,
+    site: ResolvedSite,
+    localArtifact: LocalArtifact<TemplateLocalData>,
+    remoteArtifact: RemoteArtifact<TemplateRemoteData>,
+    dependencies?: ResourceSyncDependencies,
+  ): Promise<void> {
+    // Get runtime template from API
+    const runtime = await runLiferayResourceGetTemplate(
+      config,
+      {site: site.friendlyUrlPath, id: remoteArtifact.id},
+      dependencies,
+    );
+
+    const normalizedRuntimeScript = normalizeLiferayTemplateScript(runtime.templateScript || '');
+    const runtimeHash = normalizedRuntimeScript !== '' ? sha256(normalizedRuntimeScript) : '';
+
+    // Verify hash match
+    if (runtimeHash !== '' && runtimeHash !== localArtifact.contentHash) {
+      throw new CliError(`Hash mismatch template '${remoteArtifact.name}'`, {
+        code: 'LIFERAY_RESOURCE_ERROR',
+      });
+    }
+  },
+};
+
+/**
+ * Helper: Try to fetch DDM template by key from server.
+ * Returns null if not found (swallows 404-like errors).
+ */
+async function tryGetDdmTemplateByKey(
+  config: AppConfig,
+  siteId: number,
+  classNameId: string,
+  templateKey: string,
+  dependencies?: ResourceSyncDependencies,
+): Promise<Record<string, unknown> | null> {
+  try {
+    return await authedGetJson<Record<string, unknown>>(
+      config,
+      `/api/jsonws/ddm.ddmtemplate/get-template?groupId=${siteId}&classNameId=${classNameId}&templateKey=${templateKey}`,
+      'template-lookup',
+      dependencies,
+    );
+  } catch (error) {
+    if (error instanceof CliError && error.code === 'LIFERAY_RESOURCE_ERROR') {
+      return null;
+    }
+    throw error;
+  }
+}

--- a/tests/unit/liferay-resource-sync-adt.test.ts
+++ b/tests/unit/liferay-resource-sync-adt.test.ts
@@ -67,6 +67,45 @@ async function createRepoFixture() {
 }
 
 describe('liferay resource adt-sync', () => {
+  test('throws when ADT is missing and createMissing is not enabled', async () => {
+    const {config, adtFile} = await createRepoFixture();
+    const apiClient = createLiferayApiClient({
+      fetchImpl: async (input) => {
+        const url = String(input);
+
+        if (url.includes('/by-friendly-url-path/global')) {
+          return new Response('{"id":20121,"friendlyUrlPath":"/global","name":"Global","companyId":20097}', {
+            status: 200,
+          });
+        }
+        if (url.includes('/api/jsonws/group/get-group?groupId=20121')) {
+          return new Response('{"companyId":20097}', {status: 200});
+        }
+        if (
+          url.includes('/classname/fetch-class-name?value=com.liferay.portlet.display.template.PortletDisplayTemplate')
+        ) {
+          return new Response('{"classNameId":777}', {status: 200});
+        }
+        if (
+          url.includes(
+            '/classname/fetch-class-name?value=com.liferay.portal.search.web.internal.result.display.context.SearchResultSummaryDisplayContext',
+          )
+        ) {
+          return new Response('{"classNameId":888}', {status: 200});
+        }
+        if (url.includes('/api/jsonws/ddm.ddmtemplate/get-templates')) {
+          return new Response('[]', {status: 200});
+        }
+
+        throw new Error(`Unexpected URL ${url}`);
+      },
+    });
+
+    await expect(
+      runLiferayResourceSyncAdt(config, {site: '/global', file: adtFile}, {apiClient, tokenClient: TOKEN_CLIENT}),
+    ).rejects.toThrow('does not exist and create-missing is not enabled');
+  });
+
   test('creates a missing ADT from a local file', async () => {
     const {config, adtFile} = await createRepoFixture();
     const apiClient = createLiferayApiClient({

--- a/tests/unit/liferay-resource-sync-template.test.ts
+++ b/tests/unit/liferay-resource-sync-template.test.ts
@@ -57,6 +57,51 @@ async function createRepoFixture() {
 }
 
 describe('liferay resource template-sync', () => {
+  test('throws when template is missing and createMissing is not enabled', async () => {
+    const {config, templateFile} = await createRepoFixture();
+    const apiClient = createLiferayApiClient({
+      fetchImpl: async (input) => {
+        const url = String(input);
+
+        if (url.includes('/by-friendly-url-path/global')) {
+          return new Response('{"id":20121,"friendlyUrlPath":"/global","name":"Global","companyId":20097}', {
+            status: 200,
+          });
+        }
+        if (url.includes('/api/jsonws/group/get-group?groupId=20121')) {
+          return new Response('{"companyId":20097}', {status: 200});
+        }
+        if (url.includes('/classname/fetch-class-name?value=com.liferay.dynamic.data.mapping.model.DDMStructure')) {
+          return new Response('{"classNameId":1234}', {status: 200});
+        }
+        if (url.includes('/classname/fetch-class-name?value=com.liferay.journal.model.JournalArticle')) {
+          return new Response('{"classNameId":5678}', {status: 200});
+        }
+        if (url.includes('/o/headless-delivery/v1.0/sites/20121/content-templates?page=1&pageSize=200')) {
+          return new Response('{"items":[],"lastPage":1,"page":1,"pageSize":200,"totalCount":0}', {status: 200});
+        }
+        if (
+          url.includes('/api/jsonws/ddm.ddmtemplate/get-template?groupId=20121&classNameId=1234&templateKey=MISSING')
+        ) {
+          return new Response('{"status":404}', {status: 404});
+        }
+        if (url.includes('/api/jsonws/ddm.ddmtemplate/get-templates')) {
+          return new Response('[]', {status: 200});
+        }
+
+        throw new Error(`Unexpected URL ${url}`);
+      },
+    });
+
+    await expect(
+      runLiferayResourceSyncTemplate(
+        config,
+        {site: '/global', key: 'MISSING', file: templateFile},
+        {apiClient, tokenClient: TOKEN_CLIENT},
+      ),
+    ).rejects.toThrow('does not exist and create-missing is not enabled');
+  });
+
   test('updates an existing template and verifies the resulting hash', async () => {
     const {config, templateFile} = await createRepoFixture();
     const calls: string[] = [];


### PR DESCRIPTION
﻿## Summary
This PR introduces a generic SyncEngine and migrates template and ADT sync flows to use it.

## Scope
- Added a generic sync orchestration engine:
  - resolve local artifact
  - find remote artifact
  - upsert
  - verify
- Migrated template sync to engine strategy.
- Migrated ADT sync to engine strategy (including global fallback behavior).
- Preserved public command API and output formatting.
- Added/updated tests for template and ADT sync behavior.

## Compatibility and behavior
- Existing CLI commands remain unchanged.
- Missing artifact behavior without `createMissing` is preserved (throws error).

## Validation
- `npm run test:unit -- tests/unit/liferay-resource-sync-template.test.ts tests/unit/liferay-resource-sync-adt.test.ts`
- `npm run typecheck`
- `npm run lint`

## Notes
- This keeps sync internals as facades while moving common logic into the engine.
