### PR TITLE
feat(resource): add shared identifier matchers and unify id/key/name/erc resolution (R11)

### DIFF
--- a/src/features/liferay/inventory/liferay-inventory-page-fetch.ts
+++ b/src/features/liferay/inventory/liferay-inventory-page-fetch.ts
@@ -47,6 +47,7 @@ import {
   listDdmTemplates,
   resolveResourceSite,
 } from '../resource/liferay-resource-shared.js';
+import {matchesDdmTemplate} from '../liferay-identifiers.js';
 
 type LayoutMatch = {layout: Layout; locale: string | null};
 type ArticleRef = {articleId: string; groupId: number; ddmTemplateKey?: string};
@@ -1443,21 +1444,11 @@ async function resolveTemplateSiteByKey(
     const templates = await listDdmTemplates(config, site, dependencies, {
       includeCompanyFallback: candidate.siteFriendlyUrl === '/global',
     });
-    if (templates.some((item) => matchesTemplateKey(item, templateKey))) {
+    if (templates.some((item) => matchesDdmTemplate(item, templateKey))) {
       return candidate.siteFriendlyUrl;
     }
   }
   return null;
-}
-
-function matchesTemplateKey(item: Record<string, unknown>, templateKey: string): boolean {
-  return (
-    templateKey === String(item.templateKey ?? '') ||
-    templateKey === String(item.templateId ?? '') ||
-    templateKey === String(item.externalReferenceCode ?? '') ||
-    templateKey === String(item.nameCurrentValue ?? '') ||
-    templateKey === String(item.name ?? '')
-  );
 }
 
 function buildStructureExportPath(config: AppConfig, siteFriendlyUrl: string, key: string): string | undefined {

--- a/src/features/liferay/liferay-identifiers.ts
+++ b/src/features/liferay/liferay-identifiers.ts
@@ -1,0 +1,113 @@
+/**
+ * Unified identifier matching for Liferay resource lookups.
+ *
+ * Provides single-source-of-truth predicates and normalizers for matching
+ * templates, ADTs, and inventory items by id, key, name, or ERC.
+ *
+ * Precedence order (highest → lowest):
+ *   DDM template: templateId | templateKey | externalReferenceCode | nameCurrentValue | name
+ *   ADT row:      templateId | ddmTemplate_<id> | templateKey | displayName | adtName
+ *   Inventory:    id | externalReferenceCode | name
+ *   ADT input:    --id > --display-style (strips ddmTemplate_) > --key > --name
+ */
+
+import {CliError} from '../../core/errors.js';
+
+// ---------------------------------------------------------------------------
+// DDM Template matching
+// ---------------------------------------------------------------------------
+
+/**
+ * Matches a DDM template item (from JSONWS `listDdmTemplates`) against an identifier.
+ * Fields checked: templateId, templateKey, externalReferenceCode, nameCurrentValue, name.
+ */
+export function matchesDdmTemplate(item: Record<string, unknown>, identifier: string): boolean {
+  return (
+    identifier === String(item.templateId ?? '') ||
+    identifier === String(item.templateKey ?? '') ||
+    identifier === String(item.externalReferenceCode ?? '') ||
+    identifier === String(item.nameCurrentValue ?? '') ||
+    identifier === String(item.name ?? '')
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ADT row matching
+// ---------------------------------------------------------------------------
+
+export type AdtRowShape = {
+  templateId: number | string;
+  templateKey: string;
+  displayName: string;
+  adtName: string;
+};
+
+/**
+ * Matches an ADT row against an identifier.
+ * Fields checked: templateId (as string), ddmTemplate_<templateId>, templateKey, displayName, adtName.
+ */
+export function matchesAdtRow(item: AdtRowShape, identifier: string): boolean {
+  const templateId = String(item.templateId ?? '');
+  return (
+    identifier === templateId ||
+    identifier === `ddmTemplate_${templateId}` ||
+    identifier === item.templateKey ||
+    identifier === item.displayName ||
+    identifier === item.adtName
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Inventory template matching (headless-delivery /content-templates)
+// ---------------------------------------------------------------------------
+
+export type InventoryTemplateShape = {
+  id: string;
+  externalReferenceCode?: string;
+  name?: string;
+};
+
+/**
+ * Matches an inventory template item (from headless-delivery `/content-templates`)
+ * against an identifier.
+ * Fields checked: id, externalReferenceCode, name.
+ */
+export function matchesInventoryTemplate(item: InventoryTemplateShape, identifier: string): boolean {
+  return identifier === item.id || identifier === item.externalReferenceCode || identifier === item.name;
+}
+
+// ---------------------------------------------------------------------------
+// ADT identifier normalization
+// ---------------------------------------------------------------------------
+
+export type AdtIdentifierOptions = {
+  displayStyle?: string;
+  id?: string;
+  key?: string;
+  name?: string;
+};
+
+/**
+ * Normalizes multi-field ADT command input to a single canonical identifier string.
+ * Precedence: id > displayStyle (strips `ddmTemplate_` prefix) > key > name.
+ * Throws if no usable value is found.
+ */
+export function normalizeAdtIdentifier(options: AdtIdentifierOptions): string {
+  if (options.id?.trim()) {
+    return options.id.trim();
+  }
+  if (options.displayStyle?.trim()) {
+    const trimmed = options.displayStyle.trim();
+    return trimmed.startsWith('ddmTemplate_') ? trimmed.slice('ddmTemplate_'.length) : trimmed;
+  }
+  if (options.key?.trim()) {
+    return options.key.trim();
+  }
+  if (options.name?.trim()) {
+    return options.name.trim();
+  }
+
+  throw new CliError('adt requires --display-style, --id, --key, or --name', {
+    code: 'LIFERAY_RESOURCE_ERROR',
+  });
+}

--- a/src/features/liferay/resource/liferay-resource-get-adt.ts
+++ b/src/features/liferay/resource/liferay-resource-get-adt.ts
@@ -6,6 +6,7 @@ import {runLiferayInventorySitesIncludingGlobal} from '../inventory/liferay-inve
 import {ADT_WIDGET_DIR_BY_TYPE} from './liferay-resource-paths.js';
 import {runLiferayResourceListAdts} from './liferay-resource-list-adts.js';
 import {buildResourceSiteChain} from './liferay-resource-shared.js';
+import {matchesAdtRow, normalizeAdtIdentifier} from '../liferay-identifiers.js';
 
 type ResourceDependencies = {
   apiClient?: LiferayApiClient;
@@ -39,7 +40,7 @@ export async function runLiferayResourceGetAdt(
   },
   dependencies?: ResourceDependencies,
 ): Promise<LiferayResourceAdtResult> {
-  const identifier = resolveIdentifier(options);
+  const identifier = normalizeAdtIdentifier(options);
 
   if (options.site?.trim()) {
     // Walk up the site hierarchy: child → parent → … → root. Return the first match.
@@ -58,7 +59,7 @@ export async function runLiferayResourceGetAdt(
       );
 
       for (const row of rows) {
-        if (!matchesAdt(row, identifier)) {
+        if (!matchesAdtRow(row, identifier)) {
           continue;
         }
         return {
@@ -99,7 +100,7 @@ export async function runLiferayResourceGetAdt(
     );
 
     for (const row of rows) {
-      if (!matchesAdt(row, identifier)) {
+      if (!matchesAdtRow(row, identifier)) {
         continue;
       }
 
@@ -171,51 +172,6 @@ export function formatLiferayResourceAdt(result: LiferayResourceAdtResult): stri
     `templateKey=${result.templateKey}`,
     `name=${result.adtName}`,
   ].join('\n');
-}
-
-function resolveIdentifier(options: {
-  displayStyle?: string;
-  id?: string;
-  key?: string;
-  name?: string;
-  widgetType?: string;
-}): string {
-  if (options.id?.trim()) {
-    return options.id.trim();
-  }
-  if (options.displayStyle?.trim()) {
-    const trimmed = options.displayStyle.trim();
-    return trimmed.startsWith('ddmTemplate_') ? trimmed.slice('ddmTemplate_'.length) : trimmed;
-  }
-  if (options.key?.trim()) {
-    return options.key.trim();
-  }
-  if (options.name?.trim()) {
-    return options.name.trim();
-  }
-
-  throw new CliError('adt requires --display-style, --id, --key, or --name', {
-    code: 'LIFERAY_RESOURCE_ERROR',
-  });
-}
-
-function matchesAdt(
-  row: {
-    widgetType: string;
-    templateId: number;
-    templateKey: string;
-    displayName: string;
-    adtName: string;
-  },
-  identifier: string,
-): boolean {
-  return (
-    identifier === String(row.templateId) ||
-    identifier === row.templateKey ||
-    identifier === row.displayName ||
-    identifier === row.adtName ||
-    identifier === `ddmTemplate_${row.templateId}`
-  );
 }
 
 async function collectSearchSites(

--- a/src/features/liferay/resource/liferay-resource-get-template.ts
+++ b/src/features/liferay/resource/liferay-resource-get-template.ts
@@ -4,6 +4,7 @@ import type {OAuthTokenClient} from '../../../core/http/auth.js';
 import type {LiferayApiClient} from '../../../core/http/client.js';
 import {runLiferayInventoryTemplates} from '../inventory/liferay-inventory-templates.js';
 import {buildResourceSiteChain, resolveResourceSite, listDdmTemplates} from './liferay-resource-shared.js';
+import {matchesDdmTemplate, matchesInventoryTemplate} from '../liferay-identifiers.js';
 
 type ResourceDependencies = {
   apiClient?: LiferayApiClient;
@@ -53,9 +54,7 @@ export async function runLiferayResourceGetTemplate(
         {site: candidateSite.friendlyUrlPath},
         dependencies,
       );
-      const inventoryMatch = inventoryTemplates.find(
-        (item) => options.id === item.id || options.id === item.externalReferenceCode || options.id === item.name,
-      );
+      const inventoryMatch = inventoryTemplates.find((item) => matchesInventoryTemplate(item, options.id));
 
       if (inventoryMatch) {
         site = candidateSite;
@@ -108,18 +107,4 @@ export function formatLiferayResourceTemplate(result: LiferayResourceTemplateRes
   ].join('\n');
 }
 
-function matchesTemplate(item: Record<string, unknown>, identifier: string): boolean {
-  const templateId = String(item.templateId ?? '');
-  const templateKey = String(item.templateKey ?? '');
-  const externalReferenceCode = String(item.externalReferenceCode ?? '');
-  const nameCurrentValue = String(item.nameCurrentValue ?? '');
-  const name = String(item.name ?? '');
-
-  return (
-    identifier === templateId ||
-    identifier === templateKey ||
-    identifier === externalReferenceCode ||
-    identifier === nameCurrentValue ||
-    identifier === name
-  );
-}
+const matchesTemplate = matchesDdmTemplate;

--- a/src/features/liferay/resource/liferay-resource-sync-adt.ts
+++ b/src/features/liferay/resource/liferay-resource-sync-adt.ts
@@ -12,6 +12,7 @@ import {
 import {resolveAdtFile, ADT_WIDGET_DIR_BY_TYPE} from './liferay-resource-paths.js';
 import {syncArtifact} from './sync-engine.js';
 import {adtSyncStrategy} from './sync-strategies/adt-sync-strategy.js';
+import {matchesAdtRow} from '../liferay-identifiers.js';
 
 export type LiferayResourceSyncAdtResult = ResourceSyncResult & {
   adtFile: string;
@@ -154,5 +155,5 @@ async function findAdtInSite(
     {site, widgetType, className, includeScript: true},
     dependencies,
   );
-  return adts.find((item) => [item.templateKey, item.adtName, item.displayName].includes(name)) ?? null;
+  return adts.find((item) => matchesAdtRow(item, name)) ?? null;
 }

--- a/src/features/liferay/resource/sync-strategies/adt-sync-strategy.ts
+++ b/src/features/liferay/resource/sync-strategies/adt-sync-strategy.ts
@@ -19,6 +19,7 @@ import {
   type ResourceSyncDependencies,
 } from '../liferay-resource-sync-shared.js';
 import {expectJsonSuccess} from '../../liferay-http-shared.js';
+import {matchesAdtRow} from '../../liferay-identifiers.js';
 import type {LocalArtifact, RemoteArtifact, SyncStrategy} from '../sync-engine.js';
 
 type AdtLocalData = {
@@ -95,7 +96,7 @@ export const adtSyncStrategy: SyncStrategy<AdtLocalData, AdtRemoteData> = {
 
     // Match by key (templateKey, adtName, or displayName)
     const existing = adts.find((item) => {
-      return [item.templateKey, item.adtName, item.displayName].includes(opts.key);
+      return matchesAdtRow(item, opts.key);
     });
 
     if (!existing) {

--- a/src/features/liferay/resource/sync-strategies/template-sync-strategy.ts
+++ b/src/features/liferay/resource/sync-strategies/template-sync-strategy.ts
@@ -23,6 +23,7 @@ import {
   type ResourceSyncDependencies,
 } from '../liferay-resource-sync-shared.js';
 import {expectJsonSuccess} from '../../liferay-http-shared.js';
+import {matchesInventoryTemplate} from '../../liferay-identifiers.js';
 import type {LocalArtifact, RemoteArtifact, SyncStrategy} from '../sync-engine.js';
 
 type TemplateLocalData = {
@@ -91,7 +92,7 @@ export const templateSyncStrategy: SyncStrategy<TemplateLocalData, TemplateRemot
     }
 
     const inventoryExisting = inventoryTemplates.find((item) => {
-      if (![item.id, item.externalReferenceCode, item.name].includes(opts.key)) {
+      if (!matchesInventoryTemplate(item, opts.key)) {
         return false;
       }
       if (structureIdFilter !== '' && String(item.contentStructureId) !== structureIdFilter) {

--- a/tests/unit/liferay-identifiers.test.ts
+++ b/tests/unit/liferay-identifiers.test.ts
@@ -1,0 +1,213 @@
+import {describe, expect, test} from 'vitest';
+
+import {CliError} from '../../src/core/errors.js';
+import {
+  matchesDdmTemplate,
+  matchesAdtRow,
+  matchesInventoryTemplate,
+  normalizeAdtIdentifier,
+  type AdtRowShape,
+  type InventoryTemplateShape,
+} from '../../src/features/liferay/liferay-identifiers.js';
+
+// ---------------------------------------------------------------------------
+// matchesDdmTemplate
+// ---------------------------------------------------------------------------
+
+describe('matchesDdmTemplate', () => {
+  const baseItem: Record<string, unknown> = {
+    templateId: '101',
+    templateKey: 'BASIC_TEMPLATE',
+    externalReferenceCode: 'ERC-001',
+    nameCurrentValue: 'Basic Template',
+    name: 'basic-template',
+  };
+
+  test('matches by templateId', () => {
+    expect(matchesDdmTemplate(baseItem, '101')).toBe(true);
+  });
+
+  test('matches by templateKey', () => {
+    expect(matchesDdmTemplate(baseItem, 'BASIC_TEMPLATE')).toBe(true);
+  });
+
+  test('matches by externalReferenceCode', () => {
+    expect(matchesDdmTemplate(baseItem, 'ERC-001')).toBe(true);
+  });
+
+  test('matches by nameCurrentValue', () => {
+    expect(matchesDdmTemplate(baseItem, 'Basic Template')).toBe(true);
+  });
+
+  test('matches by name', () => {
+    expect(matchesDdmTemplate(baseItem, 'basic-template')).toBe(true);
+  });
+
+  test('does not match an unrelated identifier', () => {
+    expect(matchesDdmTemplate(baseItem, 'UNKNOWN')).toBe(false);
+  });
+
+  test('does not match empty string when all fields are non-empty', () => {
+    expect(matchesDdmTemplate(baseItem, '')).toBe(false);
+  });
+
+  test('matches empty string when a field is empty (falsy coercion)', () => {
+    const itemWithEmptyKey = {...baseItem, templateKey: ''};
+    expect(matchesDdmTemplate(itemWithEmptyKey, '')).toBe(true);
+  });
+
+  test('handles numeric templateId coercion', () => {
+    const item = {...baseItem, templateId: 42};
+    expect(matchesDdmTemplate(item, '42')).toBe(true);
+  });
+
+  test('handles missing fields via ?? coercion', () => {
+    const sparseItem: Record<string, unknown> = {templateKey: 'SPARSE'};
+    expect(matchesDdmTemplate(sparseItem, 'SPARSE')).toBe(true);
+    expect(matchesDdmTemplate(sparseItem, 'UNKNOWN')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// matchesAdtRow
+// ---------------------------------------------------------------------------
+
+describe('matchesAdtRow', () => {
+  const baseRow: AdtRowShape = {
+    templateId: 202,
+    templateKey: 'FEATURED_ADT',
+    displayName: 'Featured Display',
+    adtName: 'featured-adt',
+  };
+
+  test('matches by templateId as string', () => {
+    expect(matchesAdtRow(baseRow, '202')).toBe(true);
+  });
+
+  test('matches by ddmTemplate_<templateId>', () => {
+    expect(matchesAdtRow(baseRow, 'ddmTemplate_202')).toBe(true);
+  });
+
+  test('matches by templateKey', () => {
+    expect(matchesAdtRow(baseRow, 'FEATURED_ADT')).toBe(true);
+  });
+
+  test('matches by displayName', () => {
+    expect(matchesAdtRow(baseRow, 'Featured Display')).toBe(true);
+  });
+
+  test('matches by adtName', () => {
+    expect(matchesAdtRow(baseRow, 'featured-adt')).toBe(true);
+  });
+
+  test('does not match unrelated identifier', () => {
+    expect(matchesAdtRow(baseRow, 'UNKNOWN')).toBe(false);
+  });
+
+  test('does not match partial templateId without prefix', () => {
+    // "20" should not match when templateId is 202
+    expect(matchesAdtRow(baseRow, '20')).toBe(false);
+  });
+
+  test('handles string templateId correctly', () => {
+    const rowWithStringId: AdtRowShape = {...baseRow, templateId: '303'};
+    expect(matchesAdtRow(rowWithStringId, '303')).toBe(true);
+    expect(matchesAdtRow(rowWithStringId, 'ddmTemplate_303')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// matchesInventoryTemplate
+// ---------------------------------------------------------------------------
+
+describe('matchesInventoryTemplate', () => {
+  const baseItem: InventoryTemplateShape = {
+    id: 'inv-id-1',
+    externalReferenceCode: 'ERC-INV-001',
+    name: 'Inventory Template',
+  };
+
+  test('matches by id', () => {
+    expect(matchesInventoryTemplate(baseItem, 'inv-id-1')).toBe(true);
+  });
+
+  test('matches by externalReferenceCode', () => {
+    expect(matchesInventoryTemplate(baseItem, 'ERC-INV-001')).toBe(true);
+  });
+
+  test('matches by name', () => {
+    expect(matchesInventoryTemplate(baseItem, 'Inventory Template')).toBe(true);
+  });
+
+  test('does not match unrelated identifier', () => {
+    expect(matchesInventoryTemplate(baseItem, 'UNKNOWN')).toBe(false);
+  });
+
+  test('works when optional fields are absent', () => {
+    const minimalItem: InventoryTemplateShape = {id: 'only-id'};
+    expect(matchesInventoryTemplate(minimalItem, 'only-id')).toBe(true);
+    expect(matchesInventoryTemplate(minimalItem, 'ERC-INV-001')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeAdtIdentifier
+// ---------------------------------------------------------------------------
+
+describe('normalizeAdtIdentifier', () => {
+  test('returns trimmed id when provided', () => {
+    expect(normalizeAdtIdentifier({id: '  101  ', displayStyle: 'ddmTemplate_202', key: 'KEY', name: 'Name'})).toBe(
+      '101',
+    );
+  });
+
+  test('strips ddmTemplate_ prefix from displayStyle', () => {
+    expect(normalizeAdtIdentifier({displayStyle: 'ddmTemplate_202', key: 'KEY', name: 'Name'})).toBe('202');
+  });
+
+  test('returns displayStyle as-is when no ddmTemplate_ prefix', () => {
+    expect(normalizeAdtIdentifier({displayStyle: 'plain-style', key: 'KEY', name: 'Name'})).toBe('plain-style');
+  });
+
+  test('trims whitespace from displayStyle before prefix check', () => {
+    expect(normalizeAdtIdentifier({displayStyle: '  ddmTemplate_303  '})).toBe('303');
+    expect(normalizeAdtIdentifier({displayStyle: 'ddmTemplate_303'})).toBe('303');
+  });
+
+  test('falls back to key when id and displayStyle are absent', () => {
+    expect(normalizeAdtIdentifier({key: 'MY_KEY', name: 'Name'})).toBe('MY_KEY');
+  });
+
+  test('falls back to name when only name is provided', () => {
+    expect(normalizeAdtIdentifier({name: 'My Name'})).toBe('My Name');
+  });
+
+  test('trims key and name', () => {
+    expect(normalizeAdtIdentifier({key: '  PADDED  '})).toBe('PADDED');
+    expect(normalizeAdtIdentifier({name: '  Name  '})).toBe('Name');
+  });
+
+  test('throws CliError when no field is provided', () => {
+    expect(() => normalizeAdtIdentifier({})).toThrow(CliError);
+  });
+
+  test('throws CliError when all fields are empty strings', () => {
+    expect(() => normalizeAdtIdentifier({id: '', displayStyle: '', key: '', name: ''})).toThrow(CliError);
+  });
+
+  test('throws CliError when all fields are whitespace only', () => {
+    expect(() => normalizeAdtIdentifier({id: '   ', displayStyle: '   ', key: '   ', name: '   '})).toThrow(CliError);
+  });
+
+  test('id has higher precedence than displayStyle', () => {
+    expect(normalizeAdtIdentifier({id: 'from-id', displayStyle: 'ddmTemplate_999'})).toBe('from-id');
+  });
+
+  test('displayStyle has higher precedence than key', () => {
+    expect(normalizeAdtIdentifier({displayStyle: 'from-display', key: 'from-key'})).toBe('from-display');
+  });
+
+  test('key has higher precedence than name', () => {
+    expect(normalizeAdtIdentifier({key: 'from-key', name: 'from-name'})).toBe('from-key');
+  });
+});


### PR DESCRIPTION
Summary:
- Adds src/features/liferay/liferay-identifiers.ts: a single-source-of-truth matcher for templates, ADTs and inventory items (id, key, name, externalReferenceCode) and an ADT input normalizer.
- Replaces duplicated matching logic across six consumer files and removes private helper duplication.
- Adds unit tests at tests/unit/liferay-identifiers.test.ts (36 tests).

Local verification performed:
- npm run typecheck  OK
- npm run lint  warnings preexist but no new errors
- npm run test:unit  OK (673/673)

Notes:
- No public APIs were changed; adoption is limited to internal consumers.
- Ready for review and merge if everything looks good.