### PR TITLE
refactor(resource): move postFormCandidates to shared and reuse in fragments/template (R7)

### DIFF
--- a/src/features/liferay/resource/liferay-resource-sync-fragments.ts
+++ b/src/features/liferay/resource/liferay-resource-sync-fragments.ts
@@ -5,11 +5,14 @@ import path from 'node:path';
 
 import {CliError} from '../../../core/errors.js';
 import type {AppConfig} from '../../../core/config/load-config.js';
-import {ensureData} from '../liferay-http-shared.js';
 import {runLiferayInventorySitesIncludingGlobal} from '../inventory/liferay-inventory-sites.js';
 import {resolveFragmentsBaseDir, resolveRepoPath, resolveSiteToken} from './liferay-resource-paths.js';
 import {listFragmentCollections, listFragments, resolveResourceSite} from './liferay-resource-shared.js';
-import {authedPostForm, authedPostMultipart, type ResourceSyncDependencies} from './liferay-resource-sync-shared.js';
+import {
+  authedPostMultipart,
+  postFormCandidates,
+  type ResourceSyncDependencies,
+} from './liferay-resource-sync-shared.js';
 
 type LocalFragment = {
   slug: string;
@@ -724,28 +727,6 @@ function fragmentEntryBaseForm(
     icon: fragment.icon,
     type: String(fragment.type),
   };
-}
-
-async function postFormCandidates<T>(
-  config: AppConfig,
-  apiPath: string,
-  candidates: Record<string, string>[],
-  operation: string,
-  dependencies?: ResourceSyncDependencies,
-): Promise<T> {
-  const errors: string[] = [];
-
-  for (const form of candidates) {
-    const response = await authedPostForm<T>(config, apiPath, form, dependencies);
-    if (response.ok) {
-      return ensureData(response.data, `${operation} invalid JSON in ${apiPath}`, 'LIFERAY_RESOURCE_ERROR');
-    }
-    errors.push(`status=${response.status} body=${response.body}`);
-  }
-
-  throw new CliError(`${operation} fallo en ${apiPath} (${errors.join(' | ')})`, {
-    code: 'LIFERAY_RESOURCE_ERROR',
-  });
 }
 
 function resolveFragmentsProjectDir(config: AppConfig, dir: string | undefined, siteToken: string): string {

--- a/src/features/liferay/resource/liferay-resource-sync-shared.ts
+++ b/src/features/liferay/resource/liferay-resource-sync-shared.ts
@@ -5,7 +5,7 @@ import type {AppConfig} from '../../../core/config/load-config.js';
 import type {OAuthTokenClient} from '../../../core/http/auth.js';
 import type {LiferayApiClient} from '../../../core/http/client.js';
 import {createLiferayApiClient, type HttpResponse} from '../../../core/http/client.js';
-import {buildAuthOptions, expectJsonSuccess} from '../liferay-http-shared.js';
+import {buildAuthOptions, ensureData, expectJsonSuccess} from '../liferay-http-shared.js';
 import {fetchAccessToken} from '../inventory/liferay-inventory-shared.js';
 
 type ResourceDependencies = {
@@ -32,6 +32,28 @@ export async function authedPostForm<T>(
   const accessToken = await fetchAccessToken(config, dependencies);
 
   return apiClient.postForm<T>(config.liferay.url, path, form, buildAuthOptions(config, accessToken));
+}
+
+export async function postFormCandidates<T>(
+  config: AppConfig,
+  apiPath: string,
+  candidates: Record<string, string>[],
+  operation: string,
+  dependencies?: ResourceDependencies,
+): Promise<T> {
+  const errors: string[] = [];
+
+  for (const form of candidates) {
+    const response = await authedPostForm<T>(config, apiPath, form, dependencies);
+    if (response.ok) {
+      return ensureData(response.data, `${operation} invalid JSON in ${apiPath}`, 'LIFERAY_RESOURCE_ERROR');
+    }
+    errors.push(`status=${response.status} body=${response.body}`);
+  }
+
+  throw new CliError(`${operation} failed on ${apiPath} (${errors.join(' | ')})`, {
+    code: 'LIFERAY_RESOURCE_ERROR',
+  });
 }
 
 export async function authedPostMultipart<T>(

--- a/src/features/liferay/resource/sync-strategies/template-sync-strategy.ts
+++ b/src/features/liferay/resource/sync-strategies/template-sync-strategy.ts
@@ -16,13 +16,12 @@ import {fetchStructureTemplateClassIds} from '../liferay-resource-shared.js';
 import {normalizeLiferayTemplateScript} from '../liferay-resource-template-normalize.js';
 import {
   authedGetJson,
-  authedPostForm,
   ensureString,
   localizedMap,
   sha256,
   type ResourceSyncDependencies,
+  postFormCandidates,
 } from '../liferay-resource-sync-shared.js';
-import {expectJsonSuccess} from '../../liferay-http-shared.js';
 import {matchesInventoryTemplate} from '../../liferay-identifiers.js';
 import type {LocalArtifact, RemoteArtifact, SyncStrategy} from '../sync-engine.js';
 
@@ -169,27 +168,29 @@ export const templateSyncStrategy: SyncStrategy<TemplateLocalData, TemplateRemot
       const {classNameId, resourceClassNameId} = await fetchStructureTemplateClassIds(config, dependencies);
       const structure = await fetchStructureByKey(config, site.id, opts.structureKey, dependencies);
 
-      const created = await authedPostForm<Record<string, unknown>>(
+      const created = await postFormCandidates<Record<string, unknown>>(
         config,
         '/api/jsonws/ddm.ddmtemplate/add-template',
-        {
-          externalReferenceCode: opts.key,
-          groupId: String(site.id),
-          classNameId: String(classNameId),
-          classPK: String(structure.id ?? ''),
-          resourceClassNameId: String(resourceClassNameId),
-          nameMap: localizedMap(opts.key),
-          descriptionMap: localizedMap(''),
-          type: 'display',
-          mode: '',
-          language: 'ftl',
-          script: localArtifact.normalizedContent,
-        },
+        [
+          {
+            externalReferenceCode: opts.key,
+            groupId: String(site.id),
+            classNameId: String(classNameId),
+            classPK: String(structure.id ?? ''),
+            resourceClassNameId: String(resourceClassNameId),
+            nameMap: localizedMap(opts.key),
+            descriptionMap: localizedMap(''),
+            type: 'display',
+            mode: '',
+            language: 'ftl',
+            script: localArtifact.normalizedContent,
+          },
+        ],
+        'template-create',
         dependencies,
       );
 
-      const success = await expectJsonSuccess(created, 'template-create', 'LIFERAY_RESOURCE_ERROR');
-      const createdId = String(success.data?.templateKey ?? success.data?.templateId ?? '');
+      const createdId = String(created.templateKey ?? created.templateId ?? '');
 
       return {
         id: createdId,
@@ -205,10 +206,10 @@ export const templateSyncStrategy: SyncStrategy<TemplateLocalData, TemplateRemot
     const templateId = ensureString(remoteArtifact.data.templateId, 'templateId');
     const classPk = String(remoteArtifact.data.classPK ?? '0');
 
-    await expectJsonSuccess(
-      await authedPostForm(
-        config,
-        '/api/jsonws/ddm.ddmtemplate/update-template',
+    await postFormCandidates(
+      config,
+      '/api/jsonws/ddm.ddmtemplate/update-template',
+      [
         {
           templateId,
           classPK: classPk,
@@ -220,10 +221,9 @@ export const templateSyncStrategy: SyncStrategy<TemplateLocalData, TemplateRemot
           script: localArtifact.normalizedContent,
           cacheable: 'false',
         },
-        dependencies,
-      ),
+      ],
       'template-update',
-      'LIFERAY_RESOURCE_ERROR',
+      dependencies,
     );
 
     return remoteArtifact;

--- a/tests/unit/liferay-resource-sync-fragments.test.ts
+++ b/tests/unit/liferay-resource-sync-fragments.test.ts
@@ -252,6 +252,66 @@ describe('liferay resource fragments-sync', () => {
     expect(result.fragmentResults[0]?.fragment).toBe('hero-banner');
   });
 
+  test('retries candidates in order when first form fails and second succeeds', async () => {
+    const {config, repoRoot} = await createRepoFixture();
+    const projectDir = path.join(repoRoot, 'custom-fragments');
+    await writeFragmentProject(projectDir, {collection: 'ub-base', collectionName: 'UB Base'});
+
+    let addCollectionCalls = 0;
+
+    const apiClient = createLiferayApiClient({
+      fetchImpl: async (input, init) => {
+        const url = String(input);
+
+        if (url.includes('/by-friendly-url-path/global')) {
+          return new Response('{"id":20121,"friendlyUrlPath":"/global","name":"Global"}', {status: 200});
+        }
+        if (url.includes('/api/jsonws/group/get-group?groupId=20121')) {
+          return new Response('{"companyId":10157}', {status: 200});
+        }
+        if (url.includes('/api/jsonws/fragment.fragmentcollection/get-fragment-collections?groupId=20121')) {
+          return new Response('[]', {status: 200});
+        }
+        if (url.includes('/api/jsonws/fragment.fragmentcollection/add-fragment-collection')) {
+          addCollectionCalls += 1;
+          const form = new URLSearchParams(String(init?.body ?? ''));
+
+          // First candidate includes serviceContext and fails; second candidate omits it and succeeds.
+          if (addCollectionCalls === 1) {
+            expect(form.get('serviceContext')).toBe('{}');
+            return new Response('{"message":"legacy endpoint rejects serviceContext"}', {status: 500});
+          }
+
+          expect(addCollectionCalls).toBe(2);
+          expect(form.get('serviceContext')).toBeNull();
+          return new Response('{"fragmentCollectionId":1100,"fragmentCollectionKey":"ub-base"}', {status: 200});
+        }
+        if (url.includes('/api/jsonws/fragment.fragmententry/get-fragment-entries?fragmentCollectionId=1100')) {
+          return new Response('[]', {status: 200});
+        }
+        if (url.includes('/api/jsonws/fragment.fragmententry/add-fragment-entry')) {
+          return new Response('{"fragmentEntryId":3002}', {status: 200});
+        }
+
+        throw new Error(`Unexpected URL ${url}`);
+      },
+    });
+
+    const result = await runLiferayResourceSyncFragments(
+      config,
+      {site: '/global', dir: 'custom-fragments', fragment: 'ub-base/fragments/hero-banner'},
+      {apiClient, tokenClient: TOKEN_CLIENT},
+    );
+
+    expect(result.mode).toBe('oauth-jsonws-import');
+    if (result.mode !== 'oauth-jsonws-import') {
+      throw new Error('unexpected mode');
+    }
+    expect(addCollectionCalls).toBe(2);
+    expect(result.summary.importedFragments).toBe(1);
+    expect(result.summary.errors).toBe(0);
+  });
+
   test('supports all-sites and skips site projects without src', async () => {
     const {config, repoRoot} = await createRepoFixture();
     await writeFragmentProject(path.join(repoRoot, 'liferay', 'fragments', 'sites', 'global'));


### PR DESCRIPTION
Summary:
- Moves `postFormCandidates` into `liferay-resource-sync-shared.ts` as a shared helper.
- Reuses the helper in `liferay-resource-sync-fragments.ts` (removing the local duplicate implementation).
- Reuses the same helper in an additional flow: `sync-strategies/template-sync-strategy.ts`.
- Adds/updates fragments tests to verify candidate-order fallback: first candidate fails, second succeeds.

Scope & behavior:
- Candidate order is preserved.
- Error accumulation is preserved (status/body chain across candidates).
- No public API changes.

Verification:
- `npm run test:unit -- tests/unit/liferay-resource-sync-fragments.test.ts` 