### PR TITLE
refactor(resource): R9 typed payloads with tolerant legacy parsing

### DIFF
--- a/src/features/liferay/liferay-identifiers.ts
+++ b/src/features/liferay/liferay-identifiers.ts
@@ -12,6 +12,7 @@
  */
 
 import {CliError} from '../../core/errors.js';
+import type {DdmTemplatePayload} from '../liferay/resource/liferay-resource-payloads.js';
 
 // ---------------------------------------------------------------------------
 // DDM Template matching
@@ -21,7 +22,7 @@ import {CliError} from '../../core/errors.js';
  * Matches a DDM template item (from JSONWS `listDdmTemplates`) against an identifier.
  * Fields checked: templateId, templateKey, externalReferenceCode, nameCurrentValue, name.
  */
-export function matchesDdmTemplate(item: Record<string, unknown>, identifier: string): boolean {
+export function matchesDdmTemplate(item: DdmTemplatePayload, identifier: string): boolean {
   return (
     identifier === String(item.templateId ?? '') ||
     identifier === String(item.templateKey ?? '') ||

--- a/src/features/liferay/resource/liferay-resource-get-structure.ts
+++ b/src/features/liferay/resource/liferay-resource-get-structure.ts
@@ -5,6 +5,7 @@ import type {LiferayApiClient} from '../../../core/http/client.js';
 import {createLiferayApiClient} from '../../../core/http/client.js';
 import {authedGet, fetchAccessToken, normalizeLocalizedName} from '../inventory/liferay-inventory-shared.js';
 import {buildResourceSiteChain, resolveResourceSite} from './liferay-resource-shared.js';
+import type {DataDefinitionPayload} from './liferay-resource-payloads.js';
 
 type ResourceDependencies = {
   apiClient?: LiferayApiClient;
@@ -18,7 +19,7 @@ export type LiferayResourceStructureResult = {
   key: string;
   id: number;
   name: string;
-  raw: Record<string, unknown>;
+  raw: DataDefinitionPayload;
 };
 
 export async function runLiferayResourceGetStructure(
@@ -36,11 +37,11 @@ export async function runLiferayResourceGetStructure(
     });
   }
 
-  let payload: Record<string, unknown> | null = null;
+  let payload: DataDefinitionPayload | null = null;
   let lastKeyLookupStatus: number | null = null;
 
   if (options.id || /^\d+$/.test(identifier)) {
-    const byIdResponse = await authedGet<Record<string, unknown>>(
+    const byIdResponse = await authedGet<DataDefinitionPayload>(
       config,
       apiClient,
       accessToken,
@@ -57,7 +58,7 @@ export async function runLiferayResourceGetStructure(
     const siteChain = await buildResourceSiteChain(config, options.site ?? '/global', dependencies);
 
     for (const candidate of siteChain) {
-      const response = await authedGet<Record<string, unknown>>(
+      const response = await authedGet<DataDefinitionPayload>(
         config,
         apiClient,
         accessToken,

--- a/src/features/liferay/resource/liferay-resource-get-template.ts
+++ b/src/features/liferay/resource/liferay-resource-get-template.ts
@@ -5,6 +5,7 @@ import type {LiferayApiClient} from '../../../core/http/client.js';
 import {runLiferayInventoryTemplates} from '../inventory/liferay-inventory-templates.js';
 import {buildResourceSiteChain, resolveResourceSite, listDdmTemplates} from './liferay-resource-shared.js';
 import {matchesDdmTemplate, matchesInventoryTemplate} from '../liferay-identifiers.js';
+import type {DdmTemplatePayload} from './liferay-resource-payloads.js';
 
 type ResourceDependencies = {
   apiClient?: LiferayApiClient;
@@ -32,7 +33,7 @@ export async function runLiferayResourceGetTemplate(
 ): Promise<LiferayResourceTemplateResult> {
   const siteChain = await buildResourceSiteChain(config, options.site ?? '/global', dependencies);
   let site = await resolveResourceSite(config, options.site ?? '/global', dependencies);
-  let match: Record<string, unknown> | undefined;
+  let match: DdmTemplatePayload | undefined;
 
   for (const candidate of siteChain) {
     const candidateSite = await resolveResourceSite(config, candidate.siteFriendlyUrl, dependencies);

--- a/src/features/liferay/resource/liferay-resource-payloads.ts
+++ b/src/features/liferay/resource/liferay-resource-payloads.ts
@@ -66,6 +66,7 @@ function asStr(v: unknown): string | undefined {
 
 function asNum(v: unknown): number | undefined {
   if (v == null) return undefined;
+  if (typeof v === 'string' && v.trim() === '') return undefined;
   const n = Number(v);
   return Number.isFinite(n) ? n : undefined;
 }

--- a/src/features/liferay/resource/liferay-resource-payloads.ts
+++ b/src/features/liferay/resource/liferay-resource-payloads.ts
@@ -1,0 +1,131 @@
+/**
+ * Minimal typed payloads for Liferay JSONWS and headless resource API responses.
+ *
+ * All fields are optional to accommodate legacy or partial responses.
+ * Use the normalizer functions (to*) to safely extract values from raw API data.
+ */
+
+// ---------------------------------------------------------------------------
+// Payload types
+// ---------------------------------------------------------------------------
+
+/** Payload from JSONWS ddm.ddmtemplate/get-templates or get-template. */
+export type DdmTemplatePayload = {
+  templateId?: string | number;
+  templateKey?: string;
+  externalReferenceCode?: string;
+  nameCurrentValue?: string;
+  name?: string;
+  classPK?: string | number;
+  classNameId?: number;
+  script?: string;
+  language?: string;
+  type?: string;
+  mode?: string;
+};
+
+/** Payload from JSONWS fragment.fragmentcollection/get-fragment-collections. */
+export type FragmentCollectionPayload = {
+  fragmentCollectionId?: number;
+  fragmentCollectionKey?: string;
+  name?: string;
+  description?: string;
+};
+
+/** Payload from JSONWS fragment.fragmententry/get-fragment-entries. */
+export type FragmentEntryPayload = {
+  fragmentEntryId?: number;
+  fragmentEntryKey?: string;
+  name?: string;
+  html?: string;
+  css?: string;
+  js?: string;
+  configuration?: string;
+  icon?: string;
+  type?: number;
+};
+
+/** Payload from headless data-engine /data-definitions. */
+export type DataDefinitionPayload = {
+  id?: string | number;
+  dataDefinitionKey?: string;
+  name?: string | Record<string, string>;
+  description?: string | Record<string, string>;
+  dataDefinitionFields?: unknown[];
+};
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function asStr(v: unknown): string | undefined {
+  if (v == null) return undefined;
+  const s = String(v).trim();
+  return s === '' ? undefined : s;
+}
+
+function asNum(v: unknown): number | undefined {
+  if (v == null) return undefined;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Tolerant normalizers
+// ---------------------------------------------------------------------------
+
+/**
+ * Tolerant parse of a raw JSONWS DDM template object.
+ * Returns a typed object with undefined for any missing or non-coercible fields.
+ */
+export function toDdmTemplatePayload(raw: unknown): DdmTemplatePayload {
+  if (!raw || typeof raw !== 'object') return {};
+  const r = raw as Record<string, unknown>;
+  return {
+    templateId: asStr(r.templateId),
+    templateKey: asStr(r.templateKey),
+    externalReferenceCode: asStr(r.externalReferenceCode),
+    nameCurrentValue: asStr(r.nameCurrentValue),
+    name: asStr(r.name),
+    classPK: asStr(r.classPK),
+    classNameId: asNum(r.classNameId),
+    script: r.script != null ? String(r.script) : undefined,
+    language: asStr(r.language),
+    type: asStr(r.type),
+    mode: asStr(r.mode),
+  };
+}
+
+/**
+ * Tolerant parse of a raw JSONWS fragment collection object.
+ */
+export function toFragmentCollectionPayload(raw: unknown): FragmentCollectionPayload {
+  if (!raw || typeof raw !== 'object') return {};
+  const r = raw as Record<string, unknown>;
+  return {
+    fragmentCollectionId: asNum(r.fragmentCollectionId),
+    fragmentCollectionKey: asStr(r.fragmentCollectionKey),
+    name: asStr(r.name),
+    description: r.description != null ? String(r.description) : undefined,
+  };
+}
+
+/**
+ * Tolerant parse of a raw JSONWS fragment entry object.
+ * html/css/js preserve empty strings (valid empty content).
+ */
+export function toFragmentEntryPayload(raw: unknown): FragmentEntryPayload {
+  if (!raw || typeof raw !== 'object') return {};
+  const r = raw as Record<string, unknown>;
+  return {
+    fragmentEntryId: asNum(r.fragmentEntryId),
+    fragmentEntryKey: asStr(r.fragmentEntryKey),
+    name: asStr(r.name),
+    html: r.html != null ? String(r.html) : undefined,
+    css: r.css != null ? String(r.css) : undefined,
+    js: r.js != null ? String(r.js) : undefined,
+    configuration: r.configuration != null ? String(r.configuration) : undefined,
+    icon: asStr(r.icon),
+    type: asNum(r.type),
+  };
+}

--- a/src/features/liferay/resource/liferay-resource-shared.ts
+++ b/src/features/liferay/resource/liferay-resource-shared.ts
@@ -10,6 +10,14 @@ import {
   resolveSite,
   type ResolvedSite,
 } from '../inventory/liferay-inventory-shared.js';
+import {
+  toDdmTemplatePayload,
+  toFragmentCollectionPayload,
+  toFragmentEntryPayload,
+  type DdmTemplatePayload,
+  type FragmentCollectionPayload,
+  type FragmentEntryPayload,
+} from './liferay-resource-payloads.js';
 
 const DDM_STRUCTURE_CLASS_NAME = 'com.liferay.dynamic.data.mapping.model.DDMStructure';
 const JOURNAL_ARTICLE_CLASS_NAME = 'com.liferay.journal.model.JournalArticle';
@@ -90,7 +98,7 @@ export async function listDdmTemplates(
   site: ResolvedResourceSite,
   dependencies?: ResourceDependencies,
   options?: {includeCompanyFallback?: boolean},
-): Promise<Record<string, unknown>[]> {
+): Promise<DdmTemplatePayload[]> {
   const apiClient = dependencies?.apiClient ?? createLiferayApiClient();
   const accessToken = await fetchAccessToken(config, dependencies);
   const {classNameId, resourceClassNameId} = await fetchStructureTemplateClassIds(config, dependencies);
@@ -122,7 +130,7 @@ export async function listDdmTemplatesByClassName(
   className: string,
   resourceClassNameId: number,
   dependencies?: ResourceDependencies,
-): Promise<Record<string, unknown>[]> {
+): Promise<DdmTemplatePayload[]> {
   const apiClient = dependencies?.apiClient ?? createLiferayApiClient();
   const accessToken = await fetchAccessToken(config, dependencies);
   const classNameId = await fetchClassNameId(config, apiClient, accessToken, className);
@@ -134,34 +142,34 @@ export async function listFragmentCollections(
   config: AppConfig,
   siteId: number,
   dependencies?: ResourceDependencies,
-): Promise<Record<string, unknown>[]> {
+): Promise<FragmentCollectionPayload[]> {
   const apiClient = dependencies?.apiClient ?? createLiferayApiClient();
   const accessToken = await fetchAccessToken(config, dependencies);
-  const response = await authedGet<Record<string, unknown>[]>(
+  const response = await authedGet<unknown[]>(
     config,
     apiClient,
     accessToken,
     `/api/jsonws/fragment.fragmentcollection/get-fragment-collections?groupId=${siteId}`,
   );
   const success = await expectJsonSuccess(response, 'fragment collections');
-  return Array.isArray(success.data) ? success.data : [];
+  return Array.isArray(success.data) ? success.data.map(toFragmentCollectionPayload) : [];
 }
 
 export async function listFragments(
   config: AppConfig,
   collectionId: number,
   dependencies?: ResourceDependencies,
-): Promise<Record<string, unknown>[]> {
+): Promise<FragmentEntryPayload[]> {
   const apiClient = dependencies?.apiClient ?? createLiferayApiClient();
   const accessToken = await fetchAccessToken(config, dependencies);
-  const response = await authedGet<Record<string, unknown>[]>(
+  const response = await authedGet<unknown[]>(
     config,
     apiClient,
     accessToken,
     `/api/jsonws/fragment.fragmententry/get-fragment-entries?fragmentCollectionId=${collectionId}`,
   );
   const success = await expectJsonSuccess(response, 'fragments');
-  return Array.isArray(success.data) ? success.data : [];
+  return Array.isArray(success.data) ? success.data.map(toFragmentEntryPayload) : [];
 }
 
 async function fetchClassNameId(
@@ -314,9 +322,9 @@ async function fetchDdmTemplates(
   groupId: number | null,
   classNameId: number,
   resourceClassNameId: number,
-): Promise<Record<string, unknown>[]> {
+): Promise<DdmTemplatePayload[]> {
   const groupQuery = groupId === null ? '0' : String(groupId);
-  const response = await authedGet<Record<string, unknown>[]>(
+  const response = await authedGet<unknown[]>(
     config,
     apiClient,
     accessToken,
@@ -327,5 +335,5 @@ async function fetchDdmTemplates(
     return [];
   }
 
-  return Array.isArray(response.data) ? response.data : [];
+  return Array.isArray(response.data) ? response.data.map(toDdmTemplatePayload) : [];
 }

--- a/src/features/liferay/resource/liferay-resource-sync-fragments-api.ts
+++ b/src/features/liferay/resource/liferay-resource-sync-fragments-api.ts
@@ -4,7 +4,12 @@ import {listFragmentCollections, listFragments} from './liferay-resource-shared.
 import {postFormCandidates, type ResourceSyncDependencies} from './liferay-resource-sync-shared.js';
 import type {LocalFragment, LocalFragmentCollection} from './liferay-resource-sync-fragments-types.js';
 import {sanitizeFileToken} from './liferay-resource-sync-fragments-local.js';
-import type {FragmentCollectionPayload, FragmentEntryPayload} from './liferay-resource-payloads.js';
+import {
+  toFragmentCollectionPayload,
+  toFragmentEntryPayload,
+  type FragmentCollectionPayload,
+  type FragmentEntryPayload,
+} from './liferay-resource-payloads.js';
 
 export async function listRuntimeCollectionsByKey(
   config: AppConfig,
@@ -62,7 +67,7 @@ export async function createFragmentCollection(
     description: collection.description,
   };
 
-  return postFormCandidates<FragmentCollectionPayload>(
+  const response = await postFormCandidates<FragmentCollectionPayload>(
     config,
     '/api/jsonws/fragment.fragmentcollection/add-fragment-collection',
     [
@@ -83,6 +88,8 @@ export async function createFragmentCollection(
     'fragment-collection-create',
     dependencies,
   );
+
+  return toFragmentCollectionPayload(response);
 }
 
 export async function updateFragmentCollection(
@@ -129,7 +136,7 @@ export async function createFragmentEntry(
 ): Promise<FragmentEntryPayload> {
   const base = fragmentEntryBaseForm(groupId, fragmentCollectionId, fragment);
 
-  return postFormCandidates<FragmentEntryPayload>(
+  const response = await postFormCandidates<FragmentEntryPayload>(
     config,
     '/api/jsonws/fragment.fragmententry/add-fragment-entry',
     [
@@ -145,6 +152,8 @@ export async function createFragmentEntry(
     'fragment-entry-create',
     dependencies,
   );
+
+  return toFragmentEntryPayload(response);
 }
 
 export async function updateFragmentEntry(
@@ -175,7 +184,7 @@ export async function updateFragmentEntry(
     type: String(fragment.type),
   };
 
-  return postFormCandidates<FragmentEntryPayload>(
+  const response = await postFormCandidates<FragmentEntryPayload>(
     config,
     '/api/jsonws/fragment.fragmententry/update-fragment-entry',
     [
@@ -190,6 +199,8 @@ export async function updateFragmentEntry(
     'fragment-entry-update',
     dependencies,
   );
+
+  return toFragmentEntryPayload(response);
 }
 
 function fragmentEntryBaseForm(

--- a/src/features/liferay/resource/liferay-resource-sync-fragments-api.ts
+++ b/src/features/liferay/resource/liferay-resource-sync-fragments-api.ts
@@ -4,14 +4,15 @@ import {listFragmentCollections, listFragments} from './liferay-resource-shared.
 import {postFormCandidates, type ResourceSyncDependencies} from './liferay-resource-sync-shared.js';
 import type {LocalFragment, LocalFragmentCollection} from './liferay-resource-sync-fragments-types.js';
 import {sanitizeFileToken} from './liferay-resource-sync-fragments-local.js';
+import type {FragmentCollectionPayload, FragmentEntryPayload} from './liferay-resource-payloads.js';
 
 export async function listRuntimeCollectionsByKey(
   config: AppConfig,
   groupId: number,
   dependencies?: ResourceSyncDependencies,
-): Promise<Map<string, Record<string, unknown>>> {
+): Promise<Map<string, FragmentCollectionPayload>> {
   const collections = await listFragmentCollections(config, groupId, dependencies);
-  const byKey = new Map<string, Record<string, unknown>>();
+  const byKey = new Map<string, FragmentCollectionPayload>();
 
   for (const collection of collections) {
     const key = String(collection.fragmentCollectionKey ?? '').trim();
@@ -31,9 +32,9 @@ export async function listRuntimeFragmentsByKey(
   config: AppConfig,
   fragmentCollectionId: number,
   dependencies?: ResourceSyncDependencies,
-): Promise<Map<string, Record<string, unknown>>> {
+): Promise<Map<string, FragmentEntryPayload>> {
   const runtimeFragments = await listFragments(config, fragmentCollectionId, dependencies);
-  const byKey = new Map<string, Record<string, unknown>>();
+  const byKey = new Map<string, FragmentEntryPayload>();
 
   for (const runtimeFragment of runtimeFragments) {
     const runtimeKey = String(runtimeFragment.fragmentEntryKey ?? '').trim();
@@ -54,14 +55,14 @@ export async function createFragmentCollection(
   groupId: number,
   collection: LocalFragmentCollection,
   dependencies?: ResourceSyncDependencies,
-): Promise<Record<string, unknown>> {
+): Promise<FragmentCollectionPayload> {
   const base = {
     groupId: String(groupId),
     name: collection.name,
     description: collection.description,
   };
 
-  return postFormCandidates<Record<string, unknown>>(
+  return postFormCandidates<FragmentCollectionPayload>(
     config,
     '/api/jsonws/fragment.fragmentcollection/add-fragment-collection',
     [
@@ -101,7 +102,7 @@ export async function updateFragmentCollection(
   };
 
   try {
-    await postFormCandidates<Record<string, unknown>>(
+    await postFormCandidates<FragmentCollectionPayload>(
       config,
       '/api/jsonws/fragment.fragmentcollection/update-fragment-collection',
       [
@@ -125,10 +126,10 @@ export async function createFragmentEntry(
   fragmentCollectionId: number,
   fragment: LocalFragment,
   dependencies?: ResourceSyncDependencies,
-): Promise<Record<string, unknown>> {
+): Promise<FragmentEntryPayload> {
   const base = fragmentEntryBaseForm(groupId, fragmentCollectionId, fragment);
 
-  return postFormCandidates<Record<string, unknown>>(
+  return postFormCandidates<FragmentEntryPayload>(
     config,
     '/api/jsonws/fragment.fragmententry/add-fragment-entry',
     [
@@ -153,7 +154,7 @@ export async function updateFragmentEntry(
   fragmentEntryId: number,
   fragment: LocalFragment,
   dependencies?: ResourceSyncDependencies,
-): Promise<Record<string, unknown>> {
+): Promise<FragmentEntryPayload> {
   if (fragmentEntryId <= 0) {
     throw new CliError(`fragmentEntryId invalido para ${fragment.slug}`, {
       code: 'LIFERAY_RESOURCE_ERROR',
@@ -174,7 +175,7 @@ export async function updateFragmentEntry(
     type: String(fragment.type),
   };
 
-  return postFormCandidates<Record<string, unknown>>(
+  return postFormCandidates<FragmentEntryPayload>(
     config,
     '/api/jsonws/fragment.fragmententry/update-fragment-entry',
     [

--- a/tests/unit/liferay-resource-payloads.test.ts
+++ b/tests/unit/liferay-resource-payloads.test.ts
@@ -1,0 +1,200 @@
+import {describe, expect, test} from 'vitest';
+
+import {
+  toDdmTemplatePayload,
+  toFragmentCollectionPayload,
+  toFragmentEntryPayload,
+} from '../../src/features/liferay/resource/liferay-resource-payloads.js';
+
+// ---------------------------------------------------------------------------
+// toDdmTemplatePayload
+// ---------------------------------------------------------------------------
+
+describe('toDdmTemplatePayload', () => {
+  test('full payload', () => {
+    const raw = {
+      templateId: '40801',
+      templateKey: 'NEWS_TEMPLATE',
+      externalReferenceCode: 'erc-news',
+      nameCurrentValue: 'News Template',
+      name: 'News',
+      classPK: '301',
+      classNameId: 1001,
+      script: '<#-- ftl -->',
+      language: 'ftl',
+      type: 'display',
+      mode: '',
+    };
+    const result = toDdmTemplatePayload(raw);
+    expect(result.templateId).toBe('40801');
+    expect(result.templateKey).toBe('NEWS_TEMPLATE');
+    expect(result.externalReferenceCode).toBe('erc-news');
+    expect(result.nameCurrentValue).toBe('News Template');
+    expect(result.classPK).toBe('301');
+    expect(result.classNameId).toBe(1001);
+    expect(result.script).toBe('<#-- ftl -->');
+    expect(result.language).toBe('ftl');
+    expect(result.type).toBe('display');
+  });
+
+  test('minimal payload — only templateKey', () => {
+    const result = toDdmTemplatePayload({templateKey: 'MY_TEMPLATE'});
+    expect(result.templateKey).toBe('MY_TEMPLATE');
+    expect(result.templateId).toBeUndefined();
+    expect(result.externalReferenceCode).toBeUndefined();
+    expect(result.nameCurrentValue).toBeUndefined();
+    expect(result.script).toBeUndefined();
+  });
+
+  test('empty object — all fields undefined', () => {
+    const result = toDdmTemplatePayload({});
+    expect(result.templateId).toBeUndefined();
+    expect(result.templateKey).toBeUndefined();
+    expect(result.script).toBeUndefined();
+  });
+
+  test('null input returns empty object', () => {
+    expect(toDdmTemplatePayload(null)).toEqual({});
+    expect(toDdmTemplatePayload(undefined)).toEqual({});
+  });
+
+  test('numeric templateId coerced to string', () => {
+    const result = toDdmTemplatePayload({templateId: 40801, classPK: 301});
+    expect(result.templateId).toBe('40801');
+    expect(result.classPK).toBe('301');
+  });
+
+  test('empty string fields return undefined (trimmed)', () => {
+    const result = toDdmTemplatePayload({templateKey: '   ', nameCurrentValue: ''});
+    expect(result.templateKey).toBeUndefined();
+    expect(result.nameCurrentValue).toBeUndefined();
+  });
+
+  test('empty script preserved as-is (valid empty template)', () => {
+    const result = toDdmTemplatePayload({script: ''});
+    // script uses String coercion without asStr (preserves empty)
+    expect(result.script).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// toFragmentCollectionPayload
+// ---------------------------------------------------------------------------
+
+describe('toFragmentCollectionPayload', () => {
+  test('full payload', () => {
+    const raw = {fragmentCollectionId: 10, fragmentCollectionKey: 'marketing', name: 'Marketing', description: 'Mkt'};
+    const result = toFragmentCollectionPayload(raw);
+    expect(result.fragmentCollectionId).toBe(10);
+    expect(result.fragmentCollectionKey).toBe('marketing');
+    expect(result.name).toBe('Marketing');
+    expect(result.description).toBe('Mkt');
+  });
+
+  test('minimal payload — only name', () => {
+    const result = toFragmentCollectionPayload({name: 'My Collection'});
+    expect(result.name).toBe('My Collection');
+    expect(result.fragmentCollectionId).toBeUndefined();
+    expect(result.fragmentCollectionKey).toBeUndefined();
+  });
+
+  test('null input returns empty object', () => {
+    expect(toFragmentCollectionPayload(null)).toEqual({});
+    expect(toFragmentCollectionPayload(undefined)).toEqual({});
+  });
+
+  test('string fragmentCollectionId coerced to number', () => {
+    const result = toFragmentCollectionPayload({fragmentCollectionId: '42'});
+    expect(result.fragmentCollectionId).toBe(42);
+  });
+
+  test('empty description preserved as empty string', () => {
+    const result = toFragmentCollectionPayload({description: ''});
+    // description uses String coercion, empty string preserved
+    expect(result.description).toBe('');
+  });
+
+  test('empty fragmentCollectionKey trimmed to undefined', () => {
+    const result = toFragmentCollectionPayload({fragmentCollectionKey: '  '});
+    expect(result.fragmentCollectionKey).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// toFragmentEntryPayload
+// ---------------------------------------------------------------------------
+
+describe('toFragmentEntryPayload', () => {
+  test('full payload', () => {
+    const raw = {
+      fragmentEntryId: 5,
+      fragmentEntryKey: 'hero-banner',
+      name: 'Hero Banner',
+      html: '<div>hero</div>',
+      css: '.hero{}',
+      js: 'console.log("hero");',
+      configuration: '{}',
+      icon: 'square',
+      type: 1,
+    };
+    const result = toFragmentEntryPayload(raw);
+    expect(result.fragmentEntryId).toBe(5);
+    expect(result.fragmentEntryKey).toBe('hero-banner');
+    expect(result.name).toBe('Hero Banner');
+    expect(result.html).toBe('<div>hero</div>');
+    expect(result.css).toBe('.hero{}');
+    expect(result.js).toBe('console.log("hero");');
+    expect(result.configuration).toBe('{}');
+    expect(result.icon).toBe('square');
+    expect(result.type).toBe(1);
+  });
+
+  test('empty html/css/js preserved as empty strings', () => {
+    const result = toFragmentEntryPayload({html: '', css: '', js: ''});
+    expect(result.html).toBe('');
+    expect(result.css).toBe('');
+    expect(result.js).toBe('');
+  });
+
+  test('missing html/css/js return undefined', () => {
+    const result = toFragmentEntryPayload({name: 'Fragment'});
+    expect(result.html).toBeUndefined();
+    expect(result.css).toBeUndefined();
+    expect(result.js).toBeUndefined();
+    expect(result.configuration).toBeUndefined();
+  });
+
+  test('null input returns empty object', () => {
+    expect(toFragmentEntryPayload(null)).toEqual({});
+    expect(toFragmentEntryPayload(undefined)).toEqual({});
+  });
+
+  test('string fragmentEntryId coerced to number', () => {
+    const result = toFragmentEntryPayload({fragmentEntryId: '99'});
+    expect(result.fragmentEntryId).toBe(99);
+  });
+
+  test('non-numeric fragmentEntryId returns undefined', () => {
+    const result = toFragmentEntryPayload({fragmentEntryId: 'invalid'});
+    expect(result.fragmentEntryId).toBeUndefined();
+  });
+
+  test('type coerced from string', () => {
+    const result = toFragmentEntryPayload({type: '1'});
+    expect(result.type).toBe(1);
+  });
+
+  test('empty key trimmed to undefined', () => {
+    const result = toFragmentEntryPayload({fragmentEntryKey: '  ', name: ''});
+    expect(result.fragmentEntryKey).toBeUndefined();
+    expect(result.name).toBeUndefined();
+  });
+
+  test('all fields undefined on completely unknown payload', () => {
+    const result = toFragmentEntryPayload({unknownField: 'value'});
+    expect(result.fragmentEntryId).toBeUndefined();
+    expect(result.fragmentEntryKey).toBeUndefined();
+    expect(result.name).toBeUndefined();
+    expect(result.html).toBeUndefined();
+  });
+});

--- a/tests/unit/liferay-resource-payloads.test.ts
+++ b/tests/unit/liferay-resource-payloads.test.ts
@@ -179,6 +179,12 @@ describe('toFragmentEntryPayload', () => {
     expect(result.fragmentEntryId).toBeUndefined();
   });
 
+  test('empty-string numeric fields return undefined (not 0)', () => {
+    const result = toFragmentEntryPayload({fragmentEntryId: '', type: '   '});
+    expect(result.fragmentEntryId).toBeUndefined();
+    expect(result.type).toBeUndefined();
+  });
+
   test('type coerced from string', () => {
     const result = toFragmentEntryPayload({type: '1'});
     expect(result.type).toBe(1);


### PR DESCRIPTION
## Summary
- Implements R9 with minimal typed payloads and tolerant parsing for legacy/partial responses.
- Reduces `Record<string, unknown>` usage in critical resource + fragments paths.
- Adds focused normalizers and applies them at API boundaries.
- Hardens numeric coercion to avoid treating empty strings as `0`.
- Normalizes fragment create/update responses to avoid optimistic typing assumptions.

## What Changed
- Added `liferay-resource-payloads.ts` with:
  - `DdmTemplatePayload`
  - `FragmentCollectionPayload`
  - `FragmentEntryPayload`
  - `DataDefinitionPayload`
  - `toDdmTemplatePayload`, `toFragmentCollectionPayload`, `toFragmentEntryPayload`
- Updated typed returns and normalization in resource shared helpers.
- Updated template/structure retrieval flows to consume typed payloads.
- Updated fragment sync API helpers to use typed maps and normalize create/update responses.
- Updated DDM identifier matcher signature to typed payload.
- Added dedicated unit tests for incomplete/legacy payloads.

## Backward Compatibility
- No public CLI API changes.
- No JSON/NDJSON output contract changes.
- Error codes/handling behavior remain unchanged.
- Parsing remains tolerant for partial legacy payloads.

## Validation
- `npm run typecheck`
- `npm run test:unit -- tests/unit/liferay-resource-payloads.test.ts tests/unit/liferay-resource-sync-fragments.test.ts`
- Result: pass (full suite green in branch run)