### PR TITLE
fix(liferay): complete R12/R18 cache hardening and preflight flag integration

### DIFF
--- a/src/commands/liferay/inventory.command.ts
+++ b/src/commands/liferay/inventory.command.ts
@@ -1,6 +1,7 @@
 import {Command} from 'commander';
 
 import {CliError} from '../../core/errors.js';
+import {createCommandContext} from '../../cli/command-context.js';
 import {addOutputFormatOption, createFormattedAction} from '../../cli/command-helpers.js';
 import {
   formatContentStats,
@@ -28,6 +29,7 @@ import {
   formatLiferayInventoryTemplates,
   runLiferayInventoryTemplates,
 } from '../../features/liferay/inventory/liferay-inventory-templates.js';
+import {formatLiferayPreflight, runLiferayPreflight} from '../../features/liferay/liferay-preflight.js';
 
 function collect(value: string, previous: string[]): string[] {
   return [...previous, value];
@@ -41,6 +43,7 @@ export function createInventoryCommands(parent: Command): void {
   const inventory = new Command('inventory')
     .helpGroup('Discovery:')
     .description('Discovery commands for sites, pages and web content metadata')
+    .option('--preflight', 'Run API surface preflight before executing inventory subcommands')
     .addHelpText(
       'after',
       `
@@ -54,6 +57,20 @@ Commands:
   templates   List web content templates
 `,
     );
+
+  inventory.hook('preAction', async (_thisCommand, actionCommand) => {
+    if (actionCommand.name() === 'preflight') {
+      return;
+    }
+
+    const options = actionCommand.optsWithGlobals<{preflight?: boolean; format?: string; strict?: boolean}>();
+    if (!options.preflight) {
+      return;
+    }
+
+    const context = createCommandContext(options);
+    await runLiferayPreflight(context.config);
+  });
 
   addOutputFormatOption(
     inventory
@@ -234,6 +251,19 @@ Notes:
           pageSize: Number.parseInt(options.pageSize, 10) || 200,
         }),
       {text: formatLiferayInventoryTemplates},
+    ),
+  );
+
+  addOutputFormatOption(
+    inventory
+      .command('preflight')
+      .description('Check availability of adminSite, adminUser and jsonws API surfaces')
+      .option('--force-refresh', 'Bypass cached result and re-probe surfaces'),
+    'text',
+  ).action(
+    createFormattedAction(
+      async (context, options) => runLiferayPreflight(context.config, {forceRefresh: Boolean(options.forceRefresh)}),
+      {text: formatLiferayPreflight},
     ),
   );
 

--- a/src/commands/resource/resource-command-builder.ts
+++ b/src/commands/resource/resource-command-builder.ts
@@ -1,6 +1,8 @@
 import {Command} from 'commander';
 
+import {createCommandContext} from '../../cli/command-context.js';
 import {addOutputFormatOption, createFormattedAction} from '../../cli/command-helpers.js';
+import {runLiferayPreflight} from '../../features/liferay/liferay-preflight.js';
 import {runLiferayResourceExportStructure} from '../../features/liferay/resource/liferay-resource-export-structure.js';
 import {runLiferayResourceExportTemplate} from '../../features/liferay/resource/liferay-resource-export-template.js';
 import {
@@ -90,11 +92,24 @@ export type ResourceCommandOptions = {
 };
 
 export function buildResourceCommand(options: ResourceCommandOptions): Command {
-  const resource = new Command('resource').description(options.description).addHelpText('after', options.helpText);
+  const resource = new Command('resource')
+    .description(options.description)
+    .option('--preflight', 'Run API surface preflight before executing resource subcommands')
+    .addHelpText('after', options.helpText);
 
   if (options.helpGroup) {
     resource.helpGroup(options.helpGroup);
   }
+
+  resource.hook('preAction', async (_thisCommand, actionCommand) => {
+    const options = actionCommand.optsWithGlobals<{preflight?: boolean; format?: string; strict?: boolean}>();
+    if (!options.preflight) {
+      return;
+    }
+
+    const context = createCommandContext(options);
+    await runLiferayPreflight(context.config);
+  });
 
   addOutputFormatOption(
     resource

--- a/src/features/liferay/inventory/liferay-inventory-page-fetch.ts
+++ b/src/features/liferay/inventory/liferay-inventory-page-fetch.ts
@@ -48,13 +48,13 @@ import {
   resolveResourceSite,
 } from '../resource/liferay-resource-shared.js';
 import {matchesDdmTemplate} from '../liferay-identifiers.js';
+import {classNameIdLookupCache} from '../lookup-cache.js';
 
 type LayoutMatch = {layout: Layout; locale: string | null};
 type ArticleRef = {articleId: string; groupId: number; ddmTemplateKey?: string};
 
 const CLASS_NAME_LAYOUT = 'com.liferay.portal.kernel.model.Layout';
 const CLASS_NAME_JOURNAL_ARTICLE = 'com.liferay.journal.model.JournalArticle';
-const classNameIdCache = new Map<string, number>();
 
 export async function fetchSiteRootInventory(
   config: AppConfig,
@@ -763,7 +763,7 @@ async function resolveClassNameId(
   className: string,
 ): Promise<number> {
   const cacheKey = `${config.liferay.url}|${className}`;
-  const cached = classNameIdCache.get(cacheKey);
+  const cached = classNameIdLookupCache.get(cacheKey);
   if (cached && cached > 0) {
     return cached;
   }
@@ -784,7 +784,7 @@ async function resolveClassNameId(
     );
   }
 
-  classNameIdCache.set(cacheKey, resolved);
+  classNameIdLookupCache.set(cacheKey, resolved);
   return resolved;
 }
 

--- a/src/features/liferay/inventory/liferay-inventory-shared.ts
+++ b/src/features/liferay/inventory/liferay-inventory-shared.ts
@@ -4,6 +4,7 @@ import {createOAuthTokenClient, type OAuthTokenClient} from '../../../core/http/
 import {createLiferayApiClient, type HttpResponse, type LiferayApiClient} from '../../../core/http/client.js';
 import {buildAuthOptions, expectJsonSuccess as expectJsonSuccessShared} from '../liferay-http-shared.js';
 import {createLiferayGateway} from '../liferay-gateway.js';
+import {LookupCache} from '../lookup-cache.js';
 import {
   SiteResolutionPipeline,
   createByIdStep,
@@ -26,7 +27,10 @@ type InventoryDependencies = {
   forceRefresh?: boolean;
 };
 
-const accessTokenCache = new Map<string, string>();
+// Tokens are valid for ~1 h; cache matches that lifetime to avoid redundant OAuth requests.
+const accessTokenCache = new LookupCache<string>({ttlMs: 3_600_000});
+// Site resolution is expensive (multi-step pipeline); 5-min TTL avoids repeated lookups.
+export const resolvedSiteCache = new LookupCache<ResolvedSite>();
 
 export async function fetchAccessToken(config: AppConfig, dependencies?: InventoryDependencies): Promise<string> {
   if (dependencies?.accessToken) {
@@ -39,8 +43,8 @@ export async function fetchAccessToken(config: AppConfig, dependencies?: Invento
     config.liferay.oauth2ClientSecret,
     config.liferay.scopeAliases,
   ].join('|');
-  const cached = accessTokenCache.get(cacheKey);
-  if (cached && !dependencies?.forceRefresh) {
+  const cached = accessTokenCache.get(cacheKey, dependencies?.forceRefresh);
+  if (cached) {
     return cached;
   }
 
@@ -55,6 +59,10 @@ export async function resolveSite(
   site: string,
   dependencies?: InventoryDependencies,
 ): Promise<ResolvedSite> {
+  const cacheKey = [config.liferay.url, config.liferay.oauth2ClientId, config.liferay.scopeAliases, site].join('|');
+  const cached = resolvedSiteCache.get(cacheKey, dependencies?.forceRefresh);
+  if (cached) return cached;
+
   const apiClient = dependencies?.apiClient ?? createLiferayApiClient();
   const gateway = createInventoryGateway(config, apiClient, dependencies);
 
@@ -74,7 +82,9 @@ export async function resolveSite(
       createJsonwsFallbackStep(gateway, normalizeResolvedSite, normalizeFriendlyUrl, normalizeLocalizedName),
     );
 
-  return pipeline.execute(site, `Could not resolve site "${site}".`);
+  const result = await pipeline.execute(site, `Could not resolve site "${site}".`);
+  resolvedSiteCache.set(cacheKey, result);
+  return result;
 }
 
 export async function fetchPagedItems<T>(

--- a/src/features/liferay/liferay-preflight.ts
+++ b/src/features/liferay/liferay-preflight.ts
@@ -1,0 +1,118 @@
+/**
+ * R18: Opt-in preflight check for Liferay API surface availability.
+ *
+ * Reports whether adminSite, adminUser, and jsonws surfaces are accessible
+ * from the configured credentials. Intended for automation mode diagnostics
+ * and fallback validation — NOT executed on every command invocation.
+ *
+ * Integration: invoke explicitly via `inventory preflight` or pass
+ * `--preflight` to supported commands.
+ */
+
+import type {AppConfig} from '../../core/config/load-config.js';
+import type {OAuthTokenClient} from '../../core/http/auth.js';
+import {createOAuthTokenClient} from '../../core/http/auth.js';
+import type {LiferayApiClient} from '../../core/http/client.js';
+import {createLiferayApiClient} from '../../core/http/client.js';
+import {buildAuthOptions} from './liferay-http-shared.js';
+import {LookupCache} from './lookup-cache.js';
+import {fetchAccessToken} from './inventory/liferay-inventory-shared.js';
+
+export type SurfaceStatus = 'ok' | 'forbidden' | 'unavailable' | 'unknown';
+
+export type PreflightResult = {
+  adminSite: SurfaceStatus;
+  adminUser: SurfaceStatus;
+  jsonws: SurfaceStatus;
+  /**
+   * Best expected fallback based on probe results:
+   * - 'headless': adminSite is ok
+   * - 'admin-user': adminSite unavailable/forbidden but adminUser is ok
+   * - 'jsonws': adminSite forbidden/unavailable but jsonws is ok
+   * - 'none': nothing accessible (likely auth failure or wrong URL)
+   */
+  expectedFallback: 'headless' | 'admin-user' | 'jsonws' | 'none';
+};
+
+type PreflightDependencies = {
+  apiClient?: LiferayApiClient;
+  tokenClient?: OAuthTokenClient;
+  accessToken?: string;
+  forceRefresh?: boolean;
+};
+
+// Cache preflight results per base URL for 5 minutes to avoid redundant probes.
+const preflightCache = new LookupCache<PreflightResult>();
+
+async function probeUrl(
+  config: AppConfig,
+  apiClient: LiferayApiClient,
+  accessToken: string,
+  path: string,
+): Promise<SurfaceStatus> {
+  try {
+    const response = await apiClient.get<unknown>(config.liferay.url, path, buildAuthOptions(config, accessToken));
+
+    if (response.ok) return 'ok';
+    if (response.status === 403) return 'forbidden';
+    if (response.status === 404) return 'unavailable';
+    return 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
+function resolveExpectedFallback(
+  result: Omit<PreflightResult, 'expectedFallback'>,
+): PreflightResult['expectedFallback'] {
+  if (result.adminSite === 'ok') return 'headless';
+  if (result.adminUser === 'ok') return 'admin-user';
+  if (result.jsonws === 'ok') return 'jsonws';
+  return 'none';
+}
+
+export async function runLiferayPreflight(
+  config: AppConfig,
+  dependencies?: PreflightDependencies,
+): Promise<PreflightResult> {
+  const cacheKey = config.liferay.url;
+  const cached = preflightCache.get(cacheKey, dependencies?.forceRefresh);
+  if (cached) return cached;
+
+  const apiClient = dependencies?.apiClient ?? createLiferayApiClient();
+  const tokenClient = dependencies?.tokenClient ?? createOAuthTokenClient();
+  const accessToken =
+    dependencies?.accessToken ??
+    (await fetchAccessToken(config, {tokenClient, forceRefresh: dependencies?.forceRefresh}));
+
+  const [adminSite, adminUser, jsonws] = await Promise.all([
+    probeUrl(config, apiClient, accessToken, '/o/headless-admin-site/v1.0/sites?pageSize=1&page=1'),
+    probeUrl(config, apiClient, accessToken, '/o/headless-admin-user/v1.0/my-user-account'),
+    probeUrl(config, apiClient, accessToken, '/api/jsonws/portal/get-build-number'),
+  ]);
+
+  const partial = {adminSite, adminUser, jsonws};
+  const result: PreflightResult = {...partial, expectedFallback: resolveExpectedFallback(partial)};
+
+  preflightCache.set(cacheKey, result);
+  return result;
+}
+
+export function formatLiferayPreflight(result: PreflightResult): string {
+  const icon = (s: SurfaceStatus): string => {
+    if (s === 'ok') return '✓';
+    if (s === 'forbidden') return '✗ (403 forbidden)';
+    if (s === 'unavailable') return '✗ (404 unavailable)';
+    return '? (unknown)';
+  };
+
+  const lines = [
+    'Liferay API surface preflight:',
+    `  adminSite  (headless-admin-site):  ${icon(result.adminSite)}`,
+    `  adminUser  (headless-admin-user):  ${icon(result.adminUser)}`,
+    `  jsonws     (/api/jsonws):          ${icon(result.jsonws)}`,
+    `  expectedFallback: ${result.expectedFallback}`,
+  ];
+
+  return lines.join('\n');
+}

--- a/src/features/liferay/lookup-cache.ts
+++ b/src/features/liferay/lookup-cache.ts
@@ -1,0 +1,56 @@
+/**
+ * R12: Shared TTL-aware cache for expensive Liferay lookups.
+ *
+ * Design:
+ * - Default TTL: 5 minutes — short enough to avoid stale data on active portals.
+ * - forceRefresh bypass for callers that need fresh data explicitly.
+ * - clear() exposed for test isolation.
+ * - Module-level named instances shared across features to deduplicate HTTP calls.
+ */
+
+export const DEFAULT_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+type CacheEntry<T> = {value: T; cachedAt: number};
+
+export type LookupCacheOptions = {
+  ttlMs?: number;
+};
+
+export class LookupCache<T> {
+  private readonly cache = new Map<string, CacheEntry<T>>();
+  private readonly ttlMs: number;
+
+  constructor(options?: LookupCacheOptions) {
+    this.ttlMs = options?.ttlMs ?? DEFAULT_TTL_MS;
+  }
+
+  /**
+   * Return cached value if present and not expired.
+   * @param forceRefresh If true, bypasses cache and returns undefined.
+   */
+  get(key: string, forceRefresh = false): T | undefined {
+    if (forceRefresh) return undefined;
+    const entry = this.cache.get(key);
+    if (!entry) return undefined;
+    if (Date.now() - entry.cachedAt > this.ttlMs) {
+      this.cache.delete(key);
+      return undefined;
+    }
+    return entry.value;
+  }
+
+  set(key: string, value: T): void {
+    this.cache.set(key, {value, cachedAt: Date.now()});
+  }
+
+  clear(): void {
+    this.cache.clear();
+  }
+}
+
+/**
+ * Shared cache for classNameId lookups (JSONWS classname/fetch-class-name).
+ * Shared between liferay-resource-shared and liferay-inventory-page-fetch to
+ * avoid duplicate HTTP calls for the same class name within the same session.
+ */
+export const classNameIdLookupCache = new LookupCache<number>();

--- a/src/features/liferay/resource/liferay-resource-shared.ts
+++ b/src/features/liferay/resource/liferay-resource-shared.ts
@@ -18,6 +18,7 @@ import {
   type FragmentCollectionPayload,
   type FragmentEntryPayload,
 } from './liferay-resource-payloads.js';
+import {classNameIdLookupCache} from '../lookup-cache.js';
 
 const DDM_STRUCTURE_CLASS_NAME = 'com.liferay.dynamic.data.mapping.model.DDMStructure';
 const JOURNAL_ARTICLE_CLASS_NAME = 'com.liferay.journal.model.JournalArticle';
@@ -27,6 +28,7 @@ type ResourceDependencies = {
   apiClient?: LiferayApiClient;
   tokenClient?: OAuthTokenClient;
   accessToken?: string;
+  forceRefresh?: boolean;
 };
 
 export type ResolvedResourceSite = ResolvedSite & {
@@ -69,9 +71,16 @@ export async function fetchStructureTemplateClassIds(
 ): Promise<{classNameId: number; resourceClassNameId: number}> {
   const apiClient = dependencies?.apiClient ?? createLiferayApiClient();
   const accessToken = await fetchAccessToken(config, dependencies);
+  const forceRefresh = dependencies?.forceRefresh;
 
-  const classNameId = await fetchClassNameId(config, apiClient, accessToken, DDM_STRUCTURE_CLASS_NAME);
-  const resourceClassNameId = await fetchClassNameId(config, apiClient, accessToken, JOURNAL_ARTICLE_CLASS_NAME);
+  const classNameId = await fetchClassNameId(config, apiClient, accessToken, DDM_STRUCTURE_CLASS_NAME, forceRefresh);
+  const resourceClassNameId = await fetchClassNameId(
+    config,
+    apiClient,
+    accessToken,
+    JOURNAL_ARTICLE_CLASS_NAME,
+    forceRefresh,
+  );
 
   return {classNameId, resourceClassNameId};
 }
@@ -83,7 +92,7 @@ export async function fetchClassNameIdForValue(
 ): Promise<number> {
   const apiClient = dependencies?.apiClient ?? createLiferayApiClient();
   const accessToken = await fetchAccessToken(config, dependencies);
-  return fetchClassNameId(config, apiClient, accessToken, className);
+  return fetchClassNameId(config, apiClient, accessToken, className, dependencies?.forceRefresh);
 }
 
 export async function fetchAdtResourceClassNameId(
@@ -133,7 +142,7 @@ export async function listDdmTemplatesByClassName(
 ): Promise<DdmTemplatePayload[]> {
   const apiClient = dependencies?.apiClient ?? createLiferayApiClient();
   const accessToken = await fetchAccessToken(config, dependencies);
-  const classNameId = await fetchClassNameId(config, apiClient, accessToken, className);
+  const classNameId = await fetchClassNameId(config, apiClient, accessToken, className, dependencies?.forceRefresh);
 
   return fetchDdmTemplates(config, apiClient, accessToken, site.companyId, site.id, classNameId, resourceClassNameId);
 }
@@ -177,7 +186,12 @@ async function fetchClassNameId(
   apiClient: LiferayApiClient,
   accessToken: string,
   className: string,
+  forceRefresh?: boolean,
 ): Promise<number> {
+  const cacheKey = `${config.liferay.url}|${className}`;
+  const cached = classNameIdLookupCache.get(cacheKey, forceRefresh);
+  if (cached) return cached;
+
   const response = await authedGet<ClassNamePayload>(
     config,
     apiClient,
@@ -191,6 +205,7 @@ async function fetchClassNameId(
       code: 'LIFERAY_RESOURCE_ERROR',
     });
   }
+  classNameIdLookupCache.set(cacheKey, classNameId);
   return classNameId;
 }
 

--- a/tests/unit/liferay-inventory.test.ts
+++ b/tests/unit/liferay-inventory.test.ts
@@ -1,4 +1,4 @@
-import {describe, expect, test} from 'vitest';
+import {describe, expect, test, beforeEach} from 'vitest';
 
 import {createLiferayApiClient} from '../../src/core/http/client.js';
 import {
@@ -9,7 +9,15 @@ import {
   formatLiferayInventoryTemplates,
   runLiferayInventoryTemplates,
 } from '../../src/features/liferay/inventory/liferay-inventory-templates.js';
-import {normalizeLocalizedName, resolveSite} from '../../src/features/liferay/inventory/liferay-inventory-shared.js';
+import {
+  normalizeLocalizedName,
+  resolveSite,
+  resolvedSiteCache,
+} from '../../src/features/liferay/inventory/liferay-inventory-shared.js';
+
+beforeEach(() => {
+  resolvedSiteCache.clear();
+});
 
 const CONFIG = {
   cwd: '/tmp/repo',
@@ -154,6 +162,72 @@ describe('liferay inventory shared', () => {
   test('normalizes localized name values', () => {
     expect(normalizeLocalizedName('Guest')).toBe('Guest');
     expect(normalizeLocalizedName({es_ES: 'Invitado', en_US: 'Guest'})).toBe('Invitado');
+  });
+
+  test('resolveSite cache is segmented by oauth client/scope context', async () => {
+    let lookupCalls = 0;
+    const apiClient = createLiferayApiClient({
+      fetchImpl: async (input) => {
+        const url = String(input);
+
+        if (url.includes('/o/headless-admin-site/v1.0/sites/by-friendly-url-path/global')) {
+          lookupCalls += 1;
+          return new Response(
+            JSON.stringify({id: 20_000 + lookupCalls, friendlyUrlPath: '/global', name: `Global ${lookupCalls}`}),
+            {status: 200},
+          );
+        }
+
+        throw new Error(`Unexpected URL ${url}`);
+      },
+    });
+
+    const configA = {...CONFIG};
+    const configB = {
+      ...CONFIG,
+      liferay: {
+        ...CONFIG.liferay,
+        oauth2ClientId: 'another-client',
+        scopeAliases: 'scope-b',
+      },
+    };
+
+    const resultA = await resolveSite(configA, '/global', {apiClient, tokenClient: TOKEN_CLIENT});
+    const resultB = await resolveSite(configB, '/global', {apiClient, tokenClient: TOKEN_CLIENT});
+
+    expect(resultA.id).toBe(20_001);
+    expect(resultB.id).toBe(20_002);
+    expect(lookupCalls).toBe(2);
+  });
+
+  test('resolveSite forceRefresh bypasses cached site lookup', async () => {
+    let lookupCalls = 0;
+    const apiClient = createLiferayApiClient({
+      fetchImpl: async (input) => {
+        const url = String(input);
+
+        if (url.includes('/o/headless-admin-site/v1.0/sites/by-friendly-url-path/global')) {
+          lookupCalls += 1;
+          return new Response(
+            JSON.stringify({id: 30_000 + lookupCalls, friendlyUrlPath: '/global', name: `Global ${lookupCalls}`}),
+            {status: 200},
+          );
+        }
+
+        throw new Error(`Unexpected URL ${url}`);
+      },
+    });
+
+    const first = await resolveSite(CONFIG, '/global', {apiClient, tokenClient: TOKEN_CLIENT});
+    const second = await resolveSite(CONFIG, '/global', {
+      apiClient,
+      tokenClient: TOKEN_CLIENT,
+      forceRefresh: true,
+    });
+
+    expect(first.id).toBe(30_001);
+    expect(second.id).toBe(30_002);
+    expect(lookupCalls).toBe(2);
   });
 });
 

--- a/tests/unit/liferay-lookup-cache.test.ts
+++ b/tests/unit/liferay-lookup-cache.test.ts
@@ -1,0 +1,103 @@
+import {describe, expect, test, vi} from 'vitest';
+
+import {DEFAULT_TTL_MS, LookupCache, classNameIdLookupCache} from '../../src/features/liferay/lookup-cache.js';
+
+describe('LookupCache', () => {
+  describe('get', () => {
+    test('returns undefined on cache miss', () => {
+      const cache = new LookupCache<number>();
+      expect(cache.get('missing')).toBeUndefined();
+    });
+
+    test('returns value on cache hit', () => {
+      const cache = new LookupCache<number>();
+      cache.set('key', 42);
+      expect(cache.get('key')).toBe(42);
+    });
+
+    test('returns undefined when forceRefresh is true (bypass)', () => {
+      const cache = new LookupCache<number>();
+      cache.set('key', 42);
+      expect(cache.get('key', true)).toBeUndefined();
+    });
+
+    test('returns value when forceRefresh is false (no bypass)', () => {
+      const cache = new LookupCache<number>();
+      cache.set('key', 42);
+      expect(cache.get('key', false)).toBe(42);
+    });
+
+    test('returns undefined after TTL expires', () => {
+      const cache = new LookupCache<string>({ttlMs: 100});
+      cache.set('key', 'value');
+
+      // Simulate TTL expiry by mocking Date.now
+      const now = Date.now();
+      vi.spyOn(Date, 'now').mockReturnValue(now + 200);
+
+      expect(cache.get('key')).toBeUndefined();
+
+      vi.restoreAllMocks();
+    });
+
+    test('returns value before TTL expires', () => {
+      const cache = new LookupCache<string>({ttlMs: 10_000});
+      cache.set('key', 'value');
+      expect(cache.get('key')).toBe('value');
+    });
+
+    test('removes expired entry from internal map on access', () => {
+      const cache = new LookupCache<number>({ttlMs: 100});
+      cache.set('key', 1);
+
+      const now = Date.now();
+      vi.spyOn(Date, 'now').mockReturnValue(now + 200);
+
+      cache.get('key'); // triggers removal
+      vi.restoreAllMocks();
+
+      // After restoring Date.now, the entry should be absent (was evicted)
+      expect(cache.get('key')).toBeUndefined();
+    });
+  });
+
+  describe('set', () => {
+    test('overwrites existing value', () => {
+      const cache = new LookupCache<number>();
+      cache.set('key', 1);
+      cache.set('key', 2);
+      expect(cache.get('key')).toBe(2);
+    });
+  });
+
+  describe('clear', () => {
+    test('removes all entries', () => {
+      const cache = new LookupCache<number>();
+      cache.set('a', 1);
+      cache.set('b', 2);
+      cache.clear();
+      expect(cache.get('a')).toBeUndefined();
+      expect(cache.get('b')).toBeUndefined();
+    });
+  });
+
+  describe('DEFAULT_TTL_MS', () => {
+    test('is 5 minutes', () => {
+      expect(DEFAULT_TTL_MS).toBe(5 * 60 * 1000);
+    });
+  });
+
+  describe('classNameIdLookupCache (shared instance)', () => {
+    test('is a LookupCache<number>', () => {
+      expect(classNameIdLookupCache).toBeInstanceOf(LookupCache);
+    });
+
+    test('shared instance is isolated when cleared', () => {
+      classNameIdLookupCache.clear();
+      classNameIdLookupCache.set('http://localhost:8080|com.example.Model', 999);
+      expect(classNameIdLookupCache.get('http://localhost:8080|com.example.Model')).toBe(999);
+      classNameIdLookupCache.clear();
+      expect(classNameIdLookupCache.get('http://localhost:8080|com.example.Model')).toBeUndefined();
+    });
+  });
+});

--- a/tests/unit/liferay-preflight.test.ts
+++ b/tests/unit/liferay-preflight.test.ts
@@ -1,0 +1,202 @@
+import {describe, expect, test} from 'vitest';
+
+import {createLiferayApiClient} from '../../src/core/http/client.js';
+import {formatLiferayPreflight, runLiferayPreflight} from '../../src/features/liferay/liferay-preflight.js';
+
+const CONFIG = {
+  cwd: '/tmp/repo',
+  repoRoot: '/tmp/repo',
+  dockerDir: '/tmp/repo/docker',
+  liferayDir: '/tmp/repo/liferay',
+  files: {
+    dockerEnv: '/tmp/repo/docker/.env',
+    liferayProfile: '/tmp/repo/.liferay-cli.yml',
+  },
+  liferay: {
+    url: 'http://localhost:8080',
+    oauth2ClientId: 'client-id',
+    oauth2ClientSecret: 'client-secret',
+    scopeAliases: 'scope-a',
+    timeoutSeconds: 30,
+  },
+};
+
+const TOKEN_CLIENT = {
+  fetchClientCredentialsToken: async () => ({
+    accessToken: 'token-123',
+    tokenType: 'Bearer',
+    expiresIn: 3600,
+  }),
+};
+
+function makeApiClient(responses: Record<string, {status: number; body: string}>) {
+  return createLiferayApiClient({
+    fetchImpl: async (input) => {
+      const url = String(input);
+      for (const [pattern, response] of Object.entries(responses)) {
+        if (url.includes(pattern)) {
+          return new Response(response.body, {status: response.status});
+        }
+      }
+      throw new Error(`Unexpected URL: ${url}`);
+    },
+  });
+}
+
+describe('runLiferayPreflight', () => {
+  test('all surfaces ok returns ok status and headless fallback', async () => {
+    const apiClient = makeApiClient({
+      '/o/headless-admin-site/v1.0/sites': {status: 200, body: '{"items":[],"lastPage":1}'},
+      '/o/headless-admin-user/v1.0/my-user-account': {status: 200, body: '{"id":1}'},
+      '/api/jsonws/portal/get-build-number': {status: 200, body: '7400'},
+    });
+
+    const result = await runLiferayPreflight(
+      {...CONFIG, liferay: {...CONFIG.liferay, url: 'http://localhost:9001'}},
+      {apiClient, tokenClient: TOKEN_CLIENT},
+    );
+
+    expect(result.adminSite).toBe('ok');
+    expect(result.adminUser).toBe('ok');
+    expect(result.jsonws).toBe('ok');
+    expect(result.expectedFallback).toBe('headless');
+  });
+
+  test('adminSite 403 → forbidden; fallback to jsonws when jsonws ok', async () => {
+    const apiClient = makeApiClient({
+      '/o/headless-admin-site/v1.0/sites': {status: 403, body: 'forbidden'},
+      '/o/headless-admin-user/v1.0/my-user-account': {status: 403, body: 'forbidden'},
+      '/api/jsonws/portal/get-build-number': {status: 200, body: '7400'},
+    });
+
+    const result = await runLiferayPreflight(
+      {...CONFIG, liferay: {...CONFIG.liferay, url: 'http://localhost:9002'}},
+      {apiClient, tokenClient: TOKEN_CLIENT},
+    );
+
+    expect(result.adminSite).toBe('forbidden');
+    expect(result.adminUser).toBe('forbidden');
+    expect(result.jsonws).toBe('ok');
+    expect(result.expectedFallback).toBe('jsonws');
+  });
+
+  test('adminSite 404 with adminUser ok → expectedFallback is admin-user', async () => {
+    const apiClient = makeApiClient({
+      '/o/headless-admin-site/v1.0/sites': {status: 404, body: 'not found'},
+      '/o/headless-admin-user/v1.0/my-user-account': {status: 200, body: '{}'},
+      '/api/jsonws/portal/get-build-number': {status: 200, body: '7400'},
+    });
+
+    const result = await runLiferayPreflight(
+      {...CONFIG, liferay: {...CONFIG.liferay, url: 'http://localhost:9003'}},
+      {apiClient, tokenClient: TOKEN_CLIENT},
+    );
+
+    expect(result.adminSite).toBe('unavailable');
+    expect(result.expectedFallback).toBe('admin-user');
+  });
+
+  test('all surfaces return 403 → expectedFallback is none', async () => {
+    const apiClient = makeApiClient({
+      '/o/headless-admin-site/v1.0/sites': {status: 403, body: 'forbidden'},
+      '/o/headless-admin-user/v1.0/my-user-account': {status: 403, body: 'forbidden'},
+      '/api/jsonws/portal/get-build-number': {status: 403, body: 'forbidden'},
+    });
+
+    const result = await runLiferayPreflight(
+      {...CONFIG, liferay: {...CONFIG.liferay, url: 'http://localhost:9004'}},
+      {apiClient, tokenClient: TOKEN_CLIENT},
+    );
+
+    expect(result.adminSite).toBe('forbidden');
+    expect(result.jsonws).toBe('forbidden');
+    expect(result.expectedFallback).toBe('none');
+  });
+
+  test('network error → unknown status', async () => {
+    const apiClient = createLiferayApiClient({
+      fetchImpl: async () => {
+        throw new Error('network error');
+      },
+    });
+
+    const result = await runLiferayPreflight(
+      {...CONFIG, liferay: {...CONFIG.liferay, url: 'http://localhost:9005'}},
+      {apiClient, tokenClient: TOKEN_CLIENT},
+    );
+
+    expect(result.adminSite).toBe('unknown');
+    expect(result.adminUser).toBe('unknown');
+    expect(result.jsonws).toBe('unknown');
+    expect(result.expectedFallback).toBe('none');
+  });
+
+  test('caches result; second call does not re-probe', async () => {
+    let callCount = 0;
+    const apiClient = createLiferayApiClient({
+      fetchImpl: async (input) => {
+        const url = String(input);
+        if (url.includes('preflight-cache-test')) {
+          callCount += 1;
+          return new Response('{"items":[]}', {status: 200});
+        }
+        return new Response('{}', {status: 200});
+      },
+    });
+
+    const cfg = {...CONFIG, liferay: {...CONFIG.liferay, url: 'http://preflight-cache-test:8080'}};
+    const deps = {apiClient, tokenClient: TOKEN_CLIENT};
+
+    await runLiferayPreflight(cfg, deps);
+    const countAfterFirst = callCount;
+
+    await runLiferayPreflight(cfg, deps); // should hit cache
+    expect(callCount).toBe(countAfterFirst);
+  });
+
+  test('forceRefresh bypasses cache', async () => {
+    let callCount = 0;
+    const apiClient = createLiferayApiClient({
+      fetchImpl: async () => {
+        callCount += 1;
+        return new Response('{}', {status: 200});
+      },
+    });
+
+    const cfg = {...CONFIG, liferay: {...CONFIG.liferay, url: 'http://preflight-refresh-test:8080'}};
+    const deps = {apiClient, tokenClient: TOKEN_CLIENT};
+
+    await runLiferayPreflight(cfg, deps);
+    const after1 = callCount;
+
+    await runLiferayPreflight(cfg, {...deps, forceRefresh: true});
+    expect(callCount).toBeGreaterThan(after1);
+  });
+});
+
+describe('formatLiferayPreflight', () => {
+  test('formats all-ok result', () => {
+    const result = {
+      adminSite: 'ok' as const,
+      adminUser: 'ok' as const,
+      jsonws: 'ok' as const,
+      expectedFallback: 'headless' as const,
+    };
+    const output = formatLiferayPreflight(result);
+    expect(output).toContain('adminSite');
+    expect(output).toContain('✓');
+    expect(output).toContain('headless');
+  });
+
+  test('formats forbidden result', () => {
+    const result = {
+      adminSite: 'forbidden' as const,
+      adminUser: 'forbidden' as const,
+      jsonws: 'ok' as const,
+      expectedFallback: 'jsonws' as const,
+    };
+    const output = formatLiferayPreflight(result);
+    expect(output).toContain('403 forbidden');
+    expect(output).toContain('jsonws');
+  });
+});

--- a/tests/unit/liferay-resource-export.test.ts
+++ b/tests/unit/liferay-resource-export.test.ts
@@ -1,8 +1,9 @@
 import fs from 'fs-extra';
 import path from 'node:path';
-import {describe, expect, test} from 'vitest';
+import {describe, expect, test, beforeEach} from 'vitest';
 
 import {createLiferayApiClient} from '../../src/core/http/client.js';
+import {classNameIdLookupCache} from '../../src/features/liferay/lookup-cache.js';
 import {runLiferayResourceExportStructure} from '../../src/features/liferay/resource/liferay-resource-export-structure.js';
 import {
   formatLiferayResourceExportStructures,
@@ -16,6 +17,10 @@ import {
   runLiferayResourceExportTemplates,
 } from '../../src/features/liferay/resource/liferay-resource-export-templates.js';
 import {createTempDir} from '../../src/testing/temp-repo.js';
+
+beforeEach(() => {
+  classNameIdLookupCache.clear();
+});
 
 const CONFIG = {
   cwd: '/tmp/repo',

--- a/tests/unit/liferay-resource-shared-cache.test.ts
+++ b/tests/unit/liferay-resource-shared-cache.test.ts
@@ -1,0 +1,88 @@
+import {beforeEach, describe, expect, test} from 'vitest';
+
+import {createLiferayApiClient} from '../../src/core/http/client.js';
+import {classNameIdLookupCache} from '../../src/features/liferay/lookup-cache.js';
+import {fetchClassNameIdForValue} from '../../src/features/liferay/resource/liferay-resource-shared.js';
+
+const CONFIG = {
+  cwd: '/tmp/repo',
+  repoRoot: '/tmp/repo',
+  dockerDir: '/tmp/repo/docker',
+  liferayDir: '/tmp/repo/liferay',
+  files: {
+    dockerEnv: '/tmp/repo/docker/.env',
+    liferayProfile: '/tmp/repo/.liferay-cli.yml',
+  },
+  liferay: {
+    url: 'http://localhost:8080',
+    oauth2ClientId: 'client-id',
+    oauth2ClientSecret: 'client-secret',
+    scopeAliases: 'scope-a',
+    timeoutSeconds: 30,
+  },
+};
+
+beforeEach(() => {
+  classNameIdLookupCache.clear();
+});
+
+describe('liferay resource shared classNameId cache integration', () => {
+  test('reuses cached classNameId for repeated lookup', async () => {
+    let classNameCalls = 0;
+    const apiClient = createLiferayApiClient({
+      fetchImpl: async (input) => {
+        const url = String(input);
+
+        if (url.includes('/api/jsonws/classname/fetch-class-name?value=')) {
+          classNameCalls += 1;
+          return new Response(JSON.stringify({classNameId: 7000 + classNameCalls}), {status: 200});
+        }
+
+        throw new Error(`Unexpected URL ${url}`);
+      },
+    });
+
+    const first = await fetchClassNameIdForValue(CONFIG, 'com.example.Model', {
+      apiClient,
+      accessToken: 'token-123',
+    });
+    const second = await fetchClassNameIdForValue(CONFIG, 'com.example.Model', {
+      apiClient,
+      accessToken: 'token-123',
+    });
+
+    expect(first).toBe(7001);
+    expect(second).toBe(7001);
+    expect(classNameCalls).toBe(1);
+  });
+
+  test('forceRefresh bypasses cached classNameId', async () => {
+    let classNameCalls = 0;
+    const apiClient = createLiferayApiClient({
+      fetchImpl: async (input) => {
+        const url = String(input);
+
+        if (url.includes('/api/jsonws/classname/fetch-class-name?value=')) {
+          classNameCalls += 1;
+          return new Response(JSON.stringify({classNameId: 9000 + classNameCalls}), {status: 200});
+        }
+
+        throw new Error(`Unexpected URL ${url}`);
+      },
+    });
+
+    const first = await fetchClassNameIdForValue(CONFIG, 'com.example.Model', {
+      apiClient,
+      accessToken: 'token-123',
+    });
+    const second = await fetchClassNameIdForValue(CONFIG, 'com.example.Model', {
+      apiClient,
+      accessToken: 'token-123',
+      forceRefresh: true,
+    });
+
+    expect(first).toBe(9001);
+    expect(second).toBe(9002);
+    expect(classNameCalls).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
This PR closes the remaining R12/R18 review findings by completing preflight integration and hardening lookup cache behavior.

## What Changed
- Added shared TTL lookup cache helper:
  - `src/features/liferay/lookup-cache.ts`
- Added preflight feature module:
  - `src/features/liferay/liferay-preflight.ts`
- Integrated preflight as an opt-in flag on command groups:
  - `inventory --preflight`
  - `resource --preflight`
- Kept explicit command support:
  - `inventory preflight [--force-refresh]`
- Hardened `resolveSite` cache key segmentation in inventory shared logic:
  - cache key now includes URL + OAuth client + scope + site token
- Extended preflight fallback semantics to include `admin-user` when applicable.
- Adopted shared classNameId cache in resource and inventory fetch paths.

## Tests Added/Updated
- Added:
  - `tests/unit/liferay-lookup-cache.test.ts`
  - `tests/unit/liferay-preflight.test.ts`
  - `tests/unit/liferay-resource-shared-cache.test.ts`
- Updated:
  - `tests/unit/liferay-inventory.test.ts`
  - `tests/unit/liferay-resource-export.test.ts`

## Validation
- `npm run typecheck`
- `npm run test:unit -- tests/unit/liferay-inventory.test.ts tests/unit/liferay-preflight.test.ts tests/unit/liferay-resource-shared-cache.test.ts tests/unit/liferay-resource-export.test.ts`
- Result: pass

## Backward Compatibility
- No public CLI contract break for existing JSON/NDJSON outputs.
- New behavior is opt-in via `--preflight` and `inventory preflight` command.

## Remaining Risk
- Minor overhead when `--preflight` is enabled because preflight runs before the selected command.