### PR TITLE
refactor(resource): R14 unify artifact path resolution with compatibility mode

### DIFF
--- a/src/features/liferay/resource/artifact-paths.ts
+++ b/src/features/liferay/resource/artifact-paths.ts
@@ -1,0 +1,359 @@
+import fs from 'fs-extra';
+import path from 'node:path';
+
+import {CliError} from '../../../core/errors.js';
+import type {AppConfig} from '../../../core/config/load-config.js';
+
+export type ArtifactType = 'template' | 'structure' | 'adt' | 'fragment';
+
+export const ADT_WIDGET_DIR_BY_TYPE: Record<string, string> = {
+  'asset-entry': 'asset_entry',
+  breadcrumb: 'breadcrumb',
+  'category-facet': 'category_facet',
+  'custom-facet': 'custom_facet',
+  'custom-filter': 'custom_filter',
+  'language-selector': 'language_selector',
+  'navigation-menu': 'navigation_menu',
+  'search-result-summary': 'search_result_summary',
+  searchbar: 'searchbar',
+  'similar-results': 'search_results',
+};
+
+export function requireRepoRoot(config: AppConfig): string {
+  if (!config.repoRoot) {
+    throw new CliError('This command must be run inside a project repository.', {
+      code: 'LIFERAY_REPO_NOT_FOUND',
+    });
+  }
+
+  return config.repoRoot;
+}
+
+export function resolveRepoPath(config: AppConfig, relativePath: string): string {
+  return path.resolve(requireRepoRoot(config), relativePath);
+}
+
+export function resolveStructuresBaseDir(config: AppConfig): string {
+  return resolveRepoPath(config, config.paths?.structures ?? 'liferay/resources/journal/structures');
+}
+
+export function resolveTemplatesBaseDir(config: AppConfig): string {
+  return resolveRepoPath(config, config.paths?.templates ?? 'liferay/resources/journal/templates');
+}
+
+export function resolveAdtsBaseDir(config: AppConfig): string {
+  return resolveRepoPath(config, config.paths?.adts ?? 'liferay/resources/templates/application_display');
+}
+
+export function resolveFragmentsBaseDir(config: AppConfig): string {
+  return resolveRepoPath(config, config.paths?.fragments ?? 'liferay/fragments');
+}
+
+export function resolveMigrationsBaseDir(config: AppConfig): string {
+  return resolveRepoPath(config, config.paths?.migrations ?? 'liferay/resources/journal/migrations');
+}
+
+export function resolveSiteToken(siteFriendlyUrl: string): string {
+  const token = siteFriendlyUrl.replace(/^\//, '').trim();
+  return token === '' ? 'global' : token;
+}
+
+type ResolveArtifactFileOptions =
+  | {
+      type: 'structure';
+      key: string;
+      fileOverride?: string;
+    }
+  | {
+      type: 'template';
+      key: string;
+      siteToken: string;
+      fileOverride?: string;
+    }
+  | {
+      type: 'adt';
+      key: string;
+      widgetType: string;
+      fileOverride?: string;
+    };
+
+/**
+ * Sanitizes a value for use as a file/directory token.
+ * Consolidates the duplicated sanitizeFileToken helper across export modules.
+ */
+export function sanitizeArtifactToken(value: string): string {
+  const normalized = value
+    .trim()
+    .replaceAll(/[^A-Za-z0-9_.-]+/g, '_')
+    .replaceAll(/_+/g, '_');
+  return normalized === '' ? 'unnamed' : normalized;
+}
+
+/**
+ * Resolves the base directory for an artifact type, without a site subdirectory.
+ * Used for bulk exports that iterate multiple sites and append siteToken per iteration.
+ *
+ * - templates / structures / adt: returns the configured type base dir (or dirOverride resolved)
+ * - fragment: returns the fragments base dir (or dirOverride); the 'sites/{token}' subdir
+ *   is appended by resolveArtifactSiteDir
+ */
+export function resolveArtifactBaseDir(config: AppConfig, type: ArtifactType, dirOverride?: string): string {
+  if (dirOverride?.trim()) {
+    return path.resolve(resolveRepoPath(config, dirOverride));
+  }
+  switch (type) {
+    case 'template':
+      return resolveTemplatesBaseDir(config);
+    case 'structure':
+      return resolveStructuresBaseDir(config);
+    case 'adt':
+      return resolveAdtsBaseDir(config);
+    case 'fragment':
+      return resolveFragmentsBaseDir(config);
+  }
+}
+
+export async function resolveArtifactFile(config: AppConfig, options: ResolveArtifactFileOptions): Promise<string> {
+  if (options.fileOverride) {
+    return resolveExistingArtifactFile(config, options.fileOverride);
+  }
+
+  switch (options.type) {
+    case 'structure':
+      return resolveStructureArtifactFile(config, options.key);
+    case 'template':
+      return resolveTemplateArtifactFile(config, options.siteToken, options.key);
+    case 'adt':
+      return resolveAdtArtifactFile(config, options.key, options.widgetType);
+  }
+}
+
+/**
+ * Resolves the output directory for a specific site+type combination.
+ *
+ * - templates / structures / adt: (dirOverride ?? typeBaseDir) / siteToken
+ * - fragment: uses historical 'sites/' prefix → fragmentsBaseDir / sites / siteToken
+ *   When dirOverride is provided for fragments, uses dirOverride directly
+ *   (preserves legacy --dir behavior where the dir IS the project root for that site).
+ */
+export function resolveArtifactSiteDir(
+  config: AppConfig,
+  type: ArtifactType,
+  siteToken: string,
+  dirOverride?: string,
+): string {
+  if (type === 'fragment') {
+    if (dirOverride?.trim()) {
+      return path.resolve(resolveRepoPath(config, dirOverride));
+    }
+    return path.join(resolveFragmentsBaseDir(config), 'sites', siteToken);
+  }
+  return path.join(resolveArtifactBaseDir(config, type, dirOverride), siteToken);
+}
+
+export function resolveFragmentProjectDir(config: AppConfig, siteToken: string, dirOverride?: string): string {
+  if ((dirOverride ?? '').trim() === '') {
+    return resolveArtifactSiteDir(config, 'fragment', siteToken);
+  }
+
+  const configuredDir = (dirOverride ?? '').trim();
+  const configured = path.resolve(resolveRepoPath(config, configuredDir));
+  const detectedFromConfigured = detectFragmentsProjectRoot(configured);
+  if (detectedFromConfigured) {
+    return detectedFromConfigured;
+  }
+
+  const configuredWithSite = path.join(configured, siteToken);
+  const detectedFromSitePath = detectFragmentsProjectRoot(configuredWithSite);
+  if (detectedFromSitePath) {
+    return detectedFromSitePath;
+  }
+
+  return configuredWithSite;
+}
+
+function createConfigIncompleteError(resourceType: string, exampleName: string): CliError {
+  return new CliError(
+    `${resourceType} file not found for '${exampleName}'.\n\n` +
+      `The project configuration is incomplete. To resolve this:\n` +
+      `  1. Use --file to specify the full path directly (quick workaround)\n` +
+      `  2. Create .liferay-cli.yml in the repository root with paths configuration\n` +
+      `  3. Run 'ldev project init' to scaffold the configuration file\n\n` +
+      `See: https://ldev.dev/reference/configuration#liferay-cli-yml`,
+    {code: 'LIFERAY_CONFIG_INCOMPLETE'},
+  );
+}
+
+async function resolveStructureArtifactFile(config: AppConfig, key: string): Promise<string> {
+  if (!config.paths?.structures) {
+    throw createConfigIncompleteError('Structure', key);
+  }
+
+  const baseDir = resolveStructuresBaseDir(config);
+  const matches = await findFilesByName(baseDir, `${key}.json`);
+  if (matches.length === 1) {
+    return matches[0]!;
+  }
+  if (matches.length > 1) {
+    throw new CliError(`Structure file ambiguo para ${key}: ${matches.join(', ')}`, {
+      code: 'LIFERAY_RESOURCE_FILE_AMBIGUOUS',
+    });
+  }
+
+  throw new CliError(`Structure file not found for ${key} in ${baseDir}. Use --file.`, {
+    code: 'LIFERAY_RESOURCE_FILE_NOT_FOUND',
+  });
+}
+
+async function resolveTemplateArtifactFile(config: AppConfig, siteToken: string, key: string): Promise<string> {
+  if (!config.paths?.templates) {
+    throw createConfigIncompleteError('Template', key);
+  }
+
+  const baseDir = resolveTemplatesBaseDir(config);
+  const candidates = [
+    path.join(baseDir, siteToken, `${key}.ftl`),
+    siteToken === 'global' ? null : path.join(baseDir, 'global', `${key}.ftl`),
+    path.join(baseDir, `${key}.ftl`),
+  ].filter(Boolean) as string[];
+
+  for (const candidate of candidates) {
+    if (await fs.pathExists(candidate)) {
+      return candidate;
+    }
+  }
+
+  const matches = await findFilesByName(baseDir, `${key}.ftl`);
+  if (matches.length === 1) {
+    return matches[0]!;
+  }
+  if (matches.length > 1) {
+    throw new CliError(`Template file ambiguo para ${key}: ${matches.join(', ')}`, {
+      code: 'LIFERAY_RESOURCE_FILE_AMBIGUOUS',
+    });
+  }
+
+  throw new CliError(`Template file not found for ${key} in ${baseDir}. Use --file.`, {
+    code: 'LIFERAY_RESOURCE_FILE_NOT_FOUND',
+  });
+}
+
+async function resolveAdtArtifactFile(config: AppConfig, key: string, widgetType: string): Promise<string> {
+  if (!config.paths?.adts) {
+    throw createConfigIncompleteError(`ADT (${widgetType})`, key);
+  }
+
+  const baseDir = resolveAdtsBaseDir(config);
+  const widgetDir = ADT_WIDGET_DIR_BY_TYPE[widgetType];
+  if (!widgetDir) {
+    throw new CliError(`widget-type ADT no soportado: ${widgetType}`, {
+      code: 'LIFERAY_RESOURCE_ERROR',
+    });
+  }
+
+  const matches = await findFilesByPathSuffix(baseDir, path.join(widgetDir, `${key}.ftl`));
+  if (matches.length === 1) {
+    return matches[0]!;
+  }
+  if (matches.length > 1) {
+    throw new CliError(`ADT file ambiguo para ${key} (${widgetType}): ${matches.join(', ')}`, {
+      code: 'LIFERAY_RESOURCE_FILE_AMBIGUOUS',
+    });
+  }
+
+  throw new CliError(`ADT file not found for ${key} (${widgetType}) in ${baseDir}. Use --file.`, {
+    code: 'LIFERAY_RESOURCE_FILE_NOT_FOUND',
+  });
+}
+
+async function resolveExistingArtifactFile(config: AppConfig, candidate: string): Promise<string> {
+  const repoRoot = requireRepoRoot(config);
+  const direct = path.resolve(candidate);
+  if (await fs.pathExists(direct)) {
+    return direct;
+  }
+
+  const relativeToRepo = path.resolve(repoRoot, candidate);
+  if (await fs.pathExists(relativeToRepo)) {
+    return relativeToRepo;
+  }
+
+  for (const baseDir of [
+    resolveStructuresBaseDir(config),
+    resolveTemplatesBaseDir(config),
+    resolveAdtsBaseDir(config),
+  ]) {
+    const nested = path.resolve(baseDir, candidate);
+    if (await fs.pathExists(nested)) {
+      return nested;
+    }
+  }
+
+  throw new CliError(`File not found: ${candidate}`, {
+    code: 'LIFERAY_RESOURCE_FILE_NOT_FOUND',
+  });
+}
+
+function detectFragmentsProjectRoot(startPath: string): string | null {
+  let current = path.resolve(startPath);
+
+  while (true) {
+    if (fs.existsSync(path.join(current, 'src'))) {
+      return current;
+    }
+
+    if (path.basename(current).toLowerCase() === 'src') {
+      return path.dirname(current);
+    }
+
+    const parent = path.dirname(current);
+    if (parent === current) {
+      return null;
+    }
+    current = parent;
+  }
+}
+
+async function findFilesByName(baseDir: string, filename: string): Promise<string[]> {
+  if (!(await fs.pathExists(baseDir))) {
+    return [];
+  }
+
+  const matches: string[] = [];
+  await walk(baseDir, async (entryPath) => {
+    if (path.basename(entryPath) === filename) {
+      matches.push(entryPath);
+    }
+  });
+  return matches.sort();
+}
+
+async function findFilesByPathSuffix(baseDir: string, suffixPath: string): Promise<string[]> {
+  if (!(await fs.pathExists(baseDir))) {
+    return [];
+  }
+
+  const normalizedSuffix = suffixPath.split(path.sep).join('/');
+  const matches: string[] = [];
+  await walk(baseDir, async (entryPath) => {
+    const normalized = entryPath.split(path.sep).join('/');
+    if (normalized.endsWith(normalizedSuffix)) {
+      matches.push(entryPath);
+    }
+  });
+  return matches.sort();
+}
+
+async function walk(dir: string, visit: (entryPath: string) => Promise<void>): Promise<void> {
+  const entries = await fs.readdir(dir, {withFileTypes: true});
+  for (const entry of entries) {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      await walk(entryPath, visit);
+      continue;
+    }
+    if (entry.isFile()) {
+      await visit(entryPath);
+    }
+  }
+}

--- a/src/features/liferay/resource/liferay-resource-export-adts.ts
+++ b/src/features/liferay/resource/liferay-resource-export-adts.ts
@@ -6,12 +6,8 @@ import type {OAuthTokenClient} from '../../../core/http/auth.js';
 import type {LiferayApiClient} from '../../../core/http/client.js';
 import {runLiferayInventorySitesIncludingGlobal} from '../inventory/liferay-inventory-sites.js';
 import {runLiferayResourceListAdts} from './liferay-resource-list-adts.js';
-import {
-  resolveAdtsBaseDir,
-  resolveRepoPath,
-  resolveSiteToken,
-  ADT_WIDGET_DIR_BY_TYPE,
-} from './liferay-resource-paths.js';
+import {resolveSiteToken, ADT_WIDGET_DIR_BY_TYPE} from './liferay-resource-paths.js';
+import {resolveArtifactBaseDir, sanitizeArtifactToken} from './artifact-paths.js';
 import {resolveResourceSite} from './liferay-resource-shared.js';
 
 type ResourceDependencies = {
@@ -44,9 +40,7 @@ export async function runLiferayResourceExportAdts(
   },
   dependencies?: ResourceDependencies,
 ): Promise<LiferayResourceExportAdtsResult> {
-  const baseDir = path.resolve(
-    options?.dir?.trim() ? resolveRepoPath(config, options.dir) : resolveAdtsBaseDir(config),
-  );
+  const baseDir = resolveArtifactBaseDir(config, 'adt', options?.dir);
 
   if (options?.allSites) {
     const sites = await runLiferayInventorySitesIncludingGlobal(config, undefined, dependencies);
@@ -117,7 +111,7 @@ export async function runLiferayResourceExportAdts(
       const target = path.join(
         outputDir,
         widgetDir ?? row.widgetType.replaceAll('-', '_'),
-        `${sanitizeFileToken(row.templateKey || row.adtName)}.ftl`,
+        `${sanitizeArtifactToken(row.templateKey || row.adtName)}.ftl`,
       );
       await fs.ensureDir(path.dirname(target));
       await fs.writeFile(target, `${row.script ?? ''}`);
@@ -149,12 +143,4 @@ export function formatLiferayResourceExportAdts(result: LiferayResourceExportAdt
   }
 
   return `EXPORTED site=${result.site} exported=${result.exported} failed=${result.failed} dir=${result.outputDir}`;
-}
-
-function sanitizeFileToken(value: string): string {
-  const normalized = value
-    .trim()
-    .replaceAll(/[^A-Za-z0-9_.-]+/g, '_')
-    .replaceAll(/_+/g, '_');
-  return normalized === '' ? 'unnamed' : normalized;
 }

--- a/src/features/liferay/resource/liferay-resource-export-fragments.ts
+++ b/src/features/liferay/resource/liferay-resource-export-fragments.ts
@@ -6,7 +6,8 @@ import type {OAuthTokenClient} from '../../../core/http/auth.js';
 import type {LiferayApiClient} from '../../../core/http/client.js';
 import {runLiferayInventorySitesIncludingGlobal} from '../inventory/liferay-inventory-sites.js';
 import {listFragmentCollections, listFragments, resolveResourceSite} from './liferay-resource-shared.js';
-import {resolveFragmentsBaseDir, resolveRepoPath, resolveSiteToken} from './liferay-resource-paths.js';
+import {resolveSiteToken} from './liferay-resource-paths.js';
+import {resolveArtifactBaseDir, resolveArtifactSiteDir, sanitizeArtifactToken} from './artifact-paths.js';
 
 type ResourceDependencies = {
   apiClient?: LiferayApiClient;
@@ -57,9 +58,7 @@ export async function runLiferayResourceExportFragments(
       siteToken: 'all-sites',
       collectionCount,
       fragmentCount,
-      outputDir: path.resolve(
-        options?.dir?.trim() ? resolveRepoPath(config, options.dir) : resolveFragmentsBaseDir(config),
-      ),
+      outputDir: resolveArtifactBaseDir(config, 'fragment', options?.dir),
       scannedSites: siteResults.length,
       siteResults,
     };
@@ -67,10 +66,7 @@ export async function runLiferayResourceExportFragments(
 
   const site = await resolveResourceSite(config, options?.site ?? '/global', dependencies);
   const siteToken = resolveSiteToken(site.friendlyUrlPath);
-  const baseOutputDir = options?.dir?.trim()
-    ? path.resolve(resolveRepoPath(config, options.dir))
-    : path.join(resolveFragmentsBaseDir(config), 'sites', siteToken);
-  const outputDir = path.resolve(baseOutputDir);
+  const outputDir = resolveArtifactSiteDir(config, 'fragment', siteToken, options?.dir);
   const srcDir = path.join(outputDir, 'src');
 
   await fs.remove(srcDir);
@@ -95,7 +91,7 @@ export async function runLiferayResourceExportFragments(
 
     const collectionKey =
       String(collection.fragmentCollectionKey ?? '').trim() ||
-      sanitizeFileToken(String(collection.name ?? 'collection'));
+      sanitizeArtifactToken(String(collection.name ?? 'collection'));
     const collectionDir = path.join(srcDir, collectionKey);
     await fs.ensureDir(path.join(collectionDir, 'fragments'));
     await writeJson(path.join(collectionDir, 'collection.json'), {
@@ -115,7 +111,7 @@ export async function runLiferayResourceExportFragments(
       }
 
       const fragmentKey =
-        String(fragment.fragmentEntryKey ?? '').trim() || sanitizeFileToken(String(fragment.name ?? 'fragment'));
+        String(fragment.fragmentEntryKey ?? '').trim() || sanitizeArtifactToken(String(fragment.name ?? 'fragment'));
       const fragmentDir = path.join(collectionDir, 'fragments', fragmentKey);
       await fs.ensureDir(fragmentDir);
       await fs.writeFile(path.join(fragmentDir, 'index.html'), String(fragment.html ?? ''));
@@ -180,14 +176,6 @@ export function formatLiferayResourceExportFragments(result: LiferayResourceExpo
 async function writeJson(filePath: string, payload: unknown): Promise<void> {
   await fs.ensureDir(path.dirname(filePath));
   await fs.writeFile(filePath, `${JSON.stringify(payload, null, 2)}\n`);
-}
-
-function sanitizeFileToken(value: string): string {
-  const normalized = value
-    .trim()
-    .replaceAll(/[^A-Za-z0-9_.-]+/g, '_')
-    .replaceAll(/_+/g, '_');
-  return normalized === '' ? 'unnamed' : normalized;
 }
 
 function defaultFragmentConfiguration(): {fieldSets: Array<{fields: Array<Record<string, string>>}>} {

--- a/src/features/liferay/resource/liferay-resource-export-fragments.ts
+++ b/src/features/liferay/resource/liferay-resource-export-fragments.ts
@@ -68,9 +68,7 @@ export async function runLiferayResourceExportFragments(
   const siteToken = resolveSiteToken(site.friendlyUrlPath);
   const outputDir = resolveArtifactSiteDir(config, 'fragment', siteToken, options?.dir);
   const srcDir = path.join(outputDir, 'src');
-
-  await fs.remove(srcDir);
-  await fs.ensureDir(srcDir);
+  let initializedOutput = false;
 
   const collections = await listFragmentCollections(config, site.id, dependencies);
   let collectionCount = 0;
@@ -89,6 +87,27 @@ export async function runLiferayResourceExportFragments(
       }
     }
 
+    const fragments = await listFragments(config, collectionId, dependencies);
+    const filteredFragments = fragments.filter((fragment) => {
+      if (!options?.fragment) {
+        return true;
+      }
+
+      const fragmentKey = String(fragment.fragmentEntryKey ?? '');
+      const fragmentName = String(fragment.name ?? '');
+      return [fragmentKey, fragmentName].includes(options.fragment);
+    });
+
+    if (filteredFragments.length === 0) {
+      continue;
+    }
+
+    if (!initializedOutput) {
+      await fs.remove(srcDir);
+      await fs.ensureDir(srcDir);
+      initializedOutput = true;
+    }
+
     const collectionKey =
       String(collection.fragmentCollectionKey ?? '').trim() ||
       sanitizeArtifactToken(String(collection.name ?? 'collection'));
@@ -99,17 +118,7 @@ export async function runLiferayResourceExportFragments(
       description: String(collection.description ?? ''),
     });
 
-    const fragments = await listFragments(config, collectionId, dependencies);
-    let collectionHasFragments = false;
-    for (const fragment of fragments) {
-      if (options?.fragment) {
-        const fragmentKey = String(fragment.fragmentEntryKey ?? '');
-        const fragmentName = String(fragment.name ?? '');
-        if (![fragmentKey, fragmentName].includes(options.fragment)) {
-          continue;
-        }
-      }
-
+    for (const fragment of filteredFragments) {
       const fragmentKey =
         String(fragment.fragmentEntryKey ?? '').trim() || sanitizeArtifactToken(String(fragment.name ?? 'fragment'));
       const fragmentDir = path.join(collectionDir, 'fragments', fragmentKey);
@@ -144,16 +153,9 @@ export async function runLiferayResourceExportFragments(
         name: String(fragment.name ?? fragmentKey),
         type: Number(fragment.type ?? 0) === 1 ? 'section' : 'component',
       });
-
-      collectionHasFragments = true;
       fragmentCount += 1;
     }
-
-    if (collectionHasFragments) {
-      collectionCount += 1;
-    } else {
-      await fs.remove(collectionDir);
-    }
+    collectionCount += 1;
   }
 
   return {

--- a/src/features/liferay/resource/liferay-resource-export-structure.ts
+++ b/src/features/liferay/resource/liferay-resource-export-structure.ts
@@ -1,11 +1,12 @@
 import type {AppConfig} from '../../../core/config/load-config.js';
 import type {OAuthTokenClient} from '../../../core/http/auth.js';
 import type {LiferayApiClient} from '../../../core/http/client.js';
-import {resolveStructuresBaseDir, resolveSiteToken} from './liferay-resource-paths.js';
+import {resolveSiteToken} from './liferay-resource-paths.js';
 import {runLiferayResourceGetStructure} from './liferay-resource-get-structure.js';
 import {writeLiferayResourceFile} from './liferay-resource-export-shared.js';
 import {normalizeLiferayStructurePayload} from './liferay-resource-structure-normalize.js';
 import path from 'node:path';
+import {resolveArtifactSiteDir} from './artifact-paths.js';
 
 type ResourceDependencies = {
   apiClient?: LiferayApiClient;
@@ -22,9 +23,10 @@ export async function runLiferayResourceExportStructure(
     {site: options.site, key: options.key, id: options.id},
     dependencies,
   );
+  const siteToken = resolveSiteToken(result.siteFriendlyUrl);
   const outputPath = await writeLiferayResourceFile(
     result.raw,
-    options.output ?? buildDefaultOutputPath(config, result.siteFriendlyUrl, result.key),
+    options.output ?? path.join(resolveArtifactSiteDir(config, 'structure', siteToken), `${result.key}.json`),
     {
       payloadNormalizer: normalizeLiferayStructurePayload,
       pretty: options.pretty,
@@ -32,8 +34,4 @@ export async function runLiferayResourceExportStructure(
   );
 
   return {outputPath};
-}
-
-function buildDefaultOutputPath(config: AppConfig, siteFriendlyUrl: string, key: string): string {
-  return path.join(resolveStructuresBaseDir(config), resolveSiteToken(siteFriendlyUrl), `${key}.json`);
 }

--- a/src/features/liferay/resource/liferay-resource-export-structures.ts
+++ b/src/features/liferay/resource/liferay-resource-export-structures.ts
@@ -8,7 +8,8 @@ import {runLiferayInventorySitesIncludingGlobal} from '../inventory/liferay-inve
 import {runLiferayInventoryStructures} from '../inventory/liferay-inventory-structures.js';
 import {runLiferayResourceGetStructure} from './liferay-resource-get-structure.js';
 import {writeLiferayResourceFile} from './liferay-resource-export-shared.js';
-import {resolveRepoPath, resolveSiteToken, resolveStructuresBaseDir} from './liferay-resource-paths.js';
+import {resolveSiteToken} from './liferay-resource-paths.js';
+import {resolveArtifactSiteDir} from './artifact-paths.js';
 import {normalizeLiferayStructurePayload} from './liferay-resource-structure-normalize.js';
 
 type ResourceDependencies = {
@@ -110,7 +111,7 @@ async function exportStructuresForSite(
 ): Promise<LiferayResourceExportStructuresSiteResult> {
   const rows = await runLiferayInventoryStructures(config, {site}, dependencies);
   const siteToken = resolveSiteToken(site);
-  const outputDir = resolveStructuresOutputDir(config, dir, siteToken);
+  const outputDir = resolveArtifactSiteDir(config, 'structure', siteToken, dir);
   let processed = 0;
   let diffs = 0;
 
@@ -145,14 +146,6 @@ async function exportStructuresForSite(
     processed,
     diffs,
   };
-}
-
-function resolveStructuresOutputDir(config: AppConfig, dir: string | undefined, siteToken: string): string {
-  if ((dir ?? '').trim() !== '') {
-    return path.join(path.resolve(resolveRepoPath(config, dir ?? '')), siteToken);
-  }
-
-  return path.join(resolveStructuresBaseDir(config), siteToken);
 }
 
 async function fileDiffers(filePath: string, payload: unknown): Promise<boolean> {

--- a/src/features/liferay/resource/liferay-resource-export-template.ts
+++ b/src/features/liferay/resource/liferay-resource-export-template.ts
@@ -2,10 +2,11 @@ import type {AppConfig} from '../../../core/config/load-config.js';
 import type {OAuthTokenClient} from '../../../core/http/auth.js';
 import type {LiferayApiClient} from '../../../core/http/client.js';
 import path from 'node:path';
-import {resolveSiteToken, resolveTemplatesBaseDir} from './liferay-resource-paths.js';
+import {resolveSiteToken} from './liferay-resource-paths.js';
 import {runLiferayResourceGetTemplate} from './liferay-resource-get-template.js';
 import fs from 'fs-extra';
 import {normalizeLiferayTemplateScript} from './liferay-resource-template-normalize.js';
+import {resolveArtifactSiteDir} from './artifact-paths.js';
 
 type ResourceDependencies = {
   apiClient?: LiferayApiClient;
@@ -18,15 +19,12 @@ export async function runLiferayResourceExportTemplate(
   dependencies?: ResourceDependencies,
 ): Promise<{outputPath: string}> {
   const result = await runLiferayResourceGetTemplate(config, {site: options.site, id: options.id}, dependencies);
+  const siteToken = resolveSiteToken(result.siteFriendlyUrl);
   const outputPath = path.resolve(
-    options.output ?? buildDefaultOutputPath(config, result.siteFriendlyUrl, result.templateKey),
+    options.output ?? path.join(resolveArtifactSiteDir(config, 'template', siteToken), `${result.templateKey}.ftl`),
   );
   await fs.ensureDir(path.dirname(outputPath));
   await fs.writeFile(outputPath, normalizeLiferayTemplateScript(result.templateScript));
 
   return {outputPath};
-}
-
-function buildDefaultOutputPath(config: AppConfig, siteFriendlyUrl: string, templateKey: string): string {
-  return path.join(resolveTemplatesBaseDir(config), resolveSiteToken(siteFriendlyUrl), `${templateKey}.ftl`);
 }

--- a/src/features/liferay/resource/liferay-resource-export-templates.ts
+++ b/src/features/liferay/resource/liferay-resource-export-templates.ts
@@ -8,7 +8,8 @@ import type {LiferayApiClient} from '../../../core/http/client.js';
 import {runLiferayInventorySitesIncludingGlobal} from '../inventory/liferay-inventory-sites.js';
 import {runLiferayInventoryTemplates, type LiferayInventoryTemplate} from '../inventory/liferay-inventory-templates.js';
 import {listDdmTemplates} from './liferay-resource-shared.js';
-import {resolveTemplatesBaseDir, resolveRepoPath, resolveSiteToken} from './liferay-resource-paths.js';
+import {resolveSiteToken} from './liferay-resource-paths.js';
+import {resolveArtifactBaseDir, sanitizeArtifactToken} from './artifact-paths.js';
 import {resolveResourceSite} from './liferay-resource-shared.js';
 import {normalizeLiferayTemplateScript} from './liferay-resource-template-normalize.js';
 
@@ -44,7 +45,7 @@ export async function runLiferayResourceExportTemplates(
   options?: {site?: string; dir?: string; allSites?: boolean; continueOnError?: boolean; debug?: boolean},
   dependencies?: ResourceDependencies,
 ): Promise<LiferayResourceExportTemplatesResult> {
-  const baseDir = resolveTemplatesOutputBaseDir(config, options?.dir);
+  const baseDir = resolveArtifactBaseDir(config, 'template', options?.dir);
 
   if (options?.allSites) {
     const sites = await runLiferayInventorySitesIncludingGlobal(config, undefined, dependencies);
@@ -150,7 +151,7 @@ async function exportTemplatesForSite(
         throw new CliError('templateScript is empty', {code: 'LIFERAY_RESOURCE_ERROR'});
       }
 
-      const outputName = `${sanitizeFileToken(resolveTemplateExportName(template))}.ftl`;
+      const outputName = `${sanitizeArtifactToken(resolveTemplateExportName(template))}.ftl`;
       const filePath = path.join(outputDir, outputName);
       await fs.ensureDir(path.dirname(filePath));
       await fs.writeFile(filePath, script);
@@ -175,14 +176,6 @@ async function exportTemplatesForSite(
     failed,
     debug: debugEnabled ? debug : undefined,
   };
-}
-
-function resolveTemplatesOutputBaseDir(config: AppConfig, dir: string | undefined): string {
-  if ((dir ?? '').trim() !== '') {
-    return path.resolve(resolveRepoPath(config, dir ?? ''));
-  }
-
-  return resolveTemplatesBaseDir(config);
 }
 
 async function listTemplatesForExport(
@@ -237,12 +230,4 @@ function resolveTemplateExportName(template: LiferayInventoryTemplate): string {
     return template.name;
   }
   return 'template';
-}
-
-function sanitizeFileToken(value: string): string {
-  const normalized = value
-    .trim()
-    .replaceAll(/[^A-Za-z0-9_.-]+/g, '_')
-    .replaceAll(/_+/g, '_');
-  return normalized === '' ? 'unnamed' : normalized;
 }

--- a/src/features/liferay/resource/liferay-resource-paths.ts
+++ b/src/features/liferay/resource/liferay-resource-paths.ts
@@ -1,95 +1,24 @@
-import fs from 'fs-extra';
-import path from 'node:path';
-
-import {CliError} from '../../../core/errors.js';
 import type {AppConfig} from '../../../core/config/load-config.js';
 
-export const ADT_WIDGET_DIR_BY_TYPE: Record<string, string> = {
-  'asset-entry': 'asset_entry',
-  breadcrumb: 'breadcrumb',
-  'category-facet': 'category_facet',
-  'custom-facet': 'custom_facet',
-  'custom-filter': 'custom_filter',
-  'language-selector': 'language_selector',
-  'navigation-menu': 'navigation_menu',
-  'search-result-summary': 'search_result_summary',
-  searchbar: 'searchbar',
-  'similar-results': 'search_results',
-};
+export {
+  ADT_WIDGET_DIR_BY_TYPE,
+  requireRepoRoot,
+  resolveAdtsBaseDir,
+  resolveFragmentsBaseDir,
+  resolveMigrationsBaseDir,
+  resolveRepoPath,
+  resolveSiteToken,
+  resolveStructuresBaseDir,
+  resolveTemplatesBaseDir,
+} from './artifact-paths.js';
 
-export function requireRepoRoot(config: AppConfig): string {
-  if (!config.repoRoot) {
-    throw new CliError('This command must be run inside a project repository.', {
-      code: 'LIFERAY_REPO_NOT_FOUND',
-    });
-  }
-
-  return config.repoRoot;
-}
-
-export function resolveRepoPath(config: AppConfig, relativePath: string): string {
-  return path.resolve(requireRepoRoot(config), relativePath);
-}
-
-export function resolveStructuresBaseDir(config: AppConfig): string {
-  return resolveRepoPath(config, config.paths?.structures ?? 'liferay/resources/journal/structures');
-}
-
-export function resolveTemplatesBaseDir(config: AppConfig): string {
-  return resolveRepoPath(config, config.paths?.templates ?? 'liferay/resources/journal/templates');
-}
-
-export function resolveAdtsBaseDir(config: AppConfig): string {
-  return resolveRepoPath(config, config.paths?.adts ?? 'liferay/resources/templates/application_display');
-}
-
-export function resolveFragmentsBaseDir(config: AppConfig): string {
-  return resolveRepoPath(config, config.paths?.fragments ?? 'liferay/fragments');
-}
-
-export function resolveMigrationsBaseDir(config: AppConfig): string {
-  return resolveRepoPath(config, config.paths?.migrations ?? 'liferay/resources/journal/migrations');
-}
-
-/**
- * Creates a standardized error for missing .liferay-cli.yml configuration.
- * Used when paths are not configured and --file is not provided.
- */
-function createConfigIncompleteError(resourceType: string, exampleName: string): CliError {
-  return new CliError(
-    `${resourceType} file not found for '${exampleName}'.\n\n` +
-      `The project configuration is incomplete. To resolve this:\n` +
-      `  1. Use --file to specify the full path directly (quick workaround)\n` +
-      `  2. Create .liferay-cli.yml in the repository root with paths configuration\n` +
-      `  3. Run 'ldev project init' to scaffold the configuration file\n\n` +
-      `See: https://ldev.dev/reference/configuration#liferay-cli-yml`,
-    {code: 'LIFERAY_CONFIG_INCOMPLETE'},
-  );
-}
+import {resolveArtifactFile} from './artifact-paths.js';
 
 export async function resolveStructureFile(config: AppConfig, key: string, file?: string): Promise<string> {
-  if (file) {
-    return resolveExistingResourceFile(config, file);
-  }
-
-  // Detect missing configuration before searching
-  if (!config.paths?.structures) {
-    throw createConfigIncompleteError('Structure', key);
-  }
-
-  const baseDir = resolveStructuresBaseDir(config);
-  const matches = await findFilesByName(baseDir, `${key}.json`);
-  if (matches.length === 1) {
-    return matches[0]!;
-  }
-  if (matches.length > 1) {
-    throw new CliError(`Structure file ambiguo para ${key}: ${matches.join(', ')}`, {
-      code: 'LIFERAY_RESOURCE_FILE_AMBIGUOUS',
-    });
-  }
-
-  throw new CliError(`Structure file not found for ${key} in ${baseDir}. Use --file.`, {
-    code: 'LIFERAY_RESOURCE_FILE_NOT_FOUND',
+  return resolveArtifactFile(config, {
+    type: 'structure',
+    key,
+    fileOverride: file,
   });
 }
 
@@ -99,40 +28,11 @@ export async function resolveTemplateFile(
   name: string,
   file?: string,
 ): Promise<string> {
-  if (file) {
-    return resolveExistingResourceFile(config, file);
-  }
-
-  // Detect missing configuration before searching
-  if (!config.paths?.templates) {
-    throw createConfigIncompleteError('Template', name);
-  }
-
-  const baseDir = resolveTemplatesBaseDir(config);
-  const candidates = [
-    path.join(baseDir, siteToken, `${name}.ftl`),
-    siteToken === 'global' ? null : path.join(baseDir, 'global', `${name}.ftl`),
-    path.join(baseDir, `${name}.ftl`),
-  ].filter(Boolean) as string[];
-
-  for (const candidate of candidates) {
-    if (await fs.pathExists(candidate)) {
-      return candidate;
-    }
-  }
-
-  const matches = await findFilesByName(baseDir, `${name}.ftl`);
-  if (matches.length === 1) {
-    return matches[0]!;
-  }
-  if (matches.length > 1) {
-    throw new CliError(`Template file ambiguo para ${name}: ${matches.join(', ')}`, {
-      code: 'LIFERAY_RESOURCE_FILE_AMBIGUOUS',
-    });
-  }
-
-  throw new CliError(`Template file not found for ${name} in ${baseDir}. Use --file.`, {
-    code: 'LIFERAY_RESOURCE_FILE_NOT_FOUND',
+  return resolveArtifactFile(config, {
+    type: 'template',
+    key: name,
+    siteToken,
+    fileOverride: file,
   });
 }
 
@@ -142,111 +42,10 @@ export async function resolveAdtFile(
   widgetType: string,
   file?: string,
 ): Promise<string> {
-  if (file) {
-    return resolveExistingResourceFile(config, file);
-  }
-
-  // Detect missing configuration before searching
-  if (!config.paths?.adts) {
-    throw createConfigIncompleteError(`ADT (${widgetType})`, name);
-  }
-
-  const baseDir = resolveAdtsBaseDir(config);
-  const widgetDir = ADT_WIDGET_DIR_BY_TYPE[widgetType];
-  if (!widgetDir) {
-    throw new CliError(`widget-type ADT no soportado: ${widgetType}`, {
-      code: 'LIFERAY_RESOURCE_ERROR',
-    });
-  }
-
-  const matches = await findFilesByPathSuffix(baseDir, path.join(widgetDir, `${name}.ftl`));
-  if (matches.length === 1) {
-    return matches[0]!;
-  }
-  if (matches.length > 1) {
-    throw new CliError(`ADT file ambiguo para ${name} (${widgetType}): ${matches.join(', ')}`, {
-      code: 'LIFERAY_RESOURCE_FILE_AMBIGUOUS',
-    });
-  }
-
-  throw new CliError(`ADT file not found for ${name} (${widgetType}) in ${baseDir}. Use --file.`, {
-    code: 'LIFERAY_RESOURCE_FILE_NOT_FOUND',
+  return resolveArtifactFile(config, {
+    type: 'adt',
+    key: name,
+    widgetType,
+    fileOverride: file,
   });
-}
-
-export function resolveSiteToken(siteFriendlyUrl: string): string {
-  const token = siteFriendlyUrl.replace(/^\//, '').trim();
-  return token === '' ? 'global' : token;
-}
-
-async function resolveExistingResourceFile(config: AppConfig, candidate: string): Promise<string> {
-  const repoRoot = requireRepoRoot(config);
-  const direct = path.resolve(candidate);
-  if (await fs.pathExists(direct)) {
-    return direct;
-  }
-
-  const relativeToRepo = path.resolve(repoRoot, candidate);
-  if (await fs.pathExists(relativeToRepo)) {
-    return relativeToRepo;
-  }
-
-  for (const baseDir of [
-    resolveStructuresBaseDir(config),
-    resolveTemplatesBaseDir(config),
-    resolveAdtsBaseDir(config),
-  ]) {
-    const nested = path.resolve(baseDir, candidate);
-    if (await fs.pathExists(nested)) {
-      return nested;
-    }
-  }
-
-  throw new CliError(`File not found: ${candidate}`, {
-    code: 'LIFERAY_RESOURCE_FILE_NOT_FOUND',
-  });
-}
-
-async function findFilesByName(baseDir: string, filename: string): Promise<string[]> {
-  if (!(await fs.pathExists(baseDir))) {
-    return [];
-  }
-
-  const matches: string[] = [];
-  await walk(baseDir, async (entryPath) => {
-    if (path.basename(entryPath) === filename) {
-      matches.push(entryPath);
-    }
-  });
-  return matches.sort();
-}
-
-async function findFilesByPathSuffix(baseDir: string, suffixPath: string): Promise<string[]> {
-  if (!(await fs.pathExists(baseDir))) {
-    return [];
-  }
-
-  const normalizedSuffix = suffixPath.split(path.sep).join('/');
-  const matches: string[] = [];
-  await walk(baseDir, async (entryPath) => {
-    const normalized = entryPath.split(path.sep).join('/');
-    if (normalized.endsWith(normalizedSuffix)) {
-      matches.push(entryPath);
-    }
-  });
-  return matches.sort();
-}
-
-async function walk(dir: string, visit: (entryPath: string) => Promise<void>): Promise<void> {
-  const entries = await fs.readdir(dir, {withFileTypes: true});
-  for (const entry of entries) {
-    const entryPath = path.join(dir, entry.name);
-    if (entry.isDirectory()) {
-      await walk(entryPath, visit);
-      continue;
-    }
-    if (entry.isFile()) {
-      await visit(entryPath);
-    }
-  }
 }

--- a/src/features/liferay/resource/liferay-resource-sync-fragments-local.ts
+++ b/src/features/liferay/resource/liferay-resource-sync-fragments-local.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 
 import {CliError} from '../../../core/errors.js';
 import type {AppConfig} from '../../../core/config/load-config.js';
-import {resolveFragmentsBaseDir, resolveRepoPath} from './liferay-resource-paths.js';
+import {resolveFragmentProjectDir as resolveArtifactFragmentProjectDir} from './artifact-paths.js';
 import type {
   LocalFragment,
   LocalFragmentCollection,
@@ -11,43 +11,7 @@ import type {
 } from './liferay-resource-sync-fragments-types.js';
 
 export function resolveFragmentsProjectDir(config: AppConfig, dir: string | undefined, siteToken: string): string {
-  if ((dir ?? '').trim() === '') {
-    return path.join(resolveFragmentsBaseDir(config), 'sites', siteToken);
-  }
-
-  const configured = path.resolve(resolveRepoPath(config, dir ?? ''));
-  const detectedFromConfigured = detectFragmentsProjectRoot(configured);
-  if (detectedFromConfigured) {
-    return detectedFromConfigured;
-  }
-
-  const configuredWithSite = path.join(configured, siteToken);
-  const detectedFromSitePath = detectFragmentsProjectRoot(configuredWithSite);
-  if (detectedFromSitePath) {
-    return detectedFromSitePath;
-  }
-
-  return configuredWithSite;
-}
-
-function detectFragmentsProjectRoot(startPath: string): string | null {
-  let current = path.resolve(startPath);
-
-  while (true) {
-    if (fs.existsSync(path.join(current, 'src'))) {
-      return current;
-    }
-
-    if (path.basename(current).toLowerCase() === 'src') {
-      return path.dirname(current);
-    }
-
-    const parent = path.dirname(current);
-    if (parent === current) {
-      return null;
-    }
-    current = parent;
-  }
+  return resolveArtifactFragmentProjectDir(config, siteToken, dir);
 }
 
 export async function readLocalFragmentsProject(
@@ -116,13 +80,7 @@ export async function readLocalFragmentsProject(
   };
 }
 
-export function sanitizeFileToken(value: string): string {
-  const normalized = value
-    .trim()
-    .replaceAll(/[^A-Za-z0-9_.-]+/g, '_')
-    .replaceAll(/_+/g, '_');
-  return normalized === '' ? 'unnamed' : normalized;
-}
+export {sanitizeArtifactToken as sanitizeFileToken} from './artifact-paths.js';
 
 export function toErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);

--- a/tests/unit/liferay-artifact-paths.test.ts
+++ b/tests/unit/liferay-artifact-paths.test.ts
@@ -1,0 +1,365 @@
+import fs from 'fs-extra';
+import path from 'node:path';
+import {describe, expect, test} from 'vitest';
+
+import {
+  resolveArtifactFile,
+  resolveArtifactBaseDir,
+  resolveArtifactSiteDir,
+  resolveFragmentProjectDir,
+  sanitizeArtifactToken,
+  type ArtifactType,
+} from '../../src/features/liferay/resource/artifact-paths.js';
+import {createTempDir} from '../../src/testing/temp-repo.js';
+
+// ---------------------------------------------------------------------------
+// Minimal config fixture (no filesystem access needed for path tests)
+// ---------------------------------------------------------------------------
+
+const REPO_ROOT = path.resolve('/repo');
+
+function makeConfig(paths?: {templates?: string; structures?: string; adts?: string; fragments?: string}) {
+  return {
+    repoRoot: REPO_ROOT,
+    cwd: REPO_ROOT,
+    paths: paths ?? {
+      templates: 'liferay/resources/journal/templates',
+      structures: 'liferay/resources/journal/structures',
+      adts: 'liferay/resources/templates/application_display',
+      fragments: 'liferay/fragments',
+    },
+  } as Parameters<typeof resolveArtifactBaseDir>[0];
+}
+
+// ---------------------------------------------------------------------------
+// sanitizeArtifactToken
+// ---------------------------------------------------------------------------
+
+describe('sanitizeArtifactToken', () => {
+  test('alphanumeric passes through unchanged', () => {
+    expect(sanitizeArtifactToken('myTemplate')).toBe('myTemplate');
+  });
+
+  test('spaces replaced by underscore', () => {
+    expect(sanitizeArtifactToken('my template')).toBe('my_template');
+  });
+
+  test('multiple consecutive spaces collapse to one underscore', () => {
+    expect(sanitizeArtifactToken('a  b__c')).toBe('a_b_c');
+  });
+
+  test('dashes are preserved (allowed in charset)', () => {
+    expect(sanitizeArtifactToken('a--b')).toBe('a--b');
+  });
+
+  test('dots and dashes are preserved', () => {
+    expect(sanitizeArtifactToken('my-template.v2')).toBe('my-template.v2');
+  });
+
+  test('empty string returns unnamed', () => {
+    expect(sanitizeArtifactToken('')).toBe('unnamed');
+  });
+
+  test('only specials (non-empty after trim) returns underscore', () => {
+    expect(sanitizeArtifactToken('  !!  ')).toBe('_');
+  });
+
+  test('only whitespace (empty after trim) returns unnamed', () => {
+    expect(sanitizeArtifactToken('   ')).toBe('unnamed');
+  });
+
+  test('leading/trailing spaces are trimmed before processing', () => {
+    expect(sanitizeArtifactToken('  hello world  ')).toBe('hello_world');
+  });
+
+  test('unicode chars are replaced', () => {
+    expect(sanitizeArtifactToken('café')).toBe('caf_');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveArtifactBaseDir – default paths (no dirOverride)
+// ---------------------------------------------------------------------------
+
+describe('resolveArtifactBaseDir – defaults', () => {
+  const cfg = makeConfig();
+
+  test('template → configured templates base dir', () => {
+    expect(resolveArtifactBaseDir(cfg, 'template')).toBe(path.join(REPO_ROOT, 'liferay/resources/journal/templates'));
+  });
+
+  test('structure → configured structures base dir', () => {
+    expect(resolveArtifactBaseDir(cfg, 'structure')).toBe(path.join(REPO_ROOT, 'liferay/resources/journal/structures'));
+  });
+
+  test('adt → configured adts base dir', () => {
+    expect(resolveArtifactBaseDir(cfg, 'adt')).toBe(
+      path.join(REPO_ROOT, 'liferay/resources/templates/application_display'),
+    );
+  });
+
+  test('fragment → configured fragments base dir (without sites/)', () => {
+    expect(resolveArtifactBaseDir(cfg, 'fragment')).toBe(path.join(REPO_ROOT, 'liferay/fragments'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveArtifactBaseDir – dirOverride
+// ---------------------------------------------------------------------------
+
+describe('resolveArtifactBaseDir – dirOverride', () => {
+  const cfg = makeConfig();
+
+  test.each(['template', 'structure', 'adt', 'fragment'] as ArtifactType[])(
+    '%s: absolute dirOverride is used as-is',
+    (type) => {
+      const override = path.resolve('/custom/dir');
+      expect(resolveArtifactBaseDir(cfg, type, override)).toBe(override);
+    },
+  );
+
+  test.each(['template', 'structure', 'adt', 'fragment'] as ArtifactType[])(
+    '%s: relative dirOverride is resolved against repoRoot',
+    (type) => {
+      expect(resolveArtifactBaseDir(cfg, type, 'custom/out')).toBe(path.join(REPO_ROOT, 'custom/out'));
+    },
+  );
+
+  test.each(['template', 'structure', 'adt', 'fragment'] as ArtifactType[])(
+    '%s: blank/whitespace dirOverride falls back to default',
+    (type) => {
+      const defaultDir = resolveArtifactBaseDir(cfg, type);
+      expect(resolveArtifactBaseDir(cfg, type, '   ')).toBe(defaultDir);
+      expect(resolveArtifactBaseDir(cfg, type, undefined)).toBe(defaultDir);
+    },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// resolveArtifactSiteDir – templates / structures / adts (baseDir + siteToken)
+// ---------------------------------------------------------------------------
+
+describe('resolveArtifactSiteDir – non-fragment types', () => {
+  const cfg = makeConfig();
+
+  test('template: appends siteToken to templates base dir', () => {
+    expect(resolveArtifactSiteDir(cfg, 'template', 'my-site')).toBe(
+      path.join(REPO_ROOT, 'liferay/resources/journal/templates', 'my-site'),
+    );
+  });
+
+  test('structure: appends siteToken to structures base dir', () => {
+    expect(resolveArtifactSiteDir(cfg, 'structure', 'global')).toBe(
+      path.join(REPO_ROOT, 'liferay/resources/journal/structures', 'global'),
+    );
+  });
+
+  test('adt: appends siteToken to adts base dir', () => {
+    expect(resolveArtifactSiteDir(cfg, 'adt', 'custom-site')).toBe(
+      path.join(REPO_ROOT, 'liferay/resources/templates/application_display', 'custom-site'),
+    );
+  });
+
+  test('template with dirOverride: appends siteToken to override dir', () => {
+    expect(resolveArtifactSiteDir(cfg, 'template', 'global', 'custom/templates')).toBe(
+      path.join(REPO_ROOT, 'custom/templates', 'global'),
+    );
+  });
+
+  test('structure with absolute dirOverride: appends siteToken to override', () => {
+    const override = path.resolve('/abs/structures');
+    expect(resolveArtifactSiteDir(cfg, 'structure', 'global', override)).toBe(path.join(override, 'global'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveArtifactSiteDir – fragment (historical 'sites/' prefix)
+// ---------------------------------------------------------------------------
+
+describe('resolveArtifactSiteDir – fragment (compat sites/ prefix)', () => {
+  const cfg = makeConfig();
+
+  test('no dirOverride: uses fragmentsBaseDir/sites/siteToken', () => {
+    expect(resolveArtifactSiteDir(cfg, 'fragment', 'my-site')).toBe(
+      path.join(REPO_ROOT, 'liferay/fragments', 'sites', 'my-site'),
+    );
+  });
+
+  test('global site: uses sites/global subdir', () => {
+    expect(resolveArtifactSiteDir(cfg, 'fragment', 'global')).toBe(
+      path.join(REPO_ROOT, 'liferay/fragments', 'sites', 'global'),
+    );
+  });
+
+  test('with dirOverride: returns dirOverride directly (legacy --dir behavior, no sites/ prefix)', () => {
+    // When --dir is provided for fragments, it IS the project root for that site
+    expect(resolveArtifactSiteDir(cfg, 'fragment', 'my-site', 'my/fragments/project')).toBe(
+      path.join(REPO_ROOT, 'my/fragments/project'),
+    );
+  });
+
+  test('with absolute dirOverride: returns it directly', () => {
+    const override = path.resolve('/abs/fragments/project');
+    expect(resolveArtifactSiteDir(cfg, 'fragment', 'my-site', override)).toBe(override);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveArtifactBaseDir / resolveArtifactSiteDir – fallback default paths
+// (when config.paths is not set)
+// ---------------------------------------------------------------------------
+
+describe('resolveArtifactBaseDir – fallback default paths', () => {
+  const cfgNoPathsKey = {
+    repoRoot: REPO_ROOT,
+    cwd: REPO_ROOT,
+    paths: undefined,
+  } as Parameters<typeof resolveArtifactBaseDir>[0];
+
+  test('template falls back to liferay/resources/journal/templates', () => {
+    expect(resolveArtifactBaseDir(cfgNoPathsKey, 'template')).toBe(
+      path.join(REPO_ROOT, 'liferay/resources/journal/templates'),
+    );
+  });
+
+  test('structure falls back to liferay/resources/journal/structures', () => {
+    expect(resolveArtifactBaseDir(cfgNoPathsKey, 'structure')).toBe(
+      path.join(REPO_ROOT, 'liferay/resources/journal/structures'),
+    );
+  });
+
+  test('adt falls back to liferay/resources/templates/application_display', () => {
+    expect(resolveArtifactBaseDir(cfgNoPathsKey, 'adt')).toBe(
+      path.join(REPO_ROOT, 'liferay/resources/templates/application_display'),
+    );
+  });
+
+  test('fragment falls back to liferay/fragments', () => {
+    expect(resolveArtifactBaseDir(cfgNoPathsKey, 'fragment')).toBe(path.join(REPO_ROOT, 'liferay/fragments'));
+  });
+});
+
+describe('resolveArtifactFile', () => {
+  test('template uses fileOverride relative to repo root', async () => {
+    const repoRoot = createTempDir('artifact-paths-template-file-');
+    const filePath = path.join(repoRoot, 'custom', 'NEWS.ftl');
+    await fs.ensureDir(path.dirname(filePath));
+    await fs.writeFile(filePath, '<#-- news -->');
+
+    const config = makeConfig({
+      templates: 'liferay/resources/journal/templates',
+      structures: 'liferay/resources/journal/structures',
+      adts: 'liferay/resources/templates/application_display',
+      fragments: 'liferay/fragments',
+    });
+    config.repoRoot = repoRoot;
+    config.cwd = repoRoot;
+
+    await expect(
+      resolveArtifactFile(config, {
+        type: 'template',
+        key: 'NEWS',
+        siteToken: 'global',
+        fileOverride: 'custom/NEWS.ftl',
+      }),
+    ).resolves.toBe(filePath);
+  });
+
+  test('template falls back from siteToken to global path', async () => {
+    const repoRoot = createTempDir('artifact-paths-template-global-fallback-');
+    const filePath = path.join(repoRoot, 'liferay', 'resources', 'journal', 'templates', 'global', 'NEWS.ftl');
+    await fs.ensureDir(path.dirname(filePath));
+    await fs.writeFile(filePath, '<#-- news -->');
+
+    const config = makeConfig();
+    config.repoRoot = repoRoot;
+    config.cwd = repoRoot;
+
+    await expect(resolveArtifactFile(config, {type: 'template', key: 'NEWS', siteToken: 'guest'})).resolves.toBe(
+      filePath,
+    );
+  });
+
+  test('structure keeps historical name-based lookup across site folders', async () => {
+    const repoRoot = createTempDir('artifact-paths-structure-lookup-');
+    const filePath = path.join(repoRoot, 'liferay', 'resources', 'journal', 'structures', 'guest', 'BASIC.json');
+    await fs.ensureDir(path.dirname(filePath));
+    await fs.writeJson(filePath, {dataDefinitionKey: 'BASIC'});
+
+    const config = makeConfig();
+    config.repoRoot = repoRoot;
+    config.cwd = repoRoot;
+
+    await expect(resolveArtifactFile(config, {type: 'structure', key: 'BASIC'})).resolves.toBe(filePath);
+  });
+
+  test('adt keeps historical widget-dir suffix lookup', async () => {
+    const repoRoot = createTempDir('artifact-paths-adt-lookup-');
+    const filePath = path.join(
+      repoRoot,
+      'liferay',
+      'resources',
+      'templates',
+      'application_display',
+      'global',
+      'search_result_summary',
+      'RESULTS.ftl',
+    );
+    await fs.ensureDir(path.dirname(filePath));
+    await fs.writeFile(filePath, '<#-- adt -->');
+
+    const config = makeConfig();
+    config.repoRoot = repoRoot;
+    config.cwd = repoRoot;
+
+    await expect(
+      resolveArtifactFile(config, {type: 'adt', key: 'RESULTS', widgetType: 'search-result-summary'}),
+    ).resolves.toBe(filePath);
+  });
+});
+
+describe('resolveFragmentProjectDir', () => {
+  test('without dirOverride uses historical fragments/sites/siteToken path', () => {
+    const cfg = makeConfig();
+    expect(resolveFragmentProjectDir(cfg, 'global')).toBe(path.join(REPO_ROOT, 'liferay/fragments', 'sites', 'global'));
+  });
+
+  test('dirOverride pointing to project root is returned as-is', async () => {
+    const repoRoot = createTempDir('artifact-paths-fragments-root-');
+    const projectDir = path.join(repoRoot, 'custom-fragments');
+    await fs.ensureDir(path.join(projectDir, 'src'));
+
+    const config = makeConfig();
+    config.repoRoot = repoRoot;
+    config.cwd = repoRoot;
+
+    expect(resolveFragmentProjectDir(config, 'global', 'custom-fragments')).toBe(projectDir);
+  });
+
+  test('dirOverride pointing to nested fragment dir resolves back to project root', async () => {
+    const repoRoot = createTempDir('artifact-paths-fragments-nested-');
+    const projectDir = path.join(repoRoot, 'custom-fragments');
+    const nestedDir = path.join(projectDir, 'src', 'base', 'fragments', 'hero-banner');
+    await fs.ensureDir(nestedDir);
+
+    const config = makeConfig();
+    config.repoRoot = repoRoot;
+    config.cwd = repoRoot;
+
+    expect(resolveFragmentProjectDir(config, 'global', 'custom-fragments/src/base/fragments/hero-banner')).toBe(
+      projectDir,
+    );
+  });
+
+  test('dirOverride without src falls back to dir/siteToken for all-sites compatibility', async () => {
+    const repoRoot = createTempDir('artifact-paths-fragments-site-subdir-');
+    const siteDir = path.join(repoRoot, 'custom-fragments', 'guest');
+    await fs.ensureDir(siteDir);
+
+    const config = makeConfig();
+    config.repoRoot = repoRoot;
+    config.cwd = repoRoot;
+
+    expect(resolveFragmentProjectDir(config, 'guest', 'custom-fragments')).toBe(siteDir);
+  });
+});

--- a/tests/unit/liferay-resource-export.test.ts
+++ b/tests/unit/liferay-resource-export.test.ts
@@ -1185,6 +1185,95 @@ describe('liferay resource export', () => {
     ).toBe('');
   });
 
+  test('export-fragments --all-sites does not create directories for sites without fragments', async () => {
+    const dir = createTempDir('dev-cli-resource-export-fragments-no-empty-sites-');
+    const config = {
+      ...CONFIG,
+      repoRoot: dir,
+      cwd: dir,
+      dockerDir: path.join(dir, 'docker'),
+      liferayDir: path.join(dir, 'liferay'),
+      files: {
+        dockerEnv: path.join(dir, 'docker', '.env'),
+        liferayProfile: path.join(dir, '.liferay-cli.yml'),
+      },
+      paths: {
+        structures: 'liferay/resources/journal/structures',
+        templates: 'liferay/resources/journal/templates',
+        adts: 'liferay/resources/templates/application_display',
+        fragments: 'liferay/fragments',
+      },
+    };
+    await fs.ensureDir(path.join(dir, 'docker'));
+    await fs.writeFile(path.join(dir, 'docker', '.env'), '');
+
+    const apiClient = createLiferayApiClient({
+      fetchImpl: async (input) => {
+        const url = String(input);
+        if (url.includes('/o/headless-admin-site/v1.0/sites?page=1&pageSize=200')) {
+          return new Response('{"items":[],"lastPage":1}', {status: 200});
+        }
+        if (url.includes('/api/jsonws/company/get-companies')) {
+          return new Response('[{"companyId":10157}]', {status: 200});
+        }
+        if (url.includes('/api/jsonws/group/search-count?companyId=10157')) {
+          return new Response('1', {status: 200});
+        }
+        if (url.includes('/api/jsonws/group/search?companyId=10157')) {
+          return new Response(
+            '[{"groupId":20122,"friendlyURL":"/cataleg-estrategies","nameCurrentValue":"Cataleg","site":true}]',
+            {status: 200},
+          );
+        }
+        if (url.includes('/by-friendly-url-path/global')) {
+          return new Response('{"id":20121,"friendlyUrlPath":"/global","name":"Global"}', {status: 200});
+        }
+        if (url.includes('/by-friendly-url-path/cataleg-estrategies')) {
+          return new Response('{"id":20122,"friendlyUrlPath":"/cataleg-estrategies","name":"Cataleg"}', {status: 200});
+        }
+        if (url.includes('/api/jsonws/group/get-group?groupId=20121')) {
+          return new Response('{"companyId":10157}', {status: 200});
+        }
+        if (url.includes('/api/jsonws/group/get-group?groupId=20122')) {
+          return new Response('{"companyId":10157}', {status: 200});
+        }
+        if (url.includes('/api/jsonws/fragment.fragmentcollection/get-fragment-collections?groupId=20121')) {
+          return new Response(
+            '[{"fragmentCollectionId":501,"name":"Marketing","fragmentCollectionKey":"marketing","description":"Marketing fragments"}]',
+            {status: 200},
+          );
+        }
+        if (url.includes('/api/jsonws/fragment.fragmentcollection/get-fragment-collections?groupId=20122')) {
+          return new Response('[]', {status: 200});
+        }
+        if (url.includes('/api/jsonws/fragment.fragmententry/get-fragment-entries?fragmentCollectionId=501')) {
+          return new Response(
+            '[{"fragmentEntryId":601,"fragmentEntryKey":"hero-banner","name":"Hero Banner","icon":"square","type":1}]',
+            {status: 200},
+          );
+        }
+
+        throw new Error(`Unexpected URL ${url}`);
+      },
+    });
+
+    const result = await runLiferayResourceExportFragments(
+      config,
+      {allSites: true},
+      {apiClient, tokenClient: TOKEN_CLIENT},
+    );
+
+    expect(result.mode).toBe('all-sites');
+    expect(result.scannedSites).toBe(2);
+    expect(result.fragmentCount).toBe(1);
+    expect(await fs.pathExists(path.join(dir, 'liferay', 'fragments', 'sites', 'cataleg-estrategies'))).toBe(false);
+    expect(
+      await fs.pathExists(
+        path.join(dir, 'liferay', 'fragments', 'sites', 'global', 'src', 'marketing', 'fragments', 'hero-banner'),
+      ),
+    ).toBe(true);
+  });
+
   test('export-fragments keeps historical project-root behavior when --dir is provided', async () => {
     const dir = createTempDir('dev-cli-resource-export-fragments-dir-');
     const config = {

--- a/tests/unit/liferay-resource-export.test.ts
+++ b/tests/unit/liferay-resource-export.test.ts
@@ -538,6 +538,66 @@ describe('liferay resource export', () => {
     expect(formatLiferayResourceExportStructures(result)).toContain('EXPORTED site=/global count=1');
   });
 
+  test('exports all structures under dir/siteToken when --dir is provided', async () => {
+    const dir = createTempDir('dev-cli-resource-export-structures-dir-');
+    const config = {
+      ...CONFIG,
+      repoRoot: dir,
+      cwd: dir,
+      dockerDir: path.join(dir, 'docker'),
+      liferayDir: path.join(dir, 'liferay'),
+      files: {
+        dockerEnv: path.join(dir, 'docker', '.env'),
+        liferayProfile: path.join(dir, '.liferay-cli.yml'),
+      },
+      paths: {
+        structures: 'liferay/resources/journal/structures',
+        templates: 'liferay/resources/journal/templates',
+        adts: 'liferay/resources/templates/application_display',
+        fragments: 'liferay/fragments',
+      },
+    };
+    await fs.ensureDir(path.join(dir, 'docker'));
+    await fs.writeFile(path.join(dir, 'docker', '.env'), '');
+
+    const apiClient = createLiferayApiClient({
+      fetchImpl: async (input) => {
+        const url = String(input);
+        if (url.includes('/by-friendly-url-path/global')) {
+          return new Response('{"id":20121,"friendlyUrlPath":"/global","name":"Global"}', {status: 200});
+        }
+        if (
+          url.includes('/o/data-engine/v2.0/sites/20121/data-definitions/by-content-type/journal?page=1&pageSize=200')
+        ) {
+          return new Response(
+            '{"items":[{"id":301,"dataDefinitionKey":"BASIC-WEB-CONTENT","name":{"en_US":"Basic Web Content"}}],"lastPage":1,"page":1,"pageSize":200,"totalCount":1}',
+            {status: 200},
+          );
+        }
+        if (url.includes('/api/jsonws/group/get-group?groupId=20121')) {
+          return new Response('{"companyId":10157}', {status: 200});
+        }
+        if (url.includes('/by-data-definition-key/BASIC-WEB-CONTENT')) {
+          return new Response(
+            '{"id":301,"dataDefinitionKey":"BASIC-WEB-CONTENT","name":{"en_US":"Basic Web Content"}}',
+            {status: 200},
+          );
+        }
+
+        throw new Error(`Unexpected URL ${url}`);
+      },
+    });
+
+    const result = await runLiferayResourceExportStructures(
+      config,
+      {site: '/global', dir: 'custom-structures'},
+      {apiClient, tokenClient: TOKEN_CLIENT},
+    );
+
+    expect(result.siteResults[0]?.outputDir).toBe(path.join(dir, 'custom-structures', 'global'));
+    expect(await fs.pathExists(path.join(dir, 'custom-structures', 'global', 'BASIC-WEB-CONTENT.json'))).toBe(true);
+  });
+
   test('exports all structures sanitizing volatile p_p_auth tokens', async () => {
     const dir = createTempDir('dev-cli-resource-export-structures-sanitize-');
     const config = {
@@ -651,6 +711,60 @@ describe('liferay resource export', () => {
     expect(written).toBe('<#-- ftl -->');
     expect(result.exported).toBe(1);
     expect(formatLiferayResourceExportTemplates(result)).toContain('EXPORTED site=/global exported=1 failed=0');
+  });
+
+  test('exports all templates under dir/siteToken when --dir is provided', async () => {
+    const dir = createTempDir('dev-cli-resource-export-templates-dir-');
+    const config = {
+      ...CONFIG,
+      repoRoot: dir,
+      cwd: dir,
+      dockerDir: path.join(dir, 'docker'),
+      liferayDir: path.join(dir, 'liferay'),
+      files: {
+        dockerEnv: path.join(dir, 'docker', '.env'),
+        liferayProfile: path.join(dir, '.liferay-cli.yml'),
+      },
+      paths: {
+        structures: 'liferay/resources/journal/structures',
+        templates: 'liferay/resources/journal/templates',
+        adts: 'liferay/resources/templates/application_display',
+        fragments: 'liferay/fragments',
+      },
+    };
+    await fs.ensureDir(path.join(dir, 'docker'));
+    await fs.writeFile(path.join(dir, 'docker', '.env'), '');
+
+    const apiClient = createLiferayApiClient({
+      fetchImpl: async (input) => {
+        const url = String(input);
+        if (url.includes('/by-friendly-url-path/global')) {
+          return new Response('{"id":20121,"friendlyUrlPath":"/global","name":"Global"}', {status: 200});
+        }
+        if (url.includes('/api/jsonws/group/get-group?groupId=20121')) {
+          return new Response('{"companyId":10157}', {status: 200});
+        }
+        if (url.includes('/o/headless-delivery/v1.0/sites/20121/content-templates?page=1&pageSize=200')) {
+          return new Response(
+            '{"items":[{"id":"40801","name":"News Template","contentStructureId":301,"externalReferenceCode":"NEWS_TEMPLATE","templateScript":"<#-- ftl -->"}],"lastPage":1,"page":1,"pageSize":200,"totalCount":1}',
+            {status: 200},
+          );
+        }
+
+        throw new Error(`Unexpected URL ${url}`);
+      },
+    });
+
+    const result = await runLiferayResourceExportTemplates(
+      config,
+      {site: '/global', dir: 'custom-templates'},
+      {apiClient, tokenClient: TOKEN_CLIENT},
+    );
+
+    expect(result.siteResults[0]?.outputDir).toBe(path.join(dir, 'custom-templates', 'global'));
+    expect(await fs.readFile(path.join(dir, 'custom-templates', 'global', 'NEWS_TEMPLATE.ftl'), 'utf8')).toBe(
+      '<#-- ftl -->',
+    );
   });
 
   test('exports all templates sanitizing volatile p_p_auth tokens', async () => {
@@ -897,6 +1011,95 @@ describe('liferay resource export', () => {
     ).toBe('<#-- ftl -->');
   });
 
+  test('export-adts writes under dir/siteToken when --dir is provided', async () => {
+    const dir = createTempDir('dev-cli-resource-export-adts-dir-');
+    const config = {
+      ...CONFIG,
+      repoRoot: dir,
+      cwd: dir,
+      dockerDir: path.join(dir, 'docker'),
+      liferayDir: path.join(dir, 'liferay'),
+      files: {
+        dockerEnv: path.join(dir, 'docker', '.env'),
+        liferayProfile: path.join(dir, '.liferay-cli.yml'),
+      },
+      paths: {
+        structures: 'liferay/resources/journal/structures',
+        templates: 'liferay/resources/journal/templates',
+        adts: 'liferay/resources/templates/application_display',
+        fragments: 'liferay/fragments',
+      },
+    };
+    await fs.ensureDir(path.join(dir, 'docker'));
+    await fs.writeFile(path.join(dir, 'docker', '.env'), '');
+
+    const apiClient = createLiferayApiClient({
+      fetchImpl: async (input) => {
+        const url = String(input);
+        if (url.includes('/by-friendly-url-path/global')) {
+          return new Response('{"id":20121,"friendlyUrlPath":"/global","name":"Global"}', {status: 200});
+        }
+        if (url.includes('/api/jsonws/group/get-group?groupId=20121')) {
+          return new Response('{"companyId":10157}', {status: 200});
+        }
+        if (
+          url.includes(
+            '/api/jsonws/classname/fetch-class-name?value=com.liferay.portlet.display.template.PortletDisplayTemplate',
+          )
+        ) {
+          return new Response('{"classNameId":2001}', {status: 200});
+        }
+        if (
+          url.includes(
+            '/api/jsonws/classname/fetch-class-name?value=com.liferay.portal.search.web.internal.result.display.context.SearchResultSummaryDisplayContext',
+          )
+        ) {
+          return new Response('{"classNameId":3001}', {status: 200});
+        }
+        if (url.includes('/api/jsonws/classname/fetch-class-name?value=')) {
+          return new Response('{"classNameId":3999}', {status: 200});
+        }
+        if (
+          url.includes(
+            '/api/jsonws/ddm.ddmtemplate/get-templates?companyId=10157&groupId=20121&classNameId=3001&resourceClassNameId=2001&status=0',
+          )
+        ) {
+          return new Response(
+            '[{"templateId":40801,"templateKey":"SEARCH_RESULTS","nameCurrentValue":"Search Results","classNameId":3001,"script":"<#-- ftl -->"}]',
+            {status: 200},
+          );
+        }
+        if (
+          url.includes(
+            '/api/jsonws/ddm.ddmtemplate/get-templates?companyId=10157&groupId=20121&classNameId=3002&resourceClassNameId=2001&status=0',
+          )
+        ) {
+          return new Response('[]', {status: 200});
+        }
+        if (
+          url.includes(
+            '/api/jsonws/ddm.ddmtemplate/get-templates?companyId=10157&groupId=20121&classNameId=3999&resourceClassNameId=2001&status=0',
+          )
+        ) {
+          return new Response('[]', {status: 200});
+        }
+
+        throw new Error(`Unexpected URL ${url}`);
+      },
+    });
+
+    const result = await runLiferayResourceExportAdts(
+      config,
+      {site: '/global', dir: 'custom-adts'},
+      {apiClient, tokenClient: TOKEN_CLIENT},
+    );
+
+    expect(result.outputDir).toBe(path.join(dir, 'custom-adts', 'global'));
+    expect(
+      await fs.readFile(path.join(dir, 'custom-adts', 'global', 'search_result_summary', 'SEARCH_RESULTS.ftl'), 'utf8'),
+    ).toBe('<#-- ftl -->');
+  });
+
   test('export-fragments --all-sites includes /global', async () => {
     const dir = createTempDir('dev-cli-resource-export-fragments-all-sites-');
     const config = {
@@ -980,6 +1183,70 @@ describe('liferay resource export', () => {
         'utf8',
       ),
     ).toBe('');
+  });
+
+  test('export-fragments keeps historical project-root behavior when --dir is provided', async () => {
+    const dir = createTempDir('dev-cli-resource-export-fragments-dir-');
+    const config = {
+      ...CONFIG,
+      repoRoot: dir,
+      cwd: dir,
+      dockerDir: path.join(dir, 'docker'),
+      liferayDir: path.join(dir, 'liferay'),
+      files: {
+        dockerEnv: path.join(dir, 'docker', '.env'),
+        liferayProfile: path.join(dir, '.liferay-cli.yml'),
+      },
+      paths: {
+        structures: 'liferay/resources/journal/structures',
+        templates: 'liferay/resources/journal/templates',
+        adts: 'liferay/resources/templates/application_display',
+        fragments: 'liferay/fragments',
+      },
+    };
+    await fs.ensureDir(path.join(dir, 'docker'));
+    await fs.writeFile(path.join(dir, 'docker', '.env'), '');
+
+    const apiClient = createLiferayApiClient({
+      fetchImpl: async (input) => {
+        const url = String(input);
+        if (url.includes('/by-friendly-url-path/global')) {
+          return new Response('{"id":20121,"friendlyUrlPath":"/global","name":"Global"}', {status: 200});
+        }
+        if (url.includes('/api/jsonws/group/get-group?groupId=20121')) {
+          return new Response('{"companyId":10157}', {status: 200});
+        }
+        if (url.includes('/api/jsonws/fragment.fragmentcollection/get-fragment-collections?groupId=20121')) {
+          return new Response(
+            '[{"fragmentCollectionId":501,"name":"Marketing","fragmentCollectionKey":"marketing","description":"Marketing fragments"}]',
+            {status: 200},
+          );
+        }
+        if (url.includes('/api/jsonws/fragment.fragmententry/get-fragment-entries?fragmentCollectionId=501')) {
+          return new Response(
+            '[{"fragmentEntryId":601,"fragmentEntryKey":"hero-banner","name":"Hero Banner","icon":"square","type":1}]',
+            {status: 200},
+          );
+        }
+
+        throw new Error(`Unexpected URL ${url}`);
+      },
+    });
+
+    const result = await runLiferayResourceExportFragments(
+      config,
+      {site: '/global', dir: 'custom-fragments'},
+      {apiClient, tokenClient: TOKEN_CLIENT},
+    );
+
+    expect(result.outputDir).toBe(path.join(dir, 'custom-fragments'));
+    expect(
+      await fs.readFile(
+        path.join(dir, 'custom-fragments', 'src', 'marketing', 'fragments', 'hero-banner', 'index.html'),
+        'utf8',
+      ),
+    ).toBe('');
+    expect(await fs.pathExists(path.join(dir, 'custom-fragments', 'global'))).toBe(false);
   });
 
   test('export-templates uses the same enumeration source as inventory templates', async () => {


### PR DESCRIPTION
## Summary
Implements R14 by unifying artifact path resolution behind a shared API and migrating both export and sync path consumers.

### What changed
- Added shared path module:
  - `src/features/liferay/resource/artifact-paths.ts`
- Centralized common logic for:
  - base directory resolution by artifact type
  - site-scoped output directory resolution
  - legacy-compatible fragment project resolution
  - file token sanitization
  - fileOverride/local artifact file resolution for template/structure/ADT
- Kept backward-compatible facade API in:
  - `src/features/liferay/resource/liferay-resource-paths.ts`
- Migrated export consumers to the shared API:
  - template(s), structure(s), ADTs, fragments
- Migrated fragment sync local project path resolution to shared API:
  - `liferay-resource-sync-fragments-local.ts`

### Compatibility
- No public CLI API changes.
- No JSON/NDJSON contract changes.
- Existing historical fragment path behavior is preserved.
- Existing file resolution behavior for template/structure/ADT remains backward compatible.

## Tests
Added:
- `tests/unit/liferay-artifact-paths.test.ts`
  - path combinations
  - compatibility modes
  - file override resolution
  - fragment project root detection

Updated:
- `tests/unit/liferay-resource-export.test.ts`
  - integration coverage for `--dir` path behavior in export flows
  - fragment historical compatibility assertions

## Validation
- `npm run typecheck`
- `npm run test:unit -- tests/unit/liferay-artifact-paths.test.ts tests/unit/liferay-resource-export.test.ts tests/unit/liferay-resource-sync-template.test.ts tests/unit/liferay-resource-sync-structure.test.ts tests/unit/liferay-resource-sync-fragments.test.ts tests/unit/liferay-resource-sync-adt.test.ts`
- Result: pass