### PR TITLE
refactor(liferay): complete R14 artifact path consolidation

### DIFF
--- a/src/features/liferay/inventory/liferay-inventory-page-fetch.ts
+++ b/src/features/liferay/inventory/liferay-inventory-page-fetch.ts
@@ -35,12 +35,7 @@ import type {
   PagePortletSummary,
   ResolvedRegularLayoutPage,
 } from './liferay-inventory-page.js';
-import {
-  resolveSiteToken,
-  resolveStructuresBaseDir,
-  resolveTemplatesBaseDir,
-  resolveFragmentsBaseDir,
-} from '../resource/liferay-resource-paths.js';
+import {resolveSiteToken, resolveFragmentsBaseDir, resolveArtifactSiteDir} from '../resource/liferay-resource-paths.js';
 import {
   buildResourceSiteChain,
   fetchGroupInfo,
@@ -1453,7 +1448,7 @@ async function resolveTemplateSiteByKey(
 
 function buildStructureExportPath(config: AppConfig, siteFriendlyUrl: string, key: string): string | undefined {
   try {
-    return path.join(resolveStructuresBaseDir(config), resolveSiteToken(siteFriendlyUrl), `${key}.json`);
+    return path.join(resolveArtifactSiteDir(config, 'structure', resolveSiteToken(siteFriendlyUrl)), `${key}.json`);
   } catch {
     return undefined;
   }
@@ -1461,7 +1456,7 @@ function buildStructureExportPath(config: AppConfig, siteFriendlyUrl: string, ke
 
 function buildTemplateExportPath(config: AppConfig, siteFriendlyUrl: string, key: string): string | undefined {
   try {
-    return path.join(resolveTemplatesBaseDir(config), resolveSiteToken(siteFriendlyUrl), `${key}.ftl`);
+    return path.join(resolveArtifactSiteDir(config, 'template', resolveSiteToken(siteFriendlyUrl)), `${key}.ftl`);
   } catch {
     return undefined;
   }

--- a/src/features/liferay/resource/artifact-paths.ts
+++ b/src/features/liferay/resource/artifact-paths.ts
@@ -58,6 +58,11 @@ export function resolveSiteToken(siteFriendlyUrl: string): string {
   return token === '' ? 'global' : token;
 }
 
+/** Inverse of resolveSiteToken: converts a directory token back to a site friendly URL. */
+export function siteTokenToFriendlyUrl(token: string): string {
+  return token === 'global' ? '/global' : `/${token}`;
+}
+
 type ResolveArtifactFileOptions =
   | {
       type: 'structure';

--- a/src/features/liferay/resource/liferay-resource-import-adts.ts
+++ b/src/features/liferay/resource/liferay-resource-import-adts.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 
 import {CliError, normalizeCliError} from '../../../core/errors.js';
 import type {AppConfig} from '../../../core/config/load-config.js';
-import {resolveAdtsBaseDir, resolveRepoPath} from './liferay-resource-paths.js';
+import {resolveArtifactBaseDir, resolveSiteToken, siteTokenToFriendlyUrl} from './artifact-paths.js';
 import type {LiferayResourceImportFailure} from './liferay-resource-import-structures.js';
 import type {ResourceSyncDependencies} from './liferay-resource-sync-shared.js';
 import {runLiferayResourceSyncAdt} from './liferay-resource-sync-adt.js';
@@ -44,10 +44,8 @@ export async function runLiferayResourceImportAdts(
     );
   }
 
-  const baseDir = path.resolve(
-    options?.dir?.trim() ? resolveRepoPath(config, options.dir) : resolveAdtsBaseDir(config),
-  );
-  const siteTokens = options?.allSites ? await listSiteTokens(baseDir) : [siteToToken(options?.site ?? '/global')];
+  const baseDir = resolveArtifactBaseDir(config, 'adt', options?.dir);
+  const siteTokens = options?.allSites ? await listSiteTokens(baseDir) : [resolveSiteToken(options?.site ?? '/global')];
 
   let processed = 0;
   let failed = 0;
@@ -64,7 +62,7 @@ export async function runLiferayResourceImportAdts(
         await runLiferayResourceSyncAdt(
           config,
           {
-            site: tokenToSite(siteToken),
+            site: siteTokenToFriendlyUrl(siteToken),
             file,
             widgetType: options?.widgetType,
             className: options?.className,
@@ -77,7 +75,7 @@ export async function runLiferayResourceImportAdts(
       } catch (error) {
         failed += 1;
         const entry = path.basename(file, '.ftl');
-        const failure = toImportFailure(tokenToSite(siteToken), entry, file, error);
+        const failure = toImportFailure(siteTokenToFriendlyUrl(siteToken), entry, file, error);
         failures.push(failure);
         if (!options?.continueOnError) {
           throw new CliError(`Import failed for ADT '${entry}' in site '${failure.site}': ${failure.message}`, {
@@ -91,8 +89,8 @@ export async function runLiferayResourceImportAdts(
 
   return {
     ...(options?.allSites
-      ? {mode: 'all-sites' as const, sites: siteTokens.map((token) => tokenToSite(token))}
-      : {mode: 'single-site' as const, site: tokenToSite(siteTokens[0] ?? 'global')}),
+      ? {mode: 'all-sites' as const, sites: siteTokens.map((token) => siteTokenToFriendlyUrl(token))}
+      : {mode: 'single-site' as const, site: siteTokenToFriendlyUrl(siteTokens[0] ?? 'global')}),
     processed,
     failed,
     baseDir,
@@ -167,14 +165,6 @@ async function collectUniqueFiles(baseDirs: string[], extension: string, allowed
     }
   }
   return Array.from(unique).sort();
-}
-
-function siteToToken(site: string): string {
-  return site.replace(/^\//, '').trim() || 'global';
-}
-
-function tokenToSite(token: string): string {
-  return token === 'global' ? '/global' : `/${token}`;
 }
 
 function toImportFailure(site: string, entry: string, file: string, error: unknown): LiferayResourceImportFailure {

--- a/src/features/liferay/resource/liferay-resource-import-structures.ts
+++ b/src/features/liferay/resource/liferay-resource-import-structures.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 
 import {CliError, normalizeCliError} from '../../../core/errors.js';
 import type {AppConfig} from '../../../core/config/load-config.js';
-import {resolveRepoPath, resolveStructuresBaseDir} from './liferay-resource-paths.js';
+import {resolveArtifactBaseDir, resolveSiteToken, siteTokenToFriendlyUrl} from './artifact-paths.js';
 import type {ResourceSyncDependencies} from './liferay-resource-sync-shared.js';
 import {runLiferayResourceSyncStructure} from './liferay-resource-sync-structure.js';
 
@@ -52,10 +52,8 @@ export async function runLiferayResourceImportStructures(
     );
   }
 
-  const baseDir = path.resolve(
-    options?.dir?.trim() ? resolveRepoPath(config, options.dir) : resolveStructuresBaseDir(config),
-  );
-  const siteTokens = options?.allSites ? await listSiteTokens(baseDir) : [siteToToken(options?.site ?? '/global')];
+  const baseDir = resolveArtifactBaseDir(config, 'structure', options?.dir);
+  const siteTokens = options?.allSites ? await listSiteTokens(baseDir) : [resolveSiteToken(options?.site ?? '/global')];
 
   let processed = 0;
   let failed = 0;
@@ -68,7 +66,7 @@ export async function runLiferayResourceImportStructures(
         await runLiferayResourceSyncStructure(
           config,
           {
-            site: tokenToSite(siteToken),
+            site: siteTokenToFriendlyUrl(siteToken),
             key,
             file,
             checkOnly: Boolean(options?.checkOnly),
@@ -85,7 +83,7 @@ export async function runLiferayResourceImportStructures(
         processed += 1;
       } catch (error) {
         failed += 1;
-        const failure = toImportFailure(tokenToSite(siteToken), key, file, error);
+        const failure = toImportFailure(siteTokenToFriendlyUrl(siteToken), key, file, error);
         failures.push(failure);
         if (!options?.continueOnError) {
           throw new CliError(`Import failed for structure '${key}' in site '${failure.site}': ${failure.message}`, {
@@ -99,8 +97,8 @@ export async function runLiferayResourceImportStructures(
 
   return {
     ...(options?.allSites
-      ? {mode: 'all-sites' as const, sites: siteTokens.map((token) => tokenToSite(token))}
-      : {mode: 'single-site' as const, site: tokenToSite(siteTokens[0] ?? 'global')}),
+      ? {mode: 'all-sites' as const, sites: siteTokens.map((token) => siteTokenToFriendlyUrl(token))}
+      : {mode: 'single-site' as const, site: siteTokenToFriendlyUrl(siteTokens[0] ?? 'global')}),
     processed,
     failed,
     baseDir,
@@ -159,14 +157,6 @@ async function listFiles(baseDir: string, extension: string, allowedKeys: string
     }
   }
   return matches.sort();
-}
-
-function siteToToken(site: string): string {
-  return site.replace(/^\//, '').trim() || 'global';
-}
-
-function tokenToSite(token: string): string {
-  return token === 'global' ? '/global' : `/${token}`;
 }
 
 function toImportFailure(site: string, entry: string, file: string, error: unknown): LiferayResourceImportFailure {

--- a/src/features/liferay/resource/liferay-resource-import-templates.ts
+++ b/src/features/liferay/resource/liferay-resource-import-templates.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 
 import {CliError, normalizeCliError} from '../../../core/errors.js';
 import type {AppConfig} from '../../../core/config/load-config.js';
-import {resolveRepoPath, resolveTemplatesBaseDir} from './liferay-resource-paths.js';
+import {resolveArtifactBaseDir, resolveSiteToken, siteTokenToFriendlyUrl} from './artifact-paths.js';
 import type {LiferayResourceImportFailure} from './liferay-resource-import-structures.js';
 import type {ResourceSyncDependencies} from './liferay-resource-sync-shared.js';
 import {runLiferayResourceSyncTemplate} from './liferay-resource-sync-template.js';
@@ -41,10 +41,8 @@ export async function runLiferayResourceImportTemplates(
     );
   }
 
-  const baseDir = path.resolve(
-    options?.dir?.trim() ? resolveRepoPath(config, options.dir) : resolveTemplatesBaseDir(config),
-  );
-  const siteTokens = options?.allSites ? await listSiteTokens(baseDir) : [siteToToken(options?.site ?? '/global')];
+  const baseDir = resolveArtifactBaseDir(config, 'template', options?.dir);
+  const siteTokens = options?.allSites ? await listSiteTokens(baseDir) : [resolveSiteToken(options?.site ?? '/global')];
 
   let processed = 0;
   let failed = 0;
@@ -57,7 +55,7 @@ export async function runLiferayResourceImportTemplates(
         await runLiferayResourceSyncTemplate(
           config,
           {
-            site: tokenToSite(siteToken),
+            site: siteTokenToFriendlyUrl(siteToken),
             key: id,
             file,
             structureKey: options?.structureKey,
@@ -69,7 +67,7 @@ export async function runLiferayResourceImportTemplates(
         processed += 1;
       } catch (error) {
         failed += 1;
-        const failure = toImportFailure(tokenToSite(siteToken), id, file, error);
+        const failure = toImportFailure(siteTokenToFriendlyUrl(siteToken), id, file, error);
         failures.push(failure);
         if (!options?.continueOnError) {
           throw new CliError(`Import failed for template '${id}' in site '${failure.site}': ${failure.message}`, {
@@ -83,8 +81,8 @@ export async function runLiferayResourceImportTemplates(
 
   return {
     ...(options?.allSites
-      ? {mode: 'all-sites' as const, sites: siteTokens.map((token) => tokenToSite(token))}
-      : {mode: 'single-site' as const, site: tokenToSite(siteTokens[0] ?? 'global')}),
+      ? {mode: 'all-sites' as const, sites: siteTokens.map((token) => siteTokenToFriendlyUrl(token))}
+      : {mode: 'single-site' as const, site: siteTokenToFriendlyUrl(siteTokens[0] ?? 'global')}),
     processed,
     failed,
     baseDir,
@@ -151,14 +149,6 @@ function normalizeTemplateKeys(templateKeys: string[] | undefined): string[] {
   }
 
   return [...new Set(templateKeys.map((value) => value.trim()).filter((value) => value !== ''))];
-}
-
-function siteToToken(site: string): string {
-  return site.replace(/^\//, '').trim() || 'global';
-}
-
-function tokenToSite(token: string): string {
-  return token === 'global' ? '/global' : `/${token}`;
 }
 
 function toImportFailure(site: string, entry: string, file: string, error: unknown): LiferayResourceImportFailure {

--- a/src/features/liferay/resource/liferay-resource-paths.ts
+++ b/src/features/liferay/resource/liferay-resource-paths.ts
@@ -4,12 +4,15 @@ export {
   ADT_WIDGET_DIR_BY_TYPE,
   requireRepoRoot,
   resolveAdtsBaseDir,
+  resolveArtifactBaseDir,
+  resolveArtifactSiteDir,
   resolveFragmentsBaseDir,
   resolveMigrationsBaseDir,
   resolveRepoPath,
   resolveSiteToken,
   resolveStructuresBaseDir,
   resolveTemplatesBaseDir,
+  siteTokenToFriendlyUrl,
 } from './artifact-paths.js';
 
 import {resolveArtifactFile} from './artifact-paths.js';

--- a/tests/unit/liferay-artifact-paths.test.ts
+++ b/tests/unit/liferay-artifact-paths.test.ts
@@ -8,6 +8,8 @@ import {
   resolveArtifactSiteDir,
   resolveFragmentProjectDir,
   sanitizeArtifactToken,
+  resolveSiteToken,
+  siteTokenToFriendlyUrl,
   type ArtifactType,
 } from '../../src/features/liferay/resource/artifact-paths.js';
 import {createTempDir} from '../../src/testing/temp-repo.js';
@@ -74,6 +76,62 @@ describe('sanitizeArtifactToken', () => {
 
   test('unicode chars are replaced', () => {
     expect(sanitizeArtifactToken('café')).toBe('caf_');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveSiteToken – site friendly URL → directory token
+// ---------------------------------------------------------------------------
+
+describe('resolveSiteToken', () => {
+  test('strips leading slash', () => {
+    expect(resolveSiteToken('/my-site')).toBe('my-site');
+  });
+
+  test('empty string returns global', () => {
+    expect(resolveSiteToken('')).toBe('global');
+  });
+
+  test('whitespace-only returns global', () => {
+    expect(resolveSiteToken('   ')).toBe('global');
+  });
+
+  test('/global returns global', () => {
+    expect(resolveSiteToken('/global')).toBe('global');
+  });
+
+  test('already-clean token passes through', () => {
+    expect(resolveSiteToken('my-site')).toBe('my-site');
+  });
+
+  test('nested path keeps structure', () => {
+    expect(resolveSiteToken('/parent/child')).toBe('parent/child');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// siteTokenToFriendlyUrl – directory token → site friendly URL (inverse)
+// ---------------------------------------------------------------------------
+
+describe('siteTokenToFriendlyUrl', () => {
+  test('global token → /global', () => {
+    expect(siteTokenToFriendlyUrl('global')).toBe('/global');
+  });
+
+  test('regular token → /token', () => {
+    expect(siteTokenToFriendlyUrl('my-site')).toBe('/my-site');
+  });
+
+  test('roundtrip resolveSiteToken → siteTokenToFriendlyUrl', () => {
+    for (const url of ['/global', '/my-site', '/group/subsite']) {
+      expect(siteTokenToFriendlyUrl(resolveSiteToken(url))).toBe(url);
+    }
+  });
+
+  test('roundtrip siteTokenToFriendlyUrl → resolveSiteToken', () => {
+    for (const token of ['global', 'my-site', 'group/subsite']) {
+      expect(resolveSiteToken(siteTokenToFriendlyUrl(token))).toBe(token);
+    }
   });
 });
 

--- a/tests/unit/liferay-inventory-page.test.ts
+++ b/tests/unit/liferay-inventory-page.test.ts
@@ -1,4 +1,5 @@
 import {afterEach, describe, expect, test, vi} from 'vitest';
+import path from 'node:path';
 
 import {createLiferayApiClient} from '../../src/core/http/client.js';
 import {
@@ -25,6 +26,20 @@ const CONFIG = {
     timeoutSeconds: 30,
   },
 };
+
+const EXPECTED_GUEST_STRUCTURE_EXPORT_PATH = path.resolve(
+  CONFIG.repoRoot,
+  'liferay/resources/journal/structures',
+  'guest',
+  'NEWS.json',
+);
+
+const EXPECTED_GUEST_TEMPLATE_EXPORT_PATH = path.resolve(
+  CONFIG.repoRoot,
+  'liferay/resources/journal/templates',
+  'guest',
+  'NEWS_TEMPLATE.ftl',
+);
 
 const TOKEN_CLIENT = {
   fetchClientCredentialsToken: async () => ({
@@ -953,12 +968,15 @@ describe('liferay inventory page', () => {
           contentStructureId: 301,
           key: 'NEWS',
           siteFriendlyUrl: '/guest',
+          exportPath: EXPECTED_GUEST_STRUCTURE_EXPORT_PATH,
         },
       ],
     });
     if (result.pageType !== 'displayPage') {
       throw new Error('Expected display page');
     }
+    expect(result.journalArticles?.[0]?.structureExportPath).toBe(EXPECTED_GUEST_STRUCTURE_EXPORT_PATH);
+    expect(result.journalArticles?.[0]?.templateExportPath).toBe(EXPECTED_GUEST_TEMPLATE_EXPORT_PATH);
     expect('articleProperties' in result).toBe(false);
     expect(formatLiferayInventoryPage(result)).toContain('DISPLAY PAGE');
     expect(formatLiferayInventoryPage(result)).toContain('contentField Headline=News title');

--- a/tests/unit/liferay-resource-import.test.ts
+++ b/tests/unit/liferay-resource-import.test.ts
@@ -318,6 +318,58 @@ describe('liferay resource import', () => {
     });
   });
 
+  test('import-templates with custom dir keeps the site token layout under the override directory', async () => {
+    const dir = createTempDir('dev-cli-resource-import-templates-custom-dir-');
+    const config = {
+      ...CONFIG,
+      repoRoot: dir,
+      cwd: dir,
+      dockerDir: path.join(dir, 'docker'),
+      liferayDir: path.join(dir, 'liferay'),
+      files: {
+        dockerEnv: path.join(dir, 'docker', '.env'),
+        liferayProfile: path.join(dir, '.liferay-cli.yml'),
+      },
+      paths: {
+        structures: 'liferay/resources/journal/structures',
+        templates: 'liferay/resources/journal/templates',
+        adts: 'liferay/resources/templates/application_display',
+        fragments: 'liferay/fragments',
+      },
+    };
+    await fs.ensureDir(path.join(dir, 'docker'));
+    await fs.writeFile(path.join(dir, 'docker', '.env'), '');
+    const templateDir = path.join(dir, '.tmp', 'templates-import', 'global');
+    await fs.ensureDir(templateDir);
+    const featured = path.join(templateDir, 'FEATURED.ftl');
+    await fs.writeFile(featured, 'featured');
+
+    syncTemplateMock.mockReset();
+    syncTemplateMock.mockImplementation(async (_config, options) => ({
+      status: 'updated',
+      id: options.key,
+      name: options.key,
+      extra: '',
+      templateFile: options.file,
+      siteId: 20121,
+      siteFriendlyUrl: '/global',
+    }));
+
+    const result = await runLiferayResourceImportTemplates(config, {
+      site: '/global',
+      dir: '.tmp/templates-import',
+      templateKeys: ['FEATURED'],
+    });
+
+    expect(result.baseDir).toBe(path.join(dir, '.tmp', 'templates-import'));
+    expect(result.processed).toBe(1);
+    expect(syncTemplateMock.mock.calls[0]?.[1]).toMatchObject({
+      site: '/global',
+      key: 'FEATURED',
+      file: featured,
+    });
+  });
+
   test('import-structures requires an explicit selector, --apply or --all-sites guardrail', async () => {
     const dir = createTempDir('dev-cli-resource-import-structures-guardrail-');
     const config = {
@@ -443,6 +495,58 @@ describe('liferay resource import', () => {
     ]);
     expect(syncStructureMock).toHaveBeenCalledTimes(2);
     expect(syncStructureMock.mock.calls[1]?.[1]).toMatchObject({
+      key: 'OK',
+      file: okFile,
+    });
+  });
+
+  test('import-structures with custom dir keeps the site token layout under the override directory', async () => {
+    const dir = createTempDir('dev-cli-resource-import-structures-custom-dir-');
+    const config = {
+      ...CONFIG,
+      repoRoot: dir,
+      cwd: dir,
+      dockerDir: path.join(dir, 'docker'),
+      liferayDir: path.join(dir, 'liferay'),
+      files: {
+        dockerEnv: path.join(dir, 'docker', '.env'),
+        liferayProfile: path.join(dir, '.liferay-cli.yml'),
+      },
+      paths: {
+        structures: 'liferay/resources/journal/structures',
+        templates: 'liferay/resources/journal/templates',
+        adts: 'liferay/resources/templates/application_display',
+        fragments: 'liferay/fragments',
+      },
+    };
+    await fs.ensureDir(path.join(dir, 'docker'));
+    await fs.writeFile(path.join(dir, 'docker', '.env'), '');
+    const structuresDir = path.join(dir, '.tmp', 'structures-import', 'global');
+    await fs.ensureDir(structuresDir);
+    const okFile = path.join(structuresDir, 'OK.json');
+    await fs.writeJson(okFile, {name: 'ok'});
+
+    syncStructureMock.mockReset();
+    syncStructureMock.mockImplementation(async (_config, options) => ({
+      status: 'updated',
+      id: '123',
+      key: options.key,
+      siteId: 20121,
+      siteFriendlyUrl: '/global',
+      structureFile: options.file,
+      removedFieldReferences: [],
+    }));
+
+    const result = await runLiferayResourceImportStructures(config, {
+      site: '/global',
+      dir: '.tmp/structures-import',
+      structureKeys: ['OK'],
+    });
+
+    expect(result.baseDir).toBe(path.join(dir, '.tmp', 'structures-import'));
+    expect(result.processed).toBe(1);
+    expect(syncStructureMock.mock.calls[0]?.[1]).toMatchObject({
+      site: '/global',
       key: 'OK',
       file: okFile,
     });


### PR DESCRIPTION
## Summary
This PR completes the R14 artifact path consolidation by centralizing site token path handling and hardening the affected flows with focused regression coverage.

## What Changed
- Added `siteTokenToFriendlyUrl` as the canonical inverse of `resolveSiteToken`
- Re-exported shared artifact path helpers from the resource path facade
- Migrated template, structure, and ADT import flows to use the shared artifact path helpers instead of local duplicated token/path logic
- Updated inventory display-page export path resolution to use the shared artifact site path API
- Added regression tests for:
  - `resolveSiteToken` / `siteTokenToFriendlyUrl` roundtrips
  - custom `--dir` handling in `resource import-templates`
  - custom `--dir` handling in `resource import-structures`
  - display-page structure/template export paths in inventory

## Why
R14 is about a common artifact path API for templates, structures, and fragments. The code changes remove duplicated site token conversions and route more consumers through the shared path layer, while the added tests close the remaining review gaps around override directories and inventory export paths.

## Validation
- `npm run typecheck`
- `npm run test:unit -- tests/unit/liferay-resource-import.test.ts tests/unit/liferay-inventory-page.test.ts tests/unit/liferay-artifact-paths.test.ts`
- Result: pass

## Backward Compatibility
- No public CLI API changes
- No JSON/NDJSON contract changes
- No error code changes

## Residual Risk
- Low. This keeps the existing behavior while consolidating path logic and adding targeted regression coverage.