### PR TITLE
refactor(liferay): replace safe direct CliError uses

### DIFF
--- a/src/features/liferay/content/liferay-content-prune.ts
+++ b/src/features/liferay/content/liferay-content-prune.ts
@@ -1,9 +1,9 @@
-import {CliError} from '../../../core/errors.js';
 import type {AppConfig} from '../../../core/config/load-config.js';
 import {createOAuthTokenClient, type OAuthTokenClient} from '../../../core/http/auth.js';
 import {createLiferayApiClient, type LiferayApiClient} from '../../../core/http/client.js';
 import type {Printer} from '../../../core/output/printer.js';
 import {runStep} from '../../../core/output/run-step.js';
+import {LiferayErrors} from '../errors/index.js';
 import {fetchAccessToken, normalizeLocalizedName, resolveSite} from '../inventory/liferay-inventory-shared.js';
 import {
   authedGetWithRefresh,
@@ -128,9 +128,7 @@ export async function runContentPrune(
     (options.site === undefined && options.groupId === undefined) ||
     (options.site && options.groupId !== undefined)
   ) {
-    throw new CliError('Use exactly one of site or groupId.', {
-      code: 'LIFERAY_CONTENT_PRUNE_ERROR',
-    });
+    throw LiferayErrors.contentPruneError('Use exactly one of site or groupId.');
   }
 
   const rootFolderIds = [...new Set(options.rootFolders)];
@@ -212,9 +210,7 @@ export async function runContentPrune(
     for (const key of options.structures) {
       const found = [...structureMap.values()].includes(key);
       if (!found) {
-        throw new CliError(`Structure "${key}" not found in group ${groupId}.`, {
-          code: 'LIFERAY_CONTENT_PRUNE_ERROR',
-        });
+        throw LiferayErrors.contentPruneError(`Structure "${key}" not found in group ${groupId}.`);
       }
     }
   }
@@ -467,16 +463,14 @@ async function collectFolderTree(
         continue;
       }
 
-      throw new CliError(`Folder ${rootId} not found (status=${resp.status}).`, {
-        code: 'LIFERAY_CONTENT_PRUNE_ERROR',
-      });
+      throw LiferayErrors.contentPruneError(`Folder ${rootId} not found (status=${resp.status}).`);
     }
 
     const folder = resp.data ?? {};
     if (folder.siteId !== groupId) {
-      throw new CliError(`Folder ${rootId} belongs to group ${folder.siteId ?? 'unknown'}, not ${groupId}.`, {
-        code: 'LIFERAY_CONTENT_PRUNE_ERROR',
-      });
+      throw LiferayErrors.contentPruneError(
+        `Folder ${rootId} belongs to group ${folder.siteId ?? 'unknown'}, not ${groupId}.`,
+      );
     }
 
     allFolders.set(rootId, folder);
@@ -509,9 +503,7 @@ async function collectSubfolders(
     );
 
     if (!response.ok) {
-      throw new CliError(`Subfolders for folder ${parentId} failed with status=${response.status}.`, {
-        code: 'LIFERAY_CONTENT_PRUNE_ERROR',
-      });
+      throw LiferayErrors.contentPruneError(`Subfolders for folder ${parentId} failed with status=${response.status}.`);
     }
 
     const items = response.data?.items ?? [];
@@ -681,9 +673,7 @@ async function deleteJournalArticle(
   articleId: string,
 ): Promise<FailedArticle | null> {
   if (!articleId) {
-    throw new CliError('Cannot delete article without articleId.', {
-      code: 'LIFERAY_CONTENT_PRUNE_ERROR',
-    });
+    throw LiferayErrors.contentPruneError('Cannot delete article without articleId.');
   }
 
   const response = await postFormWithRefresh(

--- a/src/features/liferay/content/liferay-content-stats.ts
+++ b/src/features/liferay/content/liferay-content-stats.ts
@@ -1,9 +1,9 @@
 import type {AppConfig} from '../../../core/config/load-config.js';
-import {CliError} from '../../../core/errors.js';
 import {createOAuthTokenClient, type OAuthTokenClient} from '../../../core/http/auth.js';
 import {createLiferayApiClient, type LiferayApiClient} from '../../../core/http/client.js';
 import type {Printer} from '../../../core/output/printer.js';
 import {runStep} from '../../../core/output/run-step.js';
+import {LiferayErrors} from '../errors/index.js';
 import {fetchAccessToken, normalizeFriendlyUrl, resolveSite} from '../inventory/liferay-inventory-shared.js';
 import {runLiferayInventorySites} from '../inventory/liferay-inventory-sites.js';
 import {
@@ -315,9 +315,7 @@ async function fetchHeadlessFoldersPageByPage(
     );
 
     if (!response.ok) {
-      throw new CliError(`${basePath} failed with status=${response.status}.`, {
-        code: 'LIFERAY_CONTENT_STATS_ERROR',
-      });
+      throw LiferayErrors.contentStatsError(`${basePath} failed with status=${response.status}.`);
     }
 
     items.push(...(response.data?.items ?? []));

--- a/src/features/liferay/inventory/liferay-inventory-page-fetch.ts
+++ b/src/features/liferay/inventory/liferay-inventory-page-fetch.ts
@@ -1,11 +1,11 @@
 /* eslint-disable max-lines -- inventory orchestration intentionally consolidated during active refactor */
-import {CliError} from '../../../core/errors.js';
 import type {AppConfig} from '../../../core/config/load-config.js';
 import path from 'node:path';
 import fs from 'fs-extra';
 import type {LiferayApiClient} from '../../../core/http/client.js';
 import {firstNonEmptyString, firstPositiveNumber, toBoolean, toBooleanOrFalse} from '../../../core/utils/coerce.js';
 import {trimLeadingSlash} from '../../../core/utils/text.js';
+import {LiferayErrors} from '../errors/index.js';
 import {authedGet, type ResolvedSite} from './liferay-inventory-shared.js';
 import {
   buildLayoutDetails,
@@ -111,9 +111,8 @@ async function resolveDisplayPageArticle(
   }
 
   if (!article) {
-    throw new CliError(
+    throw LiferayErrors.inventoryError(
       `No structured content found with friendlyUrlPath=${urlTitle}. Verify the article URL title and site visibility, or confirm JSONWS/headless permissions for this OAuth client.`,
-      {code: 'LIFERAY_INVENTORY_ERROR'},
     );
   }
 
@@ -256,9 +255,9 @@ export async function fetchRegularPageInventory(
     localeHint,
   );
   if (!match) {
-    throw new CliError(`Layout not found for friendlyUrl=${friendlyUrl} in site=${site.friendlyUrlPath}.`, {
-      code: 'LIFERAY_INVENTORY_ERROR',
-    });
+    throw LiferayErrors.inventoryError(
+      `Layout not found for friendlyUrl=${friendlyUrl} in site=${site.friendlyUrlPath}.`,
+    );
   }
   const {layout, locale: matchedLocale} = match;
 
@@ -715,9 +714,9 @@ export async function resolveRegularLayoutPageData(
 ): Promise<ResolvedRegularLayoutPage> {
   const match = await findLayoutByFriendlyUrl(config, apiClient, accessToken, site.id, friendlyUrl, privateLayout);
   if (!match) {
-    throw new CliError(`Layout not found for friendlyUrl=${friendlyUrl} in site=${site.friendlyUrlPath}.`, {
-      code: 'LIFERAY_INVENTORY_ERROR',
-    });
+    throw LiferayErrors.inventoryError(
+      `Layout not found for friendlyUrl=${friendlyUrl} in site=${site.friendlyUrlPath}.`,
+    );
   }
   const {layout} = match;
 
@@ -771,11 +770,8 @@ async function resolveClassNameId(
   );
   const resolved = Number(response.data?.classNameId ?? -1);
   if (!response.ok || resolved <= 0) {
-    throw new CliError(
+    throw LiferayErrors.inventoryError(
       `Unable to resolve classNameId for ${className}. Verify JSONWS access to /api/jsonws/classname/fetch-class-name and portal credentials/permissions.`,
-      {
-        code: 'LIFERAY_INVENTORY_ERROR',
-      },
     );
   }
 

--- a/src/features/liferay/inventory/liferay-inventory-page-url.ts
+++ b/src/features/liferay/inventory/liferay-inventory-page-url.ts
@@ -1,4 +1,4 @@
-import {CliError} from '../../../core/errors.js';
+import {LiferayErrors} from '../errors/index.js';
 
 export type InventoryPageRoute = 'portalHome' | 'siteRoot' | 'displayPage' | 'regularPage';
 
@@ -53,9 +53,7 @@ export function resolveInventoryPageRequest(options: {
     );
   }
 
-  throw new CliError('Provide --url or both --site and --friendly-url.', {
-    code: 'LIFERAY_INVENTORY_ERROR',
-  });
+  throw LiferayErrors.inventoryError('Provide --url or both --site and --friendly-url.');
 }
 
 function buildRequest(siteSlug: string, friendlyUrl: string, privateLayout: boolean): InventoryPageRequest {

--- a/src/features/liferay/inventory/liferay-inventory-page.ts
+++ b/src/features/liferay/inventory/liferay-inventory-page.ts
@@ -3,7 +3,7 @@ import type {AppConfig} from '../../../core/config/load-config.js';
 import type {OAuthTokenClient} from '../../../core/http/auth.js';
 import type {LiferayApiClient} from '../../../core/http/client.js';
 import {createLiferayApiClient} from '../../../core/http/client.js';
-import {CliError} from '../../../core/errors.js';
+import {LiferayErrors} from '../errors/index.js';
 import {fetchAccessToken, resolveSite} from './liferay-inventory-shared.js';
 import {resolveInventoryPageRequest} from './liferay-inventory-page-url.js';
 import {buildPageUrl} from '../page-layout/liferay-layout-shared.js';
@@ -321,9 +321,7 @@ export async function resolveRegularLayoutPage(
 ): Promise<ResolvedRegularLayoutPage> {
   const request = resolveInventoryPageRequest(options);
   if (request.route !== 'regularPage') {
-    throw new CliError('Only a regular page can be resolved for this flow.', {
-      code: 'LIFERAY_INVENTORY_ERROR',
-    });
+    throw LiferayErrors.inventoryError('Only a regular page can be resolved for this flow.');
   }
 
   const apiClient = dependencies?.apiClient ?? createLiferayApiClient();

--- a/src/features/liferay/inventory/liferay-inventory-shared.ts
+++ b/src/features/liferay/inventory/liferay-inventory-shared.ts
@@ -5,6 +5,7 @@ import {createLiferayApiClient, type HttpResponse, type LiferayApiClient} from '
 import {buildAuthOptions, expectJsonSuccess as expectJsonSuccessShared} from '../liferay-http-shared.js';
 import {createLiferayGateway} from '../liferay-gateway.js';
 import {LookupCache} from '../lookup-cache.js';
+import {LiferayErrors} from '../errors/index.js';
 import {
   SiteResolutionPipeline,
   createByIdStep,
@@ -120,12 +121,11 @@ export async function fetchPagedItems<T>(
       if (error instanceof CliError && error.code === 'LIFERAY_GATEWAY_ERROR') {
         // Check for 403 (permission) errors and provide scoped guidance
         if (error.message.includes('status=403')) {
-          throw new CliError(
+          throw LiferayErrors.inventoryError(
             `403 Forbidden on ${basePath} (check the bootstrap OAuth2 scopes for Data Engine/Headless Delivery).`,
-            {code: 'LIFERAY_INVENTORY_ERROR'},
           );
         }
-        throw new CliError(error.message, {code: 'LIFERAY_INVENTORY_ERROR'});
+        throw LiferayErrors.inventoryError(error.message);
       }
       throw error;
     }

--- a/src/features/liferay/inventory/liferay-inventory-sites.ts
+++ b/src/features/liferay/inventory/liferay-inventory-sites.ts
@@ -1,9 +1,9 @@
 import type {AppConfig} from '../../../core/config/load-config.js';
-import {CliError} from '../../../core/errors.js';
 import type {LiferayApiClient} from '../../../core/http/client.js';
 import {createLiferayApiClient} from '../../../core/http/client.js';
 import type {OAuthTokenClient} from '../../../core/http/auth.js';
 import {createOAuthTokenClient} from '../../../core/http/auth.js';
+import {LiferayErrors} from '../errors/index.js';
 import {fetchPagedItems, normalizeFriendlyUrl, normalizeLocalizedName} from './liferay-inventory-shared.js';
 import {createLiferayGateway, type LiferayGateway} from '../liferay-gateway.js';
 import {getOperationPolicy} from './capabilities.js';
@@ -74,7 +74,7 @@ export async function runLiferayInventorySites(
     throw lastError;
   }
 
-  throw new CliError('Could not list sites.', {code: 'LIFERAY_INVENTORY_ERROR'});
+  throw LiferayErrors.inventoryError('Could not list sites.');
 }
 
 export async function runLiferayInventorySitesIncludingGlobal(

--- a/src/features/liferay/liferay-identifiers.ts
+++ b/src/features/liferay/liferay-identifiers.ts
@@ -11,7 +11,7 @@
  *   ADT input:    --id > --display-style (strips ddmTemplate_) > --key > --name
  */
 
-import {CliError} from '../../core/errors.js';
+import {LiferayErrors} from './errors/index.js';
 import type {DdmTemplatePayload} from '../liferay/resource/liferay-resource-payloads.js';
 
 // ---------------------------------------------------------------------------
@@ -108,7 +108,5 @@ export function normalizeAdtIdentifier(options: AdtIdentifierOptions): string {
     return options.name.trim();
   }
 
-  throw new CliError('adt requires --display-style, --id, --key, or --name', {
-    code: 'LIFERAY_RESOURCE_ERROR',
-  });
+  throw LiferayErrors.resourceError('adt requires --display-style, --id, --key, or --name');
 }

--- a/src/features/liferay/liferay-theme-check.ts
+++ b/src/features/liferay/liferay-theme-check.ts
@@ -2,10 +2,10 @@ import path from 'node:path';
 
 import fs from 'fs-extra';
 
-import {CliError} from '../../core/errors.js';
 import type {AppConfig} from '../../core/config/load-config.js';
 import type {LiferayApiClient} from '../../core/http/client.js';
 import {createLiferayApiClient} from '../../core/http/client.js';
+import {LiferayErrors} from './errors/index.js';
 
 type ThemeDependencies = {
   apiClient?: LiferayApiClient;
@@ -49,7 +49,7 @@ export async function runLiferayThemeCheck(
   const sourceIconsExists = await fs.pathExists(sourceIconsFile);
 
   if (!sourceIconsExists) {
-    throw new CliError(`Falta fichero fuente: ${sourceIconsFile}`, {code: 'LIFERAY_THEME_ERROR'});
+    throw LiferayErrors.themeError(`Falta fichero fuente: ${sourceIconsFile}`);
   }
 
   const sourceIconsSvg = await fs.readFile(sourceIconsFile, 'utf8');
@@ -118,9 +118,8 @@ async function fetchText(
 ): Promise<string> {
   const response = await apiClient.get<string>('', url, {timeoutSeconds});
   if (!response.ok) {
-    throw new CliError(
+    throw LiferayErrors.themeError(
       `${label} failed with status=${response.status} at ${url}. Verify that the theme is deployed and the portal URL is reachable.`,
-      {code: 'LIFERAY_THEME_ERROR'},
     );
   }
 
@@ -135,16 +134,15 @@ async function requireHttp200(
 ): Promise<void> {
   const response = await apiClient.get('', url, {timeoutSeconds});
   if (!response.ok) {
-    throw new CliError(
+    throw LiferayErrors.themeError(
       `${label} failed with status=${response.status} at ${url}. Verify that the theme is deployed and the portal URL is reachable.`,
-      {code: 'LIFERAY_THEME_ERROR'},
     );
   }
 }
 
 function resolveSourceIconsFile(config: AppConfig, themeName: string): string {
   if (!config.repoRoot) {
-    throw new CliError('Could not resolve repo root for theme check.', {code: 'LIFERAY_THEME_ERROR'});
+    throw LiferayErrors.themeError('Could not resolve repo root for theme check.');
   }
 
   return path.join(config.repoRoot, 'liferay', 'themes', themeName, 'src', 'images', 'clay', 'icons.svg');

--- a/src/features/liferay/page-layout/liferay-page-layout-diff.ts
+++ b/src/features/liferay/page-layout/liferay-page-layout-diff.ts
@@ -1,10 +1,10 @@
 import fs from 'fs-extra';
 import path from 'node:path';
 
-import {CliError} from '../../../core/errors.js';
 import type {AppConfig} from '../../../core/config/load-config.js';
 import type {OAuthTokenClient} from '../../../core/http/auth.js';
 import type {LiferayApiClient} from '../../../core/http/client.js';
+import {LiferayErrors} from '../errors/index.js';
 import {runLiferayPageLayoutExport, type LiferayPageLayoutExport} from './liferay-page-layout-export.js';
 
 const DIFF_KIND = 'liferay-page-layout-diff';
@@ -90,9 +90,7 @@ export async function readLiferayPageLayoutExportFile(filePath: string): Promise
   const parsed = JSON.parse(await fs.readFile(resolvedFilePath, 'utf8')) as Partial<LiferayPageLayoutExport>;
 
   if (parsed.kind !== EXPORT_KIND) {
-    throw new CliError(`El fichero no parece un export de page layout: ${resolvedFilePath}`, {
-      code: 'LIFERAY_PAGE_LAYOUT_ERROR',
-    });
+    throw LiferayErrors.pageLayoutError(`El fichero no parece un export de page layout: ${resolvedFilePath}`);
   }
 
   return parsed as LiferayPageLayoutExport;
@@ -109,13 +107,13 @@ export function collectPageLayoutDiffs(
 
 function validateDiffOptions(options: {url?: string; file?: string; referenceUrl?: string}): void {
   if (!options.url) {
-    throw new CliError('Use --url to indicate the live base page.', {code: 'LIFERAY_PAGE_LAYOUT_ERROR'});
+    throw LiferayErrors.pageLayoutError('Use --url to indicate the live base page.');
   }
 
   const fileProvided = Boolean(options.file);
   const referenceUrlProvided = Boolean(options.referenceUrl);
   if (fileProvided === referenceUrlProvided) {
-    throw new CliError('Use exactly one of --file or --reference-url.', {code: 'LIFERAY_PAGE_LAYOUT_ERROR'});
+    throw LiferayErrors.pageLayoutError('Use exactly one of --file or --reference-url.');
   }
 }
 

--- a/src/features/liferay/page-layout/liferay-page-layout-export.ts
+++ b/src/features/liferay/page-layout/liferay-page-layout-export.ts
@@ -1,12 +1,12 @@
 import fs from 'fs-extra';
 import path from 'node:path';
 
-import {CliError} from '../../../core/errors.js';
 import type {AppConfig} from '../../../core/config/load-config.js';
 import type {OAuthTokenClient} from '../../../core/http/auth.js';
 import type {LiferayApiClient} from '../../../core/http/client.js';
 import {createLiferayApiClient} from '../../../core/http/client.js';
 import {trimLeadingSlash} from '../../../core/utils/text.js';
+import {LiferayErrors} from '../errors/index.js';
 import {resolveRegularLayoutPage} from '../inventory/liferay-inventory-page.js';
 import {authedGet, fetchAccessToken} from '../inventory/liferay-inventory-shared.js';
 import {buildLayoutConfigureUrl} from './liferay-page-admin-urls.js';
@@ -73,11 +73,8 @@ export async function runLiferayPageLayoutExport(
   );
 
   if (headlessSitePage === null) {
-    throw new CliError(
+    throw LiferayErrors.pageLayoutError(
       'The page cannot be exported through Headless Delivery or could not be resolved as a content page.',
-      {
-        code: 'LIFERAY_PAGE_LAYOUT_ERROR',
-      },
     );
   }
 
@@ -181,11 +178,8 @@ async function resolveExportableRegularPage(
   const page = await resolveRegularLayoutPage(config, options, dependencies);
 
   if (page.layoutType.toLowerCase() !== 'content') {
-    throw new CliError(
+    throw LiferayErrors.pageLayoutError(
       `page-layout export solo soporta layoutType=content; recibido ${page.layoutType || '<empty>'}.`,
-      {
-        code: 'LIFERAY_PAGE_LAYOUT_ERROR',
-      },
     );
   }
 

--- a/src/features/liferay/resource/artifact-paths.ts
+++ b/src/features/liferay/resource/artifact-paths.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 
 import {CliError} from '../../../core/errors.js';
 import type {AppConfig} from '../../../core/config/load-config.js';
+import {LiferayErrors} from '../errors/index.js';
 
 export type ArtifactType = 'template' | 'structure' | 'adt' | 'fragment';
 
@@ -251,9 +252,7 @@ async function resolveAdtArtifactFile(config: AppConfig, key: string, widgetType
   const baseDir = resolveAdtsBaseDir(config);
   const widgetDir = ADT_WIDGET_DIR_BY_TYPE[widgetType];
   if (!widgetDir) {
-    throw new CliError(`widget-type ADT no soportado: ${widgetType}`, {
-      code: 'LIFERAY_RESOURCE_ERROR',
-    });
+    throw LiferayErrors.resourceError(`widget-type ADT no soportado: ${widgetType}`);
   }
 
   const matches = await findFilesByPathSuffix(baseDir, path.join(widgetDir, `${key}.ftl`));

--- a/src/features/liferay/resource/liferay-resource-export-templates.ts
+++ b/src/features/liferay/resource/liferay-resource-export-templates.ts
@@ -1,10 +1,10 @@
 import fs from 'fs-extra';
 import path from 'node:path';
 
-import {CliError} from '../../../core/errors.js';
 import type {AppConfig} from '../../../core/config/load-config.js';
 import type {OAuthTokenClient} from '../../../core/http/auth.js';
 import type {LiferayApiClient} from '../../../core/http/client.js';
+import {LiferayErrors} from '../errors/index.js';
 import {runLiferayInventorySitesIncludingGlobal} from '../inventory/liferay-inventory-sites.js';
 import {runLiferayInventoryTemplates, type LiferayInventoryTemplate} from '../inventory/liferay-inventory-templates.js';
 import {listDdmTemplates} from './liferay-resource-shared.js';
@@ -148,7 +148,7 @@ async function exportTemplatesForSite(
       const script = normalizeLiferayTemplateScript(String(template.templateScript ?? ''));
 
       if (script.trim() === '') {
-        throw new CliError('templateScript is empty', {code: 'LIFERAY_RESOURCE_ERROR'});
+        throw LiferayErrors.resourceError('templateScript is empty');
       }
 
       const outputName = `${sanitizeArtifactToken(resolveTemplateExportName(template))}.ftl`;

--- a/src/features/liferay/resource/liferay-resource-get-adt.ts
+++ b/src/features/liferay/resource/liferay-resource-get-adt.ts
@@ -2,6 +2,7 @@ import {CliError} from '../../../core/errors.js';
 import type {AppConfig} from '../../../core/config/load-config.js';
 import type {OAuthTokenClient} from '../../../core/http/auth.js';
 import type {LiferayApiClient} from '../../../core/http/client.js';
+import {LiferayErrors} from '../errors/index.js';
 import {runLiferayInventorySitesIncludingGlobal} from '../inventory/liferay-inventory-sites.js';
 import {ADT_WIDGET_DIR_BY_TYPE} from './liferay-resource-paths.js';
 import {runLiferayResourceListAdts} from './liferay-resource-list-adts.js';
@@ -78,9 +79,7 @@ export async function runLiferayResourceGetAdt(
       }
     }
 
-    throw new CliError(`ADT not found: ${identifier}`, {
-      code: 'LIFERAY_RESOURCE_ERROR',
-    });
+    throw LiferayErrors.resourceError(`ADT not found: ${identifier}`);
   }
 
   // No site specified: search across all accessible sites and detect ambiguity.
@@ -123,9 +122,7 @@ export async function runLiferayResourceGetAdt(
   }
 
   if (matches.length === 0) {
-    throw new CliError(`ADT not found: ${identifier}`, {
-      code: 'LIFERAY_RESOURCE_ERROR',
-    });
+    throw LiferayErrors.resourceError(`ADT not found: ${identifier}`);
   }
 
   if (matches.length > 1) {

--- a/src/features/liferay/resource/liferay-resource-get-structure.ts
+++ b/src/features/liferay/resource/liferay-resource-get-structure.ts
@@ -1,8 +1,8 @@
-import {CliError} from '../../../core/errors.js';
 import type {AppConfig} from '../../../core/config/load-config.js';
 import type {OAuthTokenClient} from '../../../core/http/auth.js';
 import type {LiferayApiClient} from '../../../core/http/client.js';
 import {createLiferayApiClient} from '../../../core/http/client.js';
+import {LiferayErrors} from '../errors/index.js';
 import {authedGet, fetchAccessToken, normalizeLocalizedName} from '../inventory/liferay-inventory-shared.js';
 import {buildResourceSiteChain, resolveResourceSite} from './liferay-resource-shared.js';
 import type {DataDefinitionPayload} from './liferay-resource-payloads.js';
@@ -32,9 +32,7 @@ export async function runLiferayResourceGetStructure(
   let site = await resolveResourceSite(config, options.site ?? '/global', dependencies);
   const identifier = String(options.key ?? options.id ?? '').trim();
   if (identifier === '') {
-    throw new CliError('Provide --key or --id.', {
-      code: 'LIFERAY_RESOURCE_ERROR',
-    });
+    throw LiferayErrors.resourceError('Provide --key or --id.');
   }
 
   let payload: DataDefinitionPayload | null = null;
@@ -76,13 +74,9 @@ export async function runLiferayResourceGetStructure(
 
   if (!payload) {
     if (lastKeyLookupStatus !== null) {
-      throw new CliError(`resource get-structure failed with status=${lastKeyLookupStatus}.`, {
-        code: 'LIFERAY_RESOURCE_ERROR',
-      });
+      throw LiferayErrors.resourceError(`resource get-structure failed with status=${lastKeyLookupStatus}.`);
     }
-    throw new CliError(`Estructura no encontrada: ${identifier}`, {
-      code: 'LIFERAY_RESOURCE_ERROR',
-    });
+    throw LiferayErrors.resourceError(`Estructura no encontrada: ${identifier}`);
   }
 
   return {

--- a/src/features/liferay/resource/liferay-resource-get-template.ts
+++ b/src/features/liferay/resource/liferay-resource-get-template.ts
@@ -1,7 +1,7 @@
-import {CliError} from '../../../core/errors.js';
 import type {AppConfig} from '../../../core/config/load-config.js';
 import type {OAuthTokenClient} from '../../../core/http/auth.js';
 import type {LiferayApiClient} from '../../../core/http/client.js';
+import {LiferayErrors} from '../errors/index.js';
 import {runLiferayInventoryTemplates} from '../inventory/liferay-inventory-templates.js';
 import {buildResourceSiteChain, resolveResourceSite, listDdmTemplates} from './liferay-resource-shared.js';
 import {matchesDdmTemplate, matchesInventoryTemplate} from '../liferay-identifiers.js';
@@ -74,9 +74,7 @@ export async function runLiferayResourceGetTemplate(
   }
 
   if (!match) {
-    throw new CliError(`Template not found: ${options.id}`, {
-      code: 'LIFERAY_RESOURCE_ERROR',
-    });
+    throw LiferayErrors.resourceError(`Template not found: ${options.id}`);
   }
 
   return {

--- a/src/features/liferay/resource/liferay-resource-import-adts.ts
+++ b/src/features/liferay/resource/liferay-resource-import-adts.ts
@@ -1,8 +1,9 @@
 import fs from 'fs-extra';
 import path from 'node:path';
 
-import {CliError, normalizeCliError} from '../../../core/errors.js';
+import {normalizeCliError} from '../../../core/errors.js';
 import type {AppConfig} from '../../../core/config/load-config.js';
+import {LiferayErrors} from '../errors/index.js';
 import {resolveArtifactBaseDir, resolveSiteToken, siteTokenToFriendlyUrl} from './artifact-paths.js';
 import type {LiferayResourceImportFailure} from './liferay-resource-import-structures.js';
 import type {ResourceSyncDependencies} from './liferay-resource-sync-shared.js';
@@ -38,9 +39,8 @@ export async function runLiferayResourceImportAdts(
   const hasScopedFilter =
     adtKeys.length > 0 || Boolean(options?.widgetType?.trim()) || Boolean(options?.className?.trim());
   if (!options?.allSites && !options?.apply && !hasScopedFilter) {
-    throw new CliError(
+    throw LiferayErrors.resourceError(
       'resource import-adts requires --adt <key> (repeatable), --widget-type, --class-name, --apply for the resolved site, or --all-sites to avoid accidental mass imports.',
-      {code: 'LIFERAY_RESOURCE_ERROR'},
     );
   }
 
@@ -78,10 +78,10 @@ export async function runLiferayResourceImportAdts(
         const failure = toImportFailure(siteTokenToFriendlyUrl(siteToken), entry, file, error);
         failures.push(failure);
         if (!options?.continueOnError) {
-          throw new CliError(`Import failed for ADT '${entry}' in site '${failure.site}': ${failure.message}`, {
-            code: 'LIFERAY_RESOURCE_ERROR',
-            details: failure,
-          });
+          throw LiferayErrors.resourceError(
+            `Import failed for ADT '${entry}' in site '${failure.site}': ${failure.message}`,
+            {details: failure},
+          );
         }
       }
     }

--- a/src/features/liferay/resource/liferay-resource-import-structures.ts
+++ b/src/features/liferay/resource/liferay-resource-import-structures.ts
@@ -1,8 +1,9 @@
 import fs from 'fs-extra';
 import path from 'node:path';
 
-import {CliError, normalizeCliError} from '../../../core/errors.js';
+import {normalizeCliError} from '../../../core/errors.js';
 import type {AppConfig} from '../../../core/config/load-config.js';
+import {LiferayErrors} from '../errors/index.js';
 import {resolveArtifactBaseDir, resolveSiteToken, siteTokenToFriendlyUrl} from './artifact-paths.js';
 import type {ResourceSyncDependencies} from './liferay-resource-sync-shared.js';
 import {runLiferayResourceSyncStructure} from './liferay-resource-sync-structure.js';
@@ -46,9 +47,8 @@ export async function runLiferayResourceImportStructures(
 ): Promise<LiferayResourceImportStructuresResult> {
   const structureKeys = normalizeKeys(options?.structureKeys);
   if (!options?.allSites && !options?.apply && structureKeys.length === 0) {
-    throw new CliError(
+    throw LiferayErrors.resourceError(
       'resource import-structures requires --structure <key> (repeatable), --apply for the resolved site, or --all-sites to avoid accidental mass imports.',
-      {code: 'LIFERAY_RESOURCE_ERROR'},
     );
   }
 
@@ -86,10 +86,10 @@ export async function runLiferayResourceImportStructures(
         const failure = toImportFailure(siteTokenToFriendlyUrl(siteToken), key, file, error);
         failures.push(failure);
         if (!options?.continueOnError) {
-          throw new CliError(`Import failed for structure '${key}' in site '${failure.site}': ${failure.message}`, {
-            code: 'LIFERAY_RESOURCE_ERROR',
-            details: failure,
-          });
+          throw LiferayErrors.resourceError(
+            `Import failed for structure '${key}' in site '${failure.site}': ${failure.message}`,
+            {details: failure},
+          );
         }
       }
     }

--- a/src/features/liferay/resource/liferay-resource-import-templates.ts
+++ b/src/features/liferay/resource/liferay-resource-import-templates.ts
@@ -1,8 +1,9 @@
 import fs from 'fs-extra';
 import path from 'node:path';
 
-import {CliError, normalizeCliError} from '../../../core/errors.js';
+import {normalizeCliError} from '../../../core/errors.js';
 import type {AppConfig} from '../../../core/config/load-config.js';
+import {LiferayErrors} from '../errors/index.js';
 import {resolveArtifactBaseDir, resolveSiteToken, siteTokenToFriendlyUrl} from './artifact-paths.js';
 import type {LiferayResourceImportFailure} from './liferay-resource-import-structures.js';
 import type {ResourceSyncDependencies} from './liferay-resource-sync-shared.js';
@@ -35,9 +36,8 @@ export async function runLiferayResourceImportTemplates(
 ): Promise<LiferayResourceImportTemplatesResult> {
   const templateKeys = normalizeTemplateKeys(options?.templateKeys);
   if (!options?.allSites && !options?.apply && templateKeys.length === 0) {
-    throw new CliError(
+    throw LiferayErrors.resourceError(
       'resource import-templates requires --template <key> (repeatable), --apply for the resolved site, or --all-sites to avoid accidental mass imports.',
-      {code: 'LIFERAY_RESOURCE_ERROR'},
     );
   }
 
@@ -70,10 +70,10 @@ export async function runLiferayResourceImportTemplates(
         const failure = toImportFailure(siteTokenToFriendlyUrl(siteToken), id, file, error);
         failures.push(failure);
         if (!options?.continueOnError) {
-          throw new CliError(`Import failed for template '${id}' in site '${failure.site}': ${failure.message}`, {
-            code: 'LIFERAY_RESOURCE_ERROR',
-            details: failure,
-          });
+          throw LiferayErrors.resourceError(
+            `Import failed for template '${id}' in site '${failure.site}': ${failure.message}`,
+            {details: failure},
+          );
         }
       }
     }

--- a/src/features/liferay/resource/liferay-resource-migration-init.ts
+++ b/src/features/liferay/resource/liferay-resource-migration-init.ts
@@ -1,10 +1,10 @@
 import fs from 'fs-extra';
 import path from 'node:path';
 
-import {CliError} from '../../../core/errors.js';
 import type {AppConfig} from '../../../core/config/load-config.js';
 import type {OAuthTokenClient} from '../../../core/http/auth.js';
 import type {LiferayApiClient} from '../../../core/http/client.js';
+import {LiferayErrors} from '../errors/index.js';
 import {runLiferayResourceGetStructure} from './liferay-resource-get-structure.js';
 import {resolveMigrationsBaseDir, resolveSiteToken, resolveStructureFile} from './liferay-resource-paths.js';
 
@@ -61,9 +61,9 @@ export async function runLiferayResourceMigrationInit(
   );
 
   if ((await fs.pathExists(outputPath)) && !options.overwrite) {
-    throw new CliError(`The descriptor already exists: ${outputPath}. Use --overwrite to regenerate it.`, {
-      code: 'LIFERAY_RESOURCE_ERROR',
-    });
+    throw LiferayErrors.resourceError(
+      `The descriptor already exists: ${outputPath}. Use --overwrite to regenerate it.`,
+    );
   }
 
   const descriptor = {

--- a/src/features/liferay/resource/liferay-resource-migration.ts
+++ b/src/features/liferay/resource/liferay-resource-migration.ts
@@ -2,8 +2,8 @@ import fs from 'fs-extra';
 import os from 'node:os';
 import path from 'node:path';
 
-import {CliError} from '../../../core/errors.js';
 import type {AppConfig} from '../../../core/config/load-config.js';
+import {LiferayErrors} from '../errors/index.js';
 import {runLiferayInventoryTemplates} from '../inventory/liferay-inventory-templates.js';
 import {runLiferayResourceGetStructure} from './liferay-resource-get-structure.js';
 import {resolveStructureFile} from './liferay-resource-paths.js';
@@ -266,7 +266,7 @@ async function readDescriptorNode(config: AppConfig, migrationFile: string): Pro
     ? migrationFile
     : path.resolve(config.repoRoot ?? config.cwd, migrationFile);
   if (!(await fs.pathExists(candidate))) {
-    throw new CliError(`Migration descriptor not found: ${migrationFile}`, {code: 'LIFERAY_RESOURCE_ERROR'});
+    throw LiferayErrors.resourceError(`Migration descriptor not found: ${migrationFile}`);
   }
   return await fs.readJson(candidate);
 }
@@ -275,12 +275,12 @@ function parseMigrationDescriptor(descriptorNode: Record<string, unknown>): Migr
   const site = String(descriptorNode.site ?? '/global').trim() || '/global';
   const structureKey = String(descriptorNode.structureKey ?? '').trim();
   if (structureKey === '') {
-    throw new CliError('Invalid descriptor: missing structureKey', {code: 'LIFERAY_RESOURCE_ERROR'});
+    throw LiferayErrors.resourceError('Invalid descriptor: missing structureKey');
   }
 
   const introduceNode = asRecord(descriptorNode.introduce);
   if (Object.keys(introduceNode).length === 0) {
-    throw new CliError('Invalid descriptor: missing introduce.', {code: 'LIFERAY_RESOURCE_ERROR'});
+    throw LiferayErrors.resourceError('Invalid descriptor: missing introduce.');
   }
 
   const introduce = parseStageDescriptor(introduceNode, 'introduce');
@@ -302,7 +302,7 @@ function parseStageDescriptor(node: Record<string, unknown>, stageName: Migratio
     mappings: normalizeMappingsArray(rawPlanNode.mappings),
   };
   if (!Array.isArray(planNode.mappings) || planNode.mappings.length === 0) {
-    throw new CliError(`Invalid descriptor: ${stageName}.mappings[] is empty.`, {code: 'LIFERAY_RESOURCE_ERROR'});
+    throw LiferayErrors.resourceError(`Invalid descriptor: ${stageName}.mappings[] is empty.`);
   }
   return {
     structureFile,
@@ -418,9 +418,8 @@ function buildCleanupPlanNode(
     (Array.isArray(explicitRootFolderIds) && explicitRootFolderIds.length > 0);
 
   if (migratedArticleKeys.length === 0 && !hasExplicitScope) {
-    throw new CliError(
+    throw LiferayErrors.resourceError(
       'Cleanup stage unsafe: no migrated articleIds were produced and the descriptor does not declare articleIds, folderIds or rootFolderIds.',
-      {code: 'LIFERAY_RESOURCE_ERROR'},
     );
   }
 

--- a/src/features/liferay/resource/liferay-resource-shared.ts
+++ b/src/features/liferay/resource/liferay-resource-shared.ts
@@ -1,8 +1,8 @@
-import {CliError} from '../../../core/errors.js';
 import type {AppConfig} from '../../../core/config/load-config.js';
 import type {OAuthTokenClient} from '../../../core/http/auth.js';
 import type {LiferayApiClient} from '../../../core/http/client.js';
 import {createLiferayApiClient} from '../../../core/http/client.js';
+import {LiferayErrors} from '../errors/index.js';
 import {
   authedGet,
   expectJsonSuccess,
@@ -54,9 +54,7 @@ export async function resolveResourceSite(
   const companyId = await resolveCompanyId(config, apiClient, accessToken, resolvedSite.id);
 
   if (companyId <= 0) {
-    throw new CliError(`site sin companyId valido: ${site}`, {
-      code: 'LIFERAY_RESOURCE_ERROR',
-    });
+    throw LiferayErrors.resourceError(`site sin companyId valido: ${site}`);
   }
 
   return {
@@ -201,9 +199,7 @@ async function fetchClassNameId(
   const success = await expectJsonSuccess(response, `classname ${className}`);
   const classNameId = success.data?.classNameId ?? -1;
   if (classNameId <= 0) {
-    throw new CliError(`classNameId no resuelto para ${className}`, {
-      code: 'LIFERAY_RESOURCE_ERROR',
-    });
+    throw LiferayErrors.resourceError(`classNameId no resuelto para ${className}`);
   }
   classNameIdLookupCache.set(cacheKey, classNameId);
   return classNameId;

--- a/src/features/liferay/resource/liferay-resource-sync-adt.ts
+++ b/src/features/liferay/resource/liferay-resource-sync-adt.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 
-import {CliError} from '../../../core/errors.js';
 import type {AppConfig} from '../../../core/config/load-config.js';
+import {LiferayErrors} from '../errors/index.js';
 import type {ResourceSyncDependencies, ResourceSyncResult} from './liferay-resource-sync-shared.js';
 import {resolveResourceSite} from './liferay-resource-shared.js';
 import {
@@ -38,9 +38,7 @@ export async function runLiferayResourceSyncAdt(
   const resolvedWidget = normalizeAdtWidgetType(options.widgetType ?? inferAdtWidgetType(options.file ?? ''));
   const resolvedClassName = options.className?.trim() || ADT_CLASS_BY_WIDGET_TYPE[resolvedWidget];
   if (!resolvedWidget || !resolvedClassName) {
-    throw new CliError(`widget-type ADT no soportado: ${resolvedWidget || options.widgetType || ''}`, {
-      code: 'LIFERAY_RESOURCE_ERROR',
-    });
+    throw LiferayErrors.resourceError(`widget-type ADT no soportado: ${resolvedWidget || options.widgetType || ''}`);
   }
 
   const name = options.key?.trim() || inferAdtName(options.file ?? '');
@@ -130,9 +128,8 @@ function inferAdtWidgetType(file: string): string {
  */
 function inferAdtName(file: string): string {
   if (!file) {
-    throw new CliError(
+    throw LiferayErrors.resourceError(
       "ADT requires --file or (--key and --widget-type). Use 'resource adt --display-style ddmTemplate_<ID>' if you need to inspect it first.",
-      {code: 'LIFERAY_RESOURCE_ERROR'},
     );
   }
   return path.basename(file, path.extname(file));

--- a/src/features/liferay/resource/liferay-resource-sync-fragments-api.ts
+++ b/src/features/liferay/resource/liferay-resource-sync-fragments-api.ts
@@ -1,4 +1,4 @@
-import {CliError} from '../../../core/errors.js';
+import {LiferayErrors} from '../errors/index.js';
 import type {AppConfig} from '../../../core/config/load-config.js';
 import {listFragmentCollections, listFragments} from './liferay-resource-shared.js';
 import {postFormCandidates, type ResourceSyncDependencies} from './liferay-resource-sync-shared.js';
@@ -165,9 +165,7 @@ export async function updateFragmentEntry(
   dependencies?: ResourceSyncDependencies,
 ): Promise<FragmentEntryPayload> {
   if (fragmentEntryId <= 0) {
-    throw new CliError(`fragmentEntryId invalido para ${fragment.slug}`, {
-      code: 'LIFERAY_RESOURCE_ERROR',
-    });
+    throw LiferayErrors.resourceError(`fragmentEntryId invalido para ${fragment.slug}`);
   }
 
   const base = {

--- a/src/features/liferay/resource/liferay-resource-sync-fragments-importer.ts
+++ b/src/features/liferay/resource/liferay-resource-sync-fragments-importer.ts
@@ -1,5 +1,5 @@
-import {CliError} from '../../../core/errors.js';
 import type {AppConfig} from '../../../core/config/load-config.js';
+import {LiferayErrors} from '../errors/index.js';
 import type {ResourceSyncDependencies} from './liferay-resource-sync-shared.js';
 import {
   createFragmentCollection,
@@ -47,9 +47,7 @@ export async function runFragmentsImportLegacy(
 
       const collectionId = Number(runtimeCollection.fragmentCollectionId ?? -1);
       if (collectionId <= 0) {
-        throw new CliError(`fragmentCollectionId invalido para ${localCollection.slug}`, {
-          code: 'LIFERAY_RESOURCE_ERROR',
-        });
+        throw LiferayErrors.resourceError(`fragmentCollectionId invalido para ${localCollection.slug}`);
       }
 
       const runtimeByKey = await listRuntimeFragmentsByKey(config, collectionId, dependencies);

--- a/src/features/liferay/resource/liferay-resource-sync-fragments-local.ts
+++ b/src/features/liferay/resource/liferay-resource-sync-fragments-local.ts
@@ -1,8 +1,8 @@
 import fs from 'fs-extra';
 import path from 'node:path';
 
-import {CliError} from '../../../core/errors.js';
 import type {AppConfig} from '../../../core/config/load-config.js';
+import {LiferayErrors} from '../errors/index.js';
 import {resolveFragmentProjectDir as resolveArtifactFragmentProjectDir} from './artifact-paths.js';
 import type {
   LocalFragment,
@@ -20,9 +20,7 @@ export async function readLocalFragmentsProject(
 ): Promise<LocalFragmentsProject> {
   const srcDir = path.join(projectDir, 'src');
   if (!(await fs.pathExists(srcDir))) {
-    throw new CliError(`src directory not found in ${projectDir}`, {
-      code: 'LIFERAY_RESOURCE_ERROR',
-    });
+    throw LiferayErrors.resourceError(`src directory not found in ${projectDir}`);
   }
 
   const collections: LocalFragmentCollection[] = [];
@@ -65,13 +63,9 @@ export async function readLocalFragmentsProject(
 
   if (collections.length === 0) {
     if (filter !== '') {
-      throw new CliError(`Fragment '${filter}' not found in ${projectDir}`, {
-        code: 'LIFERAY_RESOURCE_ERROR',
-      });
+      throw LiferayErrors.resourceError(`Fragment '${filter}' not found in ${projectDir}`);
     }
-    throw new CliError(`No fragments were found to import in ${projectDir}`, {
-      code: 'LIFERAY_RESOURCE_ERROR',
-    });
+    throw LiferayErrors.resourceError(`No fragments were found to import in ${projectDir}`);
   }
 
   return {

--- a/src/features/liferay/resource/liferay-resource-sync-fragments.ts
+++ b/src/features/liferay/resource/liferay-resource-sync-fragments.ts
@@ -1,7 +1,7 @@
 import fs from 'fs-extra';
 
-import {CliError} from '../../../core/errors.js';
 import type {AppConfig} from '../../../core/config/load-config.js';
+import {LiferayErrors} from '../errors/index.js';
 import {runLiferayInventorySitesIncludingGlobal} from '../inventory/liferay-inventory-sites.js';
 import {resolveSiteToken} from './liferay-resource-paths.js';
 import {resolveResourceSite} from './liferay-resource-shared.js';
@@ -33,9 +33,7 @@ export async function runLiferayResourceSyncFragments(
   dependencies?: ResourceSyncDependencies,
 ): Promise<LiferayResourceSyncFragmentsResult> {
   if (options?.allSites && (options?.fragment ?? '').trim() !== '') {
-    throw new CliError('--fragment requires --site or --site-id', {
-      code: 'LIFERAY_RESOURCE_ERROR',
-    });
+    throw LiferayErrors.resourceError('--fragment requires --site or --site-id');
   }
 
   if (options?.allSites) {

--- a/src/features/liferay/resource/liferay-resource-sync-shared.ts
+++ b/src/features/liferay/resource/liferay-resource-sync-shared.ts
@@ -1,10 +1,10 @@
 import {createHash} from 'node:crypto';
 
-import {CliError} from '../../../core/errors.js';
 import type {AppConfig} from '../../../core/config/load-config.js';
 import type {OAuthTokenClient} from '../../../core/http/auth.js';
 import type {LiferayApiClient} from '../../../core/http/client.js';
 import {createLiferayApiClient, type HttpResponse} from '../../../core/http/client.js';
+import {LiferayErrors} from '../errors/index.js';
 import {buildAuthOptions, ensureData, expectJsonSuccess} from '../liferay-http-shared.js';
 import {fetchAccessToken} from '../inventory/liferay-inventory-shared.js';
 
@@ -51,9 +51,7 @@ export async function postFormCandidates<T>(
     errors.push(`status=${response.status} body=${response.body}`);
   }
 
-  throw new CliError(`${operation} failed on ${apiPath} (${errors.join(' | ')})`, {
-    code: 'LIFERAY_RESOURCE_ERROR',
-  });
+  throw LiferayErrors.resourceError(`${operation} failed on ${apiPath} (${errors.join(' | ')})`);
 }
 
 export async function authedPostMultipart<T>(
@@ -134,7 +132,7 @@ export function normalizeSyncStatus(checkOnly: boolean): 'checked' | 'updated' {
 export function ensureString(value: unknown, label: string): string {
   const normalized = String(value ?? '').trim();
   if (normalized === '') {
-    throw new CliError(`${label} is empty`, {code: 'LIFERAY_RESOURCE_ERROR'});
+    throw LiferayErrors.resourceError(`${label} is empty`);
   }
   return normalized;
 }

--- a/src/features/liferay/resource/liferay-resource-sync-structure-migration.ts
+++ b/src/features/liferay/resource/liferay-resource-sync-structure-migration.ts
@@ -1,9 +1,9 @@
 import fs from 'fs-extra';
 
-import {CliError} from '../../../core/errors.js';
 import type {AppConfig} from '../../../core/config/load-config.js';
 import type {OAuthTokenClient} from '../../../core/http/auth.js';
 import type {LiferayApiClient} from '../../../core/http/client.js';
+import {LiferayErrors} from '../errors/index.js';
 import {fetchAccessToken} from '../inventory/liferay-inventory-shared.js';
 import {authOptions, expectJsonSuccess} from './liferay-resource-sync-structure-utils.js';
 
@@ -65,12 +65,12 @@ export async function runStructureMigration(
       : planRoot;
   const planData = parseMigrationPlan(plan);
   if (planData.rules.length === 0) {
-    throw new CliError('Invalid migration plan: missing mappings[]', {code: 'LIFERAY_RESOURCE_ERROR'});
+    throw LiferayErrors.resourceError('Invalid migration plan: missing mappings[]');
   }
 
   const structure = await options.fetchStructureByKeyFn(config, options.apiClient, accessToken, siteId, structureKey);
   if (!structure?.id) {
-    throw new CliError(`Could not resolve structure ${structureKey}`, {code: 'LIFERAY_RESOURCE_ERROR'});
+    throw LiferayErrors.resourceError(`Could not resolve structure ${structureKey}`);
   }
 
   const selected = await selectStructureContents(
@@ -163,8 +163,7 @@ export async function runStructureMigration(
     const summary = failures
       .map(({contentId, articleKey, message}) => `${articleKey || contentId}: ${message}`)
       .join('; ');
-    throw new CliError(`Structure migration failed for ${failures.length} content item(s): ${summary}`, {
-      code: 'LIFERAY_RESOURCE_ERROR',
+    throw LiferayErrors.resourceError(`Structure migration failed for ${failures.length} content item(s): ${summary}`, {
       details: {stats, failures},
     });
   }
@@ -394,9 +393,8 @@ async function verifyStructuredContentPersistence(
     }
   }
 
-  throw new CliError(
+  throw LiferayErrors.resourceError(
     `structure-migrate update was accepted but contentFields were not persisted for content ${contentId}.`,
-    {code: 'LIFERAY_RESOURCE_ERROR'},
   );
 }
 

--- a/src/features/liferay/resource/liferay-resource-sync-structure-shared.ts
+++ b/src/features/liferay/resource/liferay-resource-sync-structure-shared.ts
@@ -1,8 +1,8 @@
-import {CliError} from '../../../core/errors.js';
 import type {AppConfig} from '../../../core/config/load-config.js';
 import type {OAuthTokenClient} from '../../../core/http/auth.js';
 import type {LiferayApiClient} from '../../../core/http/client.js';
 import {createLiferayApiClient} from '../../../core/http/client.js';
+import {LiferayErrors} from '../errors/index.js';
 import {fetchAccessToken} from '../inventory/liferay-inventory-shared.js';
 
 type ResourceDependencies = {
@@ -30,7 +30,7 @@ export async function fetchStructureByKey(
   );
 
   if (!response.ok) {
-    throw new CliError(`structure-get failed with status=${response.status}.`, {code: 'LIFERAY_RESOURCE_ERROR'});
+    throw LiferayErrors.resourceError(`structure-get failed with status=${response.status}.`);
   }
 
   return response.data ?? {};

--- a/src/features/liferay/resource/liferay-resource-sync-structure.ts
+++ b/src/features/liferay/resource/liferay-resource-sync-structure.ts
@@ -1,5 +1,6 @@
 import type {AppConfig} from '../../../core/config/load-config.js';
 import {CliError} from '../../../core/errors.js';
+import {LiferayErrors} from '../errors/index.js';
 import {resolveSite} from '../inventory/liferay-inventory-shared.js';
 import {resolveStructureFile} from './liferay-resource-paths.js';
 import type {MigrationStats} from './liferay-resource-sync-structure-migration.js';
@@ -67,9 +68,7 @@ export async function runLiferayResourceSyncStructure(
 
   // Guard: missing + !createMissing
   if (!remote && !options.createMissing) {
-    throw new CliError(`Structure '${options.key}' does not exist and create-missing is not enabled.`, {
-      code: 'LIFERAY_RESOURCE_ERROR',
-    });
+    throw LiferayErrors.resourceError(`Structure '${options.key}' does not exist and create-missing is not enabled.`);
   }
 
   // Guard: missing + checkOnly

--- a/src/features/liferay/resource/sync-engine.ts
+++ b/src/features/liferay/resource/sync-engine.ts
@@ -15,6 +15,7 @@
 import type {AppConfig} from '../../../core/config/load-config.js';
 import {CliError} from '../../../core/errors.js';
 import type {ResolvedSite} from '../inventory/liferay-site-resolver.js';
+import {LiferayErrors} from '../errors/index.js';
 import type {ResourceSyncDependencies, ResourceSyncResult} from './liferay-resource-sync-shared.js';
 
 /**
@@ -138,9 +139,9 @@ export async function syncArtifact<Local = Record<string, unknown>, Remote = Rec
 
   // 3. If missing and not allowed, preserve legacy sync semantics.
   if (!remoteArtifact && !options.createMissing) {
-    throw new CliError(`Artifact '${localArtifact.id}' does not exist and create-missing is not enabled.`, {
-      code: 'LIFERAY_RESOURCE_ERROR',
-    });
+    throw LiferayErrors.resourceError(
+      `Artifact '${localArtifact.id}' does not exist and create-missing is not enabled.`,
+    );
   }
 
   // 4. If missing and check-only (only reachable when createMissing=true)

--- a/src/features/liferay/resource/sync-strategies/adt-sync-strategy.ts
+++ b/src/features/liferay/resource/sync-strategies/adt-sync-strategy.ts
@@ -8,6 +8,7 @@ import fs from 'fs-extra';
 import type {AppConfig} from '../../../../core/config/load-config.js';
 import {CliError} from '../../../../core/errors.js';
 import type {ResolvedSite} from '../../inventory/liferay-site-resolver.js';
+import {LiferayErrors} from '../../errors/index.js';
 import {runLiferayResourceListAdts} from '../liferay-resource-list-adts.js';
 import {resolveAdtFile} from '../liferay-resource-paths.js';
 import {fetchAdtResourceClassNameId, fetchClassNameIdForValue} from '../liferay-resource-shared.js';
@@ -223,9 +224,7 @@ export const adtSyncStrategy: SyncStrategy<AdtLocalData, AdtRemoteData> = {
     if (runtime?.script) {
       const runtimeHash = sha256(runtime.script);
       if (runtimeHash !== localArtifact.contentHash) {
-        throw new CliError(`Hash mismatch ADT '${remoteArtifact.name}'`, {
-          code: 'LIFERAY_RESOURCE_ERROR',
-        });
+        throw LiferayErrors.resourceError(`Hash mismatch ADT '${remoteArtifact.name}'`);
       }
     }
   },

--- a/src/features/liferay/resource/sync-strategies/structure-sync-strategy.ts
+++ b/src/features/liferay/resource/sync-strategies/structure-sync-strategy.ts
@@ -10,6 +10,7 @@ import {CliError} from '../../../../core/errors.js';
 import type {LiferayApiClient} from '../../../../core/http/client.js';
 import type {OAuthTokenClient} from '../../../../core/http/auth.js';
 import {createLiferayApiClient} from '../../../../core/http/client.js';
+import {LiferayErrors} from '../../errors/index.js';
 import {fetchAccessToken} from '../../inventory/liferay-inventory-shared.js';
 import type {ResolvedSite} from '../../inventory/liferay-site-resolver.js';
 import {resolveStructureFile} from '../liferay-resource-paths.js';
@@ -150,9 +151,8 @@ export const structureSyncStrategy: SyncStrategy<StructureLocalData, StructureRe
 
     // Breaking-change guard
     if (removedFieldReferences.length > 0 && !opts.migrationPlan && !opts.allowBreakingChange) {
-      throw new CliError(
+      throw LiferayErrors.resourceBreakingChange(
         `Blocked change: the structure removes ${removedFieldReferences.length} field(s) ${removedFieldReferences.join(', ')}. Define --migration-plan or use --allow-breaking-change.`,
-        {code: 'LIFERAY_RESOURCE_BREAKING_CHANGE'},
       );
     }
 
@@ -362,12 +362,9 @@ async function updateStructureWithRecovery(
       return {data: recovered, recoveredAfterTimeout: true};
     }
 
-    throw new CliError(
+    throw LiferayErrors.resourceTimeoutRecoverable(
       `structure-update timed out, and ldev could not confirm whether the update eventually applied. Re-run 'ldev resource get-structure --site ${siteId} --key ${key}' or retry the import once the portal is responsive again.`,
-      {
-        code: 'LIFERAY_RESOURCE_TIMEOUT_RECOVERABLE',
-        details: {operation: 'structure-update', key, siteId, recoverable: true},
-      },
+      {details: {operation: 'structure-update', key, siteId, recoverable: true}},
     );
   }
 }

--- a/src/features/liferay/resource/sync-strategies/template-sync-strategy.ts
+++ b/src/features/liferay/resource/sync-strategies/template-sync-strategy.ts
@@ -9,6 +9,7 @@ import type {AppConfig} from '../../../../core/config/load-config.js';
 import {CliError} from '../../../../core/errors.js';
 import type {ResolvedSite} from '../../inventory/liferay-site-resolver.js';
 import {runLiferayInventoryTemplates} from '../../inventory/liferay-inventory-templates.js';
+import {LiferayErrors} from '../../errors/index.js';
 import {runLiferayResourceGetTemplate} from '../liferay-resource-get-template.js';
 import {fetchStructureByKey} from '../liferay-resource-sync-structure-shared.js';
 import {resolveTemplateFile, resolveSiteToken} from '../liferay-resource-paths.js';
@@ -160,9 +161,7 @@ export const templateSyncStrategy: SyncStrategy<TemplateLocalData, TemplateRemot
     if (!remoteArtifact) {
       // Create new template
       if (!opts.structureKey) {
-        throw new CliError('To create a template, provide --structure-key.', {
-          code: 'LIFERAY_RESOURCE_ERROR',
-        });
+        throw LiferayErrors.resourceError('To create a template, provide --structure-key.');
       }
 
       const {classNameId, resourceClassNameId} = await fetchStructureTemplateClassIds(config, dependencies);
@@ -248,9 +247,7 @@ export const templateSyncStrategy: SyncStrategy<TemplateLocalData, TemplateRemot
 
     // Verify hash match
     if (runtimeHash !== '' && runtimeHash !== localArtifact.contentHash) {
-      throw new CliError(`Hash mismatch template '${remoteArtifact.name}'`, {
-        code: 'LIFERAY_RESOURCE_ERROR',
-      });
+      throw LiferayErrors.resourceError(`Hash mismatch template '${remoteArtifact.name}'`);
     }
   },
 };


### PR DESCRIPTION
## Summary
- Replaces safe direct `new CliError(message, {code: ...})` usages under `src/features/liferay/**` with the corresponding `LiferayErrors` factories.
- Keeps the change mechanical and reversible by preserving the existing throw sites, control flow, messages, and `details` objects.
- Leaves excluded and non-compatible cases untouched.

## What Changed
- Migrated safe direct uses for:
  - `LIFERAY_INVENTORY_ERROR`
  - `LIFERAY_RESOURCE_ERROR`
  - `LIFERAY_RESOURCE_BREAKING_CHANGE`
  - `LIFERAY_RESOURCE_TIMEOUT_RECOVERABLE`
  - `LIFERAY_CONTENT_PRUNE_ERROR`
  - `LIFERAY_CONTENT_STATS_ERROR`
  - `LIFERAY_THEME_ERROR`
  - `LIFERAY_PAGE_LAYOUT_ERROR`
- Cleaned up unused `CliError` imports where they were no longer needed.
- Preserved `CliError` imports in files that still need them for excluded codes or dynamic error-code paths.

## Explicitly Left Out
- Excluded codes:
  - `LIFERAY_SITE_NOT_FOUND`
  - `LIFERAY_RESOURCE_FILE_NOT_FOUND`
  - `LIFERAY_RESOURCE_FILE_AMBIGUOUS`
  - `LIFERAY_REPO_NOT_FOUND`
  - `LIFERAY_CONFIG_INCOMPLETE`
  - `LIFERAY_SEARCH_ERROR`
- Dynamic `errorCode` helpers, especially `src/features/liferay/liferay-http-shared.ts`.
- One `LIFERAY_RESOURCE_ERROR` in `src/features/liferay/resource/liferay-resource-get-adt.ts` remains direct because its current `details` payload is an array, and migrating it would require reshaping semantics beyond this PR.

## Validation
- `npm run typecheck`
- `npm run test:unit`
- `rg -n "new CliError" src/features/liferay`

## Result
Remaining direct `new CliError` usages in `src/features/liferay/**` are limited to excluded codes, dynamic error-code paths, the error factory internals, and the single non-compatible `get-adt` ambiguity case described above.
