### PR TITLE
refactor(core): extract shared concurrency helpers from content modules

### DIFF
--- a/src/core/concurrency.ts
+++ b/src/core/concurrency.ts
@@ -1,0 +1,86 @@
+/**
+ * Creates a concurrency limiter: a function that queues tasks and runs at most
+ * `concurrency` of them in parallel.
+ */
+export function createConcurrencyLimiter(concurrency: number): <T>(task: () => Promise<T>) => Promise<T> {
+  let active = 0;
+  const queue: Array<() => void> = [];
+
+  const runNext = (): void => {
+    if (active >= concurrency) {
+      return;
+    }
+
+    const next = queue.shift();
+    if (!next) {
+      return;
+    }
+
+    active += 1;
+    next();
+  };
+
+  return async <T>(task: () => Promise<T>): Promise<T> =>
+    new Promise<T>((resolve, reject) => {
+      queue.push(() => {
+        void task()
+          .then(resolve, reject)
+          .finally(() => {
+            active -= 1;
+            runNext();
+          });
+      });
+      runNext();
+    });
+}
+
+/**
+ * Runs `worker` over every item in `items` with at most `concurrency` workers
+ * in parallel, preserving result order. Returns an empty array when items is
+ * empty.
+ */
+export async function mapConcurrent<TInput, TOutput>(
+  items: TInput[],
+  concurrency: number,
+  worker: (item: TInput, index: number) => Promise<TOutput>,
+): Promise<TOutput[]> {
+  if (items.length === 0) {
+    return [];
+  }
+
+  const results = new Array<TOutput>(items.length);
+  let nextIndex = 0;
+  const workerCount = Math.min(concurrency, items.length);
+
+  await Promise.all(
+    Array.from({length: workerCount}, async () => {
+      while (true) {
+        const currentIndex = nextIndex++;
+        if (currentIndex >= items.length) {
+          return;
+        }
+
+        results[currentIndex] = await worker(items[currentIndex]!, currentIndex);
+      }
+    }),
+  );
+
+  return results;
+}
+
+/**
+ * Runs `worker` over every item in `items` with at most `concurrency` workers
+ * in parallel. Returns when all workers complete. Returns immediately for
+ * empty arrays.
+ */
+export async function runConcurrent<T>(
+  items: T[],
+  concurrency: number,
+  worker: (item: T, index: number) => Promise<void>,
+): Promise<void> {
+  if (items.length === 0) {
+    return;
+  }
+
+  await mapConcurrent(items, concurrency, worker);
+}

--- a/src/features/liferay/content/liferay-content-prune.ts
+++ b/src/features/liferay/content/liferay-content-prune.ts
@@ -1,4 +1,5 @@
 import type {AppConfig} from '../../../core/config/load-config.js';
+import {runConcurrent} from '../../../core/concurrency.js';
 import {createOAuthTokenClient, type OAuthTokenClient} from '../../../core/http/auth.js';
 import {createLiferayApiClient, type LiferayApiClient} from '../../../core/http/client.js';
 import type {Printer} from '../../../core/output/printer.js';
@@ -799,32 +800,6 @@ function isPresentNumber(value: number | undefined): value is number {
 
 function canDeleteWholeFolders(options: ContentPruneOptions): boolean {
   return (!options.structures || options.structures.length === 0) && (options.keep === undefined || options.keep === 0);
-}
-
-async function runConcurrent<T>(
-  items: T[],
-  concurrency: number,
-  worker: (item: T, index: number) => Promise<void>,
-): Promise<void> {
-  if (items.length === 0) {
-    return;
-  }
-
-  let nextIndex = 0;
-  const workerCount = Math.min(concurrency, items.length);
-
-  await Promise.all(
-    Array.from({length: workerCount}, async () => {
-      while (true) {
-        const currentIndex = nextIndex++;
-        if (currentIndex >= items.length) {
-          return;
-        }
-
-        await worker(items[currentIndex]!, currentIndex);
-      }
-    }),
-  );
 }
 
 async function deleteWithRefresh<T>(

--- a/src/features/liferay/content/liferay-content-stats.ts
+++ b/src/features/liferay/content/liferay-content-stats.ts
@@ -1,4 +1,5 @@
 import type {AppConfig} from '../../../core/config/load-config.js';
+import {createConcurrencyLimiter, mapConcurrent} from '../../../core/concurrency.js';
 import {createOAuthTokenClient, type OAuthTokenClient} from '../../../core/http/auth.js';
 import {createLiferayApiClient, type LiferayApiClient} from '../../../core/http/client.js';
 import type {Printer} from '../../../core/output/printer.js';
@@ -513,65 +514,4 @@ function compareSites(left: ContentStatsSite, right: ContentStatsSite, sortBy: '
   }
 
   return compareSitesByVolume(left, right);
-}
-
-function createConcurrencyLimiter(concurrency: number): <T>(task: () => Promise<T>) => Promise<T> {
-  let active = 0;
-  const queue: Array<() => void> = [];
-
-  const runNext = (): void => {
-    if (active >= concurrency) {
-      return;
-    }
-
-    const next = queue.shift();
-    if (!next) {
-      return;
-    }
-
-    active += 1;
-    next();
-  };
-
-  return async <T>(task: () => Promise<T>): Promise<T> =>
-    new Promise<T>((resolve, reject) => {
-      queue.push(() => {
-        void task()
-          .then(resolve, reject)
-          .finally(() => {
-            active -= 1;
-            runNext();
-          });
-      });
-      runNext();
-    });
-}
-
-async function mapConcurrent<TInput, TOutput>(
-  items: TInput[],
-  concurrency: number,
-  worker: (item: TInput, index: number) => Promise<TOutput>,
-): Promise<TOutput[]> {
-  if (items.length === 0) {
-    return [];
-  }
-
-  const results = new Array<TOutput>(items.length);
-  let nextIndex = 0;
-  const workerCount = Math.min(concurrency, items.length);
-
-  await Promise.all(
-    Array.from({length: workerCount}, async () => {
-      while (true) {
-        const currentIndex = nextIndex++;
-        if (currentIndex >= items.length) {
-          return;
-        }
-
-        results[currentIndex] = await worker(items[currentIndex]!, currentIndex);
-      }
-    }),
-  );
-
-  return results;
 }


### PR DESCRIPTION
## Summary

Extracts the duplicated concurrency helpers from `src/features/liferay/content/` into a new shared module at `src/core/concurrency.ts`, and replaces their local implementations with imports from the shared module.

## Motivation

Two content modules contained identical or near-identical concurrency primitives with no shared origin:

- `runConcurrent` was independently defined in `liferay-content-prune.ts`
- `mapConcurrent` and `createConcurrencyLimiter` were independently defined in `liferay-content-stats.ts`

This was pure duplication  same algorithm, same semantics, no behavioral difference.

## What Changed

**Added:**
- `src/core/concurrency.ts`  minimal shared module exposing:
  - `createConcurrencyLimiter(concurrency)`  queues individual tasks, runs at most N in parallel
  - `mapConcurrent(items, concurrency, worker)`  maps over items with bounded parallelism, preserves result order
  - `runConcurrent(items, concurrency, worker)`  same as `mapConcurrent` but returns `void`; implemented on top of it to eliminate the duplicate algorithm

**Modified:**
- `liferay-content-prune.ts`  removed local `runConcurrent`, added import from `src/core/concurrency.ts`
- `liferay-content-stats.ts`  removed local `createConcurrencyLimiter` and `mapConcurrent`, added imports from `src/core/concurrency.ts`

## Behavior Preserved

- Concurrency limits: unchanged
- Result order: `mapConcurrent` uses a pre-sized array with fixed index assignment (`results[currentIndex]`), identical to the original
- Error propagation: any worker rejection propagates through `Promise.all` exactly as before
- Empty array semantics: both `mapConcurrent` (returns `[]`) and `runConcurrent` (returns early) behave identically

## Validation

- `npm run typecheck`  pass
- `npm run test:unit -- tests/unit/liferay-content-prune.test.ts tests/unit/liferay-content-stats.test.ts`  802 tests, 78 files, all passing

## Scope

Only the three files listed above were touched. No business logic, no public CLI contract, no output format, and no error messages were changed.
