### PR TITLE
refactor(resource): use LiferayGateway in sync strategies

### DIFF
--- a/src/features/liferay/resource/liferay-resource-sync-shared.ts
+++ b/src/features/liferay/resource/liferay-resource-sync-shared.ts
@@ -5,7 +5,7 @@ import type {OAuthTokenClient} from '../../../core/http/auth.js';
 import type {LiferayApiClient} from '../../../core/http/client.js';
 import {createLiferayApiClient, type HttpResponse} from '../../../core/http/client.js';
 import {LiferayErrors} from '../errors/index.js';
-import {buildAuthOptions, ensureData, expectJsonSuccess} from '../liferay-http-shared.js';
+import {buildAuthOptions, ensureData} from '../liferay-http-shared.js';
 import {fetchAccessToken} from '../inventory/liferay-inventory-shared.js';
 
 type ResourceDependencies = {
@@ -22,7 +22,7 @@ export type ResourceSyncResult = {
   extra: string;
 };
 
-export async function authedPostForm<T>(
+async function postFormCandidateResponse<T>(
   config: AppConfig,
   path: string,
   form: Record<string, string>,
@@ -44,7 +44,7 @@ export async function postFormCandidates<T>(
   const errors: string[] = [];
 
   for (const form of candidates) {
-    const response = await authedPostForm<T>(config, apiPath, form, dependencies);
+    const response = await postFormCandidateResponse<T>(config, apiPath, form, dependencies);
     if (response.ok) {
       return ensureData(response.data, `${operation} invalid JSON in ${apiPath}`, 'LIFERAY_RESOURCE_ERROR');
     }
@@ -52,45 +52,6 @@ export async function postFormCandidates<T>(
   }
 
   throw LiferayErrors.resourceError(`${operation} failed on ${apiPath} (${errors.join(' | ')})`);
-}
-
-export async function authedPostMultipart<T>(
-  config: AppConfig,
-  path: string,
-  form: FormData,
-  dependencies?: ResourceDependencies,
-): Promise<HttpResponse<T>> {
-  const apiClient = dependencies?.apiClient ?? createLiferayApiClient();
-  const accessToken = await fetchAccessToken(config, dependencies);
-
-  return apiClient.postMultipart<T>(config.liferay.url, path, form, buildAuthOptions(config, accessToken));
-}
-
-export async function authedGetJson<T>(
-  config: AppConfig,
-  path: string,
-  label: string,
-  dependencies?: ResourceDependencies,
-): Promise<T> {
-  const apiClient = dependencies?.apiClient ?? createLiferayApiClient();
-  const accessToken = await fetchAccessToken(config, dependencies);
-  const response = await apiClient.get<T>(config.liferay.url, path, buildAuthOptions(config, accessToken));
-  const success = await expectJsonSuccess(response, label, 'LIFERAY_RESOURCE_ERROR');
-  return (success.data ?? null) as T;
-}
-
-export async function authedPutJson<T>(
-  config: AppConfig,
-  path: string,
-  payload: unknown,
-  label: string,
-  dependencies?: ResourceDependencies,
-): Promise<T> {
-  const apiClient = dependencies?.apiClient ?? createLiferayApiClient();
-  const accessToken = await fetchAccessToken(config, dependencies);
-  const response = await apiClient.putJson<T>(config.liferay.url, path, payload, buildAuthOptions(config, accessToken));
-  const success = await expectJsonSuccess(response, label, 'LIFERAY_RESOURCE_ERROR');
-  return (success.data ?? null) as T;
 }
 
 export function sha256(text: string): string {

--- a/src/features/liferay/resource/sync-strategies/adt-sync-strategy.ts
+++ b/src/features/liferay/resource/sync-strategies/adt-sync-strategy.ts
@@ -7,19 +7,13 @@ import fs from 'fs-extra';
 
 import type {AppConfig} from '../../../../core/config/load-config.js';
 import {CliError} from '../../../../core/errors.js';
+import {createLiferayGateway, type LiferayGateway} from '../../liferay-gateway.js';
 import type {ResolvedSite} from '../../inventory/liferay-site-resolver.js';
 import {LiferayErrors} from '../../errors/index.js';
 import {runLiferayResourceListAdts} from '../liferay-resource-list-adts.js';
 import {resolveAdtFile} from '../liferay-resource-paths.js';
 import {fetchAdtResourceClassNameId, fetchClassNameIdForValue} from '../liferay-resource-shared.js';
-import {
-  authedGetJson,
-  authedPostForm,
-  localizedMap,
-  sha256,
-  type ResourceSyncDependencies,
-} from '../liferay-resource-sync-shared.js';
-import {expectJsonSuccess} from '../../liferay-http-shared.js';
+import {localizedMap, sha256, type ResourceSyncDependencies} from '../liferay-resource-sync-shared.js';
 import {matchesAdtRow} from '../../liferay-identifiers.js';
 import type {LocalArtifact, RemoteArtifact, SyncStrategy} from '../sync-engine.js';
 
@@ -125,43 +119,40 @@ export const adtSyncStrategy: SyncStrategy<AdtLocalData, AdtRemoteData> = {
     dependencies?: ResourceSyncDependencies,
   ): Promise<RemoteArtifact<AdtRemoteData>> {
     const opts = options as AdtSyncOptions;
+    const gateway = createLiferayGateway(config, dependencies?.apiClient, dependencies?.tokenClient);
 
     if (!remoteArtifact) {
       // Create new ADT
       const classNameId = await fetchClassNameIdForValue(config, opts.className, dependencies);
       const resourceClassNameId = await fetchAdtResourceClassNameId(config, dependencies);
 
-      const created = await expectJsonSuccess(
-        await authedPostForm<Record<string, unknown>>(
-          config,
-          '/api/jsonws/ddm.ddmtemplate/add-template',
-          {
-            externalReferenceCode: opts.key,
-            groupId: String(site.id),
-            classNameId: String(classNameId),
-            classPK: '0', // ADTs have no structure binding
-            resourceClassNameId: String(resourceClassNameId),
-            nameMap: localizedMap(opts.key),
-            descriptionMap: localizedMap(''),
-            type: 'display',
-            mode: '',
-            language: 'ftl',
-            script: localArtifact.normalizedContent,
-          },
-          dependencies,
-        ),
+      const created = await postFormAsResource<Record<string, unknown>>(
+        gateway,
+        '/api/jsonws/ddm.ddmtemplate/add-template',
+        {
+          externalReferenceCode: opts.key,
+          groupId: String(site.id),
+          classNameId: String(classNameId),
+          classPK: '0', // ADTs have no structure binding
+          resourceClassNameId: String(resourceClassNameId),
+          nameMap: localizedMap(opts.key),
+          descriptionMap: localizedMap(''),
+          type: 'display',
+          mode: '',
+          language: 'ftl',
+          script: localArtifact.normalizedContent,
+        },
         'adt-create',
-        'LIFERAY_RESOURCE_ERROR',
       );
 
-      const createdId = String(created.data?.templateKey ?? created.data?.templateId ?? '');
+      const createdId = String(created.templateKey ?? created.templateId ?? '');
 
       return {
         id: createdId,
         name: opts.key,
         data: {
           templateId: createdId,
-          templateKey: created.data?.templateKey as string | undefined,
+          templateKey: created.templateKey as string | undefined,
           widgetType: opts.widgetType,
           className: opts.className,
         },
@@ -169,32 +160,27 @@ export const adtSyncStrategy: SyncStrategy<AdtLocalData, AdtRemoteData> = {
     }
 
     // Update existing ADT
-    const ddmTemplate = await authedGetJson<Record<string, unknown>>(
-      config,
+    const ddmTemplate = await getJsonAsResource<Record<string, unknown>>(
+      gateway,
       `/api/jsonws/ddm.ddmtemplate/get-template?templateId=${remoteArtifact.data.templateId}`,
       'adt-ddm-get',
-      dependencies,
     );
 
-    await expectJsonSuccess(
-      await authedPostForm(
-        config,
-        '/api/jsonws/ddm.ddmtemplate/update-template',
-        {
-          templateId: remoteArtifact.data.templateId,
-          classPK: String(ddmTemplate.classPK ?? '0'),
-          nameMap: localizedMap(opts.key),
-          descriptionMap: localizedMap(''),
-          type: 'display',
-          mode: '',
-          language: 'ftl',
-          script: localArtifact.normalizedContent,
-          cacheable: 'false',
-        },
-        dependencies,
-      ),
+    await postFormAsResource(
+      gateway,
+      '/api/jsonws/ddm.ddmtemplate/update-template',
+      {
+        templateId: remoteArtifact.data.templateId,
+        classPK: String(ddmTemplate.classPK ?? '0'),
+        nameMap: localizedMap(opts.key),
+        descriptionMap: localizedMap(''),
+        type: 'display',
+        mode: '',
+        language: 'ftl',
+        script: localArtifact.normalizedContent,
+        cacheable: 'false',
+      },
       'adt-update',
-      'LIFERAY_RESOURCE_ERROR',
     );
 
     return remoteArtifact;
@@ -229,3 +215,32 @@ export const adtSyncStrategy: SyncStrategy<AdtLocalData, AdtRemoteData> = {
     }
   },
 };
+
+async function getJsonAsResource<T>(gateway: LiferayGateway, path: string, label: string): Promise<T> {
+  try {
+    return await gateway.getJson<T>(path, label);
+  } catch (error) {
+    rethrowGatewayAsResourceError(error);
+  }
+}
+
+async function postFormAsResource<T>(
+  gateway: LiferayGateway,
+  path: string,
+  form: Record<string, string>,
+  label: string,
+): Promise<T> {
+  try {
+    return await gateway.postForm<T>(path, form, label);
+  } catch (error) {
+    rethrowGatewayAsResourceError(error);
+  }
+}
+
+function rethrowGatewayAsResourceError(error: unknown): never {
+  if (error instanceof CliError && error.code === 'LIFERAY_GATEWAY_ERROR') {
+    throw LiferayErrors.resourceError(error.message);
+  }
+
+  throw error;
+}

--- a/src/features/liferay/resource/sync-strategies/structure-sync-strategy.ts
+++ b/src/features/liferay/resource/sync-strategies/structure-sync-strategy.ts
@@ -8,10 +8,9 @@ import fs from 'fs-extra';
 import type {AppConfig} from '../../../../core/config/load-config.js';
 import {CliError} from '../../../../core/errors.js';
 import type {LiferayApiClient} from '../../../../core/http/client.js';
-import type {OAuthTokenClient} from '../../../../core/http/auth.js';
 import {createLiferayApiClient} from '../../../../core/http/client.js';
+import {createLiferayGateway, type LiferayGateway} from '../../liferay-gateway.js';
 import {LiferayErrors} from '../../errors/index.js';
-import {fetchAccessToken} from '../../inventory/liferay-inventory-shared.js';
 import type {ResolvedSite} from '../../inventory/liferay-site-resolver.js';
 import {resolveStructureFile} from '../liferay-resource-paths.js';
 import {
@@ -106,11 +105,9 @@ export const structureSyncStrategy: SyncStrategy<StructureLocalData, StructureRe
     dependencies?: StructureResourceDependencies,
   ): Promise<RemoteArtifact<StructureRemoteData> | null> {
     const opts = options as StructureSyncOptions;
-    const apiClient: LiferayApiClient =
-      (dependencies as unknown as {apiClient?: LiferayApiClient})?.apiClient ?? createLiferayApiClient();
-    const accessToken = await fetchAccessToken(config, dependencies);
+    const {gateway} = createStructureTransport(config, dependencies);
 
-    const existing = await fetchStructureByKey(config, apiClient, accessToken, site.id, opts.key);
+    const existing = await fetchStructureByKeyViaGateway(gateway, site.id, opts.key);
     if (!existing) {
       return null;
     }
@@ -139,9 +136,7 @@ export const structureSyncStrategy: SyncStrategy<StructureLocalData, StructureRe
     dependencies?: StructureResourceDependencies,
   ): Promise<RemoteArtifact<StructureRemoteData>> {
     const opts = options as StructureSyncOptions;
-    const apiClient: LiferayApiClient =
-      (dependencies as unknown as {apiClient?: LiferayApiClient})?.apiClient ?? createLiferayApiClient();
-    const accessToken = await fetchAccessToken(config, dependencies);
+    const {apiClient, tokenClient, gateway} = createStructureTransport(config, dependencies);
 
     const payload = await fs.readJson(localArtifact.data.filePath);
     const payloadFieldRefs = collectFieldReferences(payload);
@@ -160,7 +155,7 @@ export const structureSyncStrategy: SyncStrategy<StructureLocalData, StructureRe
     let migration: MigrationStats | undefined;
     const migrationOptions = {
       apiClient,
-      tokenClient: (dependencies as unknown as {tokenClient?: OAuthTokenClient})?.tokenClient,
+      tokenClient,
       cleanupSource: Boolean(opts.cleanupMigration),
       dryRun: Boolean(opts.migrationDryRun),
       fetchStructureByKeyFn: fetchStructureByKey,
@@ -193,18 +188,14 @@ export const structureSyncStrategy: SyncStrategy<StructureLocalData, StructureRe
       }
 
       const createPayload = removeExternalReferenceCode(payload);
-      const created = await expectJsonSuccess(
-        await apiClient.postJson<Record<string, unknown>>(
-          config.liferay.url,
-          `/o/data-engine/v2.0/sites/${site.id}/data-definitions/by-content-type/journal`,
-          createPayload,
-          authOptions(config, accessToken),
-        ),
+      const created = await postJsonAsResource<Record<string, unknown>>(
+        gateway,
+        `/o/data-engine/v2.0/sites/${site.id}/data-definitions/by-content-type/journal`,
+        createPayload,
         'structure-create',
-        'LIFERAY_RESOURCE_ERROR',
       );
 
-      const createdId = String((created.data as unknown as Record<string, unknown>)?.id ?? '');
+      const createdId = String((created as Record<string, unknown> | null)?.id ?? '');
       if (opts.migrationPlan && shouldRunPostMigration(phase)) {
         migration = await runStructureMigration(config, opts.key, site.id, opts.migrationPlan, migrationOptions);
       }
@@ -214,7 +205,7 @@ export const structureSyncStrategy: SyncStrategy<StructureLocalData, StructureRe
         name: opts.key,
         data: {
           structureId: createdId,
-          runtimeDefinition: (created.data as unknown as Record<string, unknown>) ?? {},
+          runtimeDefinition: (created as Record<string, unknown> | null) ?? {},
           existingFieldRefs: payloadFieldRefs,
           removedFieldReferences,
           migration,
@@ -236,18 +227,14 @@ export const structureSyncStrategy: SyncStrategy<StructureLocalData, StructureRe
     if (autoTransition) {
       const sourceSnapshots = await captureMigrationSourceSnapshots(config, runtimeId, site.id, opts.migrationPlan!, {
         apiClient,
-        tokenClient: (dependencies as unknown as {tokenClient?: OAuthTokenClient})?.tokenClient,
+        tokenClient,
       });
       updatePayload = buildTransitionPayload(remoteArtifact.data.runtimeDefinition, payload);
-      await expectJsonSuccess(
-        await apiClient.putJson<Record<string, unknown>>(
-          config.liferay.url,
-          `/o/data-engine/v2.0/data-definitions/${runtimeId}`,
-          updatePayload,
-          authOptions(config, accessToken),
-        ),
+      await putJsonAsResource<Record<string, unknown>>(
+        gateway,
+        `/o/data-engine/v2.0/data-definitions/${runtimeId}`,
+        updatePayload,
         'structure-update transition',
-        'LIFERAY_RESOURCE_ERROR',
       );
 
       migration = await runStructureMigration(config, opts.key, site.id, opts.migrationPlan!, {
@@ -257,9 +244,7 @@ export const structureSyncStrategy: SyncStrategy<StructureLocalData, StructureRe
     }
 
     const updated = await updateStructureWithRecovery(
-      config,
-      apiClient,
-      accessToken,
+      gateway,
       site.id,
       runtimeId,
       opts.key,
@@ -300,6 +285,38 @@ export const structureSyncStrategy: SyncStrategy<StructureLocalData, StructureRe
 
 // ---- Private Helpers ----
 
+function createStructureTransport(config: AppConfig, dependencies?: StructureResourceDependencies) {
+  const apiClient = dependencies?.apiClient ?? createLiferayApiClient();
+  const tokenClient = dependencies?.tokenClient;
+
+  return {
+    apiClient,
+    tokenClient,
+    gateway: createLiferayGateway(config, apiClient, tokenClient),
+  };
+}
+
+async function fetchStructureByKeyViaGateway(
+  gateway: LiferayGateway,
+  siteId: number,
+  key: string,
+): Promise<Record<string, unknown> | null> {
+  try {
+    return (
+      (await gateway.getJson<Record<string, unknown>>(
+        `/o/data-engine/v2.0/sites/${siteId}/data-definitions/by-content-type/journal/by-data-definition-key/${encodeURIComponent(key)}`,
+        'resource structure-sync get',
+      )) ?? {}
+    );
+  } catch (error) {
+    if (isGatewayStatus(error, 404)) {
+      return null;
+    }
+
+    rethrowGatewayAsResourceError(error);
+  }
+}
+
 async function fetchStructureByKey(
   config: AppConfig,
   apiClient: LiferayApiClient,
@@ -319,10 +336,34 @@ async function fetchStructureByKey(
   return (success.data as Record<string, unknown>) ?? {};
 }
 
+async function postJsonAsResource<T>(
+  gateway: LiferayGateway,
+  path: string,
+  payload: unknown,
+  label: string,
+): Promise<T> {
+  try {
+    return await gateway.postJson<T>(path, payload, label);
+  } catch (error) {
+    rethrowGatewayAsResourceError(error);
+  }
+}
+
+async function putJsonAsResource<T>(
+  gateway: LiferayGateway,
+  path: string,
+  payload: unknown,
+  label: string,
+): Promise<T> {
+  try {
+    return await gateway.putJson<T>(path, payload, label);
+  } catch (error) {
+    rethrowGatewayAsResourceError(error);
+  }
+}
+
 async function updateStructureWithRecovery(
-  config: AppConfig,
-  apiClient: LiferayApiClient,
-  accessToken: string,
+  gateway: LiferayGateway,
   siteId: number,
   runtimeId: string,
   key: string,
@@ -331,26 +372,20 @@ async function updateStructureWithRecovery(
   dependencies?: StructureResourceDependencies,
 ): Promise<{data: Record<string, unknown> | null; recoveredAfterTimeout: boolean}> {
   try {
-    const updated = await expectJsonSuccess(
-      await apiClient.putJson<Record<string, unknown>>(
-        config.liferay.url,
-        `/o/data-engine/v2.0/data-definitions/${runtimeId}`,
-        payload,
-        authOptions(config, accessToken),
-      ),
+    const updated = await putJsonAsResource<Record<string, unknown>>(
+      gateway,
+      `/o/data-engine/v2.0/data-definitions/${runtimeId}`,
+      payload,
       'structure-update',
-      'LIFERAY_RESOURCE_ERROR',
     );
-    return {data: (updated.data as Record<string, unknown>) ?? null, recoveredAfterTimeout: false};
+    return {data: (updated as Record<string, unknown> | null) ?? null, recoveredAfterTimeout: false};
   } catch (error) {
     if (!isRecoverableTimeoutError(error)) {
       throw error;
     }
 
     const recovered = await pollStructureUpdateRecovery(
-      config,
-      apiClient,
-      accessToken,
+      gateway,
       siteId,
       key,
       payload,
@@ -370,9 +405,7 @@ async function updateStructureWithRecovery(
 }
 
 async function pollStructureUpdateRecovery(
-  config: AppConfig,
-  apiClient: LiferayApiClient,
-  accessToken: string,
+  gateway: LiferayGateway,
   siteId: number,
   key: string,
   payload: Record<string, unknown>,
@@ -391,7 +424,7 @@ async function pollStructureUpdateRecovery(
   }
 
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
-    const runtime = await fetchStructureByKey(config, apiClient, accessToken, siteId, key);
+    const runtime = await fetchStructureByKeyViaGateway(gateway, siteId, key);
     if (runtime && structureShapeMatches(runtime, expectedShape)) {
       return runtime;
     }
@@ -402,6 +435,20 @@ async function pollStructureUpdateRecovery(
   }
 
   return null;
+}
+
+function isGatewayStatus(error: unknown, status: number): boolean {
+  return (
+    error instanceof CliError && error.code === 'LIFERAY_GATEWAY_ERROR' && error.message.includes(`status=${status}`)
+  );
+}
+
+function rethrowGatewayAsResourceError(error: unknown): never {
+  if (error instanceof CliError && error.code === 'LIFERAY_GATEWAY_ERROR') {
+    throw LiferayErrors.resourceError(error.message);
+  }
+
+  throw error;
 }
 
 function isRecoverableTimeoutError(error: unknown): boolean {

--- a/src/features/liferay/resource/sync-strategies/template-sync-strategy.ts
+++ b/src/features/liferay/resource/sync-strategies/template-sync-strategy.ts
@@ -7,6 +7,7 @@ import fs from 'fs-extra';
 
 import type {AppConfig} from '../../../../core/config/load-config.js';
 import {CliError} from '../../../../core/errors.js';
+import {createLiferayGateway, type LiferayGateway} from '../../liferay-gateway.js';
 import type {ResolvedSite} from '../../inventory/liferay-site-resolver.js';
 import {runLiferayInventoryTemplates} from '../../inventory/liferay-inventory-templates.js';
 import {LiferayErrors} from '../../errors/index.js';
@@ -16,7 +17,6 @@ import {resolveTemplateFile, resolveSiteToken} from '../liferay-resource-paths.j
 import {fetchStructureTemplateClassIds} from '../liferay-resource-shared.js';
 import {normalizeLiferayTemplateScript} from '../liferay-resource-template-normalize.js';
 import {
-  authedGetJson,
   ensureString,
   localizedMap,
   sha256,
@@ -103,13 +103,8 @@ export const templateSyncStrategy: SyncStrategy<TemplateLocalData, TemplateRemot
 
     // Try direct DDM template lookup
     const {classNameId} = await fetchStructureTemplateClassIds(config, dependencies);
-    const directDdmTemplate = await tryGetDdmTemplateByKey(
-      config,
-      site.id,
-      String(classNameId),
-      opts.key,
-      dependencies,
-    );
+    const gateway = createLiferayGateway(config, dependencies?.apiClient, dependencies?.tokenClient);
+    const directDdmTemplate = await tryGetDdmTemplateByKey(gateway, site.id, String(classNameId), opts.key);
 
     const existing = directDdmTemplate
       ? structureIdFilter === '' || String(directDdmTemplate.classPK ?? '') === structureIdFilter
@@ -257,23 +252,34 @@ export const templateSyncStrategy: SyncStrategy<TemplateLocalData, TemplateRemot
  * Returns null if not found (swallows 404-like errors).
  */
 async function tryGetDdmTemplateByKey(
-  config: AppConfig,
+  gateway: LiferayGateway,
   siteId: number,
   classNameId: string,
   templateKey: string,
-  dependencies?: ResourceSyncDependencies,
 ): Promise<Record<string, unknown> | null> {
   try {
-    return await authedGetJson<Record<string, unknown>>(
-      config,
+    return await gateway.getJson<Record<string, unknown>>(
       `/api/jsonws/ddm.ddmtemplate/get-template?groupId=${siteId}&classNameId=${classNameId}&templateKey=${templateKey}`,
       'template-lookup',
-      dependencies,
     );
   } catch (error) {
-    if (error instanceof CliError && error.code === 'LIFERAY_RESOURCE_ERROR') {
+    if (isGatewayStatus(error, 404)) {
       return null;
     }
-    throw error;
+    rethrowGatewayAsResourceError(error);
   }
+}
+
+function isGatewayStatus(error: unknown, status: number): boolean {
+  return (
+    error instanceof CliError && error.code === 'LIFERAY_GATEWAY_ERROR' && error.message.includes(`status=${status}`)
+  );
+}
+
+function rethrowGatewayAsResourceError(error: unknown): never {
+  if (error instanceof CliError && error.code === 'LIFERAY_GATEWAY_ERROR') {
+    throw LiferayErrors.resourceError(error.message);
+  }
+
+  throw error;
 }


### PR DESCRIPTION
## Summary
- replaces parallel auth and HTTP wrappers in the resource sync layer with `LiferayGateway` for the normal get/create/update paths covered in this change
- keeps `postFormCandidates` as a small shared helper for candidate form retries while removing the exported auth wrapper layer from sync shared
- preserves existing resource-sync semantics for 404 lookups, post-update verification, and structure timeout recovery

## What Changed
- removed exported auth wrappers from `liferay-resource-sync-shared.ts`:
  - `authedGetJson`
  - `authedPutJson`
  - `authedPostMultipart`
  - `authedPostForm`
- migrated template sync direct DDM template lookup to `LiferayGateway`
- migrated ADT sync get/create/update transport to `LiferayGateway`
- migrated structure sync lookup, create, transition update, normal update, and timeout-recovery polling transport to `LiferayGateway`
- kept a minimal legacy-signature helper in structure sync only for the out-of-scope migration callback wiring

## Behavior Preserved
- 404 still behaves as a lookup miss where it already did
- existing create/update flows remain unchanged
- verification after sync remains unchanged
- structure timeout recovery remains unchanged, including recoverable timeout behavior when the final state cannot be proven
- observable CLI behavior, messages, and resource error semantics are preserved by remapping gateway errors at the strategy boundary

## Deliberately Left Out
- no changes to `liferay-resource-shared.ts`
- no changes to get/import/export resource commands outside the requested sync layer
- no migration changes to structure migration modules
- no broader resource-wide gateway migration

## Validation
- `npm run typecheck`
- `npm run test:unit -- tests/unit/liferay-resource-sync-template.test.ts tests/unit/liferay-resource-sync-adt.test.ts tests/unit/liferay-resource-sync-structure.test.ts tests/unit/liferay-resource-sync-fragments.test.ts`
- `rg -n "authedGetJson|authedPutJson|authedPostMultipart|authedPostForm" src/features/liferay/resource`
- `rg -n "fetchAccessToken\(|buildAuthOptions\(|createLiferayApiClient\(" src/features/liferay/resource/sync-strategies`

## Notes
The final `rg` check still reports one `createLiferayApiClient()` call in structure sync. That helper is intentionally retained only to satisfy the existing migration callback signature in the out-of-scope structure migration path; the normal sync transport paths in this PR use `LiferayGateway`.
