### PR TITLE
feat(gateway): add deleteJson method to LiferayGateway

### DIFF
--- a/src/features/liferay/liferay-gateway.ts
+++ b/src/features/liferay/liferay-gateway.ts
@@ -143,6 +143,22 @@ export class LiferayGateway {
   }
 
   /**
+   * DELETE /path, parse JSON response if present, assert ok status, return data.
+   * @throws CliError if response not ok
+   */
+  async deleteJson<T>(path: string, label: string): Promise<T> {
+    const accessToken = await this.getAccessToken();
+    const response = await this.apiClient.delete<T>(
+      this.config.liferay.url,
+      path,
+      buildAuthOptions(this.config, accessToken),
+    );
+
+    const success = await expectJsonSuccess(response, label, 'LIFERAY_GATEWAY_ERROR');
+    return (success.data ?? null) as T;
+  }
+
+  /**
    * Clear the access token cache (useful for testing or explicit refresh).
    */
   clearTokenCache(): void {

--- a/tests/unit/liferay-gateway.test.ts
+++ b/tests/unit/liferay-gateway.test.ts
@@ -287,6 +287,87 @@ describe('LiferayGateway', () => {
     });
   });
 
+  describe('deleteJson', () => {
+    test('calls apiClient.delete with Authorization header', async () => {
+      const apiClient = createMockApiClient();
+      const tokenClient = createMockTokenClient();
+      const response = mockHttpResponse(true, 200, {id: 1, deleted: true});
+
+      vi.mocked(apiClient.delete).mockResolvedValue(response);
+
+      const gateway = new LiferayGateway(mockConfig, apiClient, tokenClient);
+      const result = await gateway.deleteJson<{id: number; deleted: boolean}>('/api/items/1', 'delete-item');
+
+      expect(result).toEqual({id: 1, deleted: true});
+      expect(apiClient.delete).toHaveBeenCalledWith(
+        'http://localhost:8080',
+        '/api/items/1',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'Bearer test-access-token',
+          }),
+          timeoutSeconds: 45,
+        }),
+      );
+    });
+
+    test('uses the token client to obtain the access token', async () => {
+      const apiClient = createMockApiClient();
+      const tokenClient = createMockTokenClient();
+      const response = mockHttpResponse(true, 204, null);
+
+      vi.mocked(apiClient.delete).mockResolvedValue(response);
+
+      const gateway = new LiferayGateway(mockConfig, apiClient, tokenClient);
+      await gateway.deleteJson('/api/items/99', 'delete-item');
+
+      expect(tokenClient.fetchClientCredentialsToken).toHaveBeenCalledTimes(1);
+    });
+
+    test('returns null when response has no body', async () => {
+      const apiClient = createMockApiClient();
+      const tokenClient = createMockTokenClient();
+      const response = mockHttpResponse(true, 204, null);
+
+      vi.mocked(apiClient.delete).mockResolvedValue(response);
+
+      const gateway = new LiferayGateway(mockConfig, apiClient, tokenClient);
+      const result = await gateway.deleteJson('/api/items/99', 'delete-item');
+
+      expect(result).toBeNull();
+    });
+
+    test('handles error response (404)', async () => {
+      const apiClient = createMockApiClient();
+      const tokenClient = createMockTokenClient();
+      const response = mockHttpResponse(false, 404, null);
+
+      vi.mocked(apiClient.delete).mockResolvedValue(response);
+
+      const gateway = new LiferayGateway(mockConfig, apiClient, tokenClient);
+
+      await expect(gateway.deleteJson('/api/items/999', 'delete-missing')).rejects.toThrow(/status=404/);
+    });
+
+    test('throws CliError with LIFERAY_GATEWAY_ERROR code on failure', async () => {
+      const apiClient = createMockApiClient();
+      const tokenClient = createMockTokenClient();
+      const response = mockHttpResponse(false, 500, null);
+
+      vi.mocked(apiClient.delete).mockResolvedValue(response);
+
+      const gateway = new LiferayGateway(mockConfig, apiClient, tokenClient);
+
+      try {
+        await gateway.deleteJson('/api/items/1', 'delete-item');
+        expect.fail('Should have thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(CliError);
+        expect((error as CliError).code).toBe('LIFERAY_GATEWAY_ERROR');
+      }
+    });
+  });
+
   describe('token caching', () => {
     test('caches access token and reuses it on subsequent calls', async () => {
       const apiClient = createMockApiClient();


### PR DESCRIPTION
## Summary

Adds `deleteJson<T>(path, label)` to `LiferayGateway`, following the same pattern as the existing `getJson`, `postJson`, `postForm`, `postMultipart`, and `putJson` methods.

This is a purely additive change that prepares the gateway for the next content migration PR without touching any callers yet.

## What Changed

**Modified:**
- `src/features/liferay/liferay-gateway.ts`  added `deleteJson<T>` method.
- `tests/unit/liferay-gateway.test.ts`  added `describe('deleteJson', ...)` block with 5 tests.

## Implementation

`deleteJson` follows the same pattern as `putJson`, changing only the HTTP verb:

1. Obtains the access token via `getAccessToken()` (token cache reused).
2. Calls `apiClient.delete<T>(config.liferay.url, path, buildAuthOptions(...))`.
3. Validates the response with `expectJsonSuccess(response, label, 'LIFERAY_GATEWAY_ERROR')`.
4. Returns `(success.data ?? null) as T`.

`DELETE` responses may or may not include a body (e.g. 200 with body, 204 without). The same `data ?? null` contract as all other methods is preserved.

## Tests Added

- `calls apiClient.delete with Authorization header`  verifies URL, path, auth options, and return value.
- `uses the token client to obtain the access token`  verifies token client is called once.
- `returns null when response has no body`  verifies 204/no-body handling.
- `handles error response (404)`  verifies status code in error message.
- `throws CliError with LIFERAY_GATEWAY_ERROR code on failure`  verifies error code.

## Validation

- `npm run typecheck`  pass
- `npm run test:unit`  807 tests, 78 files, all passing (24 tests in `liferay-gateway.test.ts`)

## Scope / What Was NOT Changed

- No callers migrated yet.
- `LiferayApiClient` not modified (`delete` method was already defined there).
- `buildAuthOptions`, `expectJsonSuccess`, `ensureData` not modified.
- No `content/`, `resource/`, or `inventory/` modules touched.
- No existing `LiferayGateway` method signatures changed.
- No new abstractions introduced.
