### PR TITLE
refactor(content): migrate content auth transport to LiferayGateway

### DIFF
--- a/src/features/liferay/content/liferay-content-journal-shared.ts
+++ b/src/features/liferay/content/liferay-content-journal-shared.ts
@@ -2,38 +2,8 @@ import type {AppConfig} from '../../../core/config/load-config.js';
 import {CliError} from '../../../core/errors.js';
 import type {OAuthTokenClient} from '../../../core/http/auth.js';
 import type {LiferayApiClient} from '../../../core/http/client.js';
-import {
-  authedGet,
-  fetchAccessToken,
-  fetchPagedItems,
-  normalizeLocalizedName,
-} from '../inventory/liferay-inventory-shared.js';
-
-export type JournalAuthState = {
-  accessToken: string;
-  tokenClient: OAuthTokenClient;
-};
-
-export async function authedGetWithRefresh<T>(
-  config: AppConfig,
-  apiClient: LiferayApiClient,
-  authState: JournalAuthState,
-  path: string,
-) {
-  const response = await authedGet<T>(config, apiClient, authState.accessToken, path);
-
-  if (response.status !== 401) {
-    return response;
-  }
-
-  authState.accessToken = await fetchAccessToken(config, {
-    apiClient,
-    tokenClient: authState.tokenClient,
-    forceRefresh: true,
-  });
-
-  return authedGet<T>(config, apiClient, authState.accessToken, path);
-}
+import type {LiferayGateway} from '../liferay-gateway.js';
+import {fetchPagedItems, normalizeLocalizedName} from '../inventory/liferay-inventory-shared.js';
 
 export type JsonwsJournalArticleRow = {
   resourcePrimKey?: string;
@@ -61,7 +31,7 @@ export type JsonwsJournalFolder = {
 export async function resolveJournalStructureDefinitions(
   config: AppConfig,
   apiClient: LiferayApiClient,
-  authState: JournalAuthState,
+  tokenClient: OAuthTokenClient,
   groupId: number,
   structureMap: Map<number, string>,
   structureNameMap: Map<string, string>,
@@ -70,7 +40,7 @@ export async function resolveJournalStructureDefinitions(
     config,
     `/o/data-engine/v2.0/sites/${groupId}/data-definitions/by-content-type/journal`,
     200,
-    {apiClient, tokenClient: authState.tokenClient, accessToken: authState.accessToken},
+    {apiClient, tokenClient},
   );
 
   for (const definition of definitions) {
@@ -82,9 +52,7 @@ export async function resolveJournalStructureDefinitions(
 }
 
 export async function hydrateMissingJournalStructureDefinitions(
-  config: AppConfig,
-  apiClient: LiferayApiClient,
-  authState: JournalAuthState,
+  gateway: LiferayGateway,
   structureIds: number[],
   structureMap: Map<number, string>,
   structureNameMap: Map<string, string>,
@@ -94,18 +62,21 @@ export async function hydrateMissingJournalStructureDefinitions(
   );
 
   for (const structureId of missingIds) {
-    const response = await authedGetWithRefresh<JournalStructureDefinition>(
-      config,
-      apiClient,
-      authState,
-      `/o/data-engine/v2.0/data-definitions/${structureId}`,
-    );
+    let definition: JournalStructureDefinition;
 
-    if (!response.ok) {
-      continue;
+    try {
+      definition = await gateway.getJson<JournalStructureDefinition>(
+        `/o/data-engine/v2.0/data-definitions/${structureId}`,
+        `journal structure ${structureId}`,
+      );
+    } catch (error) {
+      if (isGatewayError(error)) {
+        continue;
+      }
+
+      throw error;
     }
 
-    const definition = response.data;
     if (!definition?.id || !definition.dataDefinitionKey) {
       continue;
     }
@@ -116,46 +87,49 @@ export async function hydrateMissingJournalStructureDefinitions(
 }
 
 export async function fetchJournalArticleRowsInFolder(
-  config: AppConfig,
-  apiClient: LiferayApiClient,
-  authState: JournalAuthState,
+  gateway: LiferayGateway,
   groupId: number,
   folderId: number,
   errorCode: string,
 ): Promise<JsonwsJournalArticleRow[]> {
   const pageSize = 200;
-  const timeoutSeconds = Math.max(config.liferay.timeoutSeconds, 600);
   const rows: JsonwsJournalArticleRow[] = [];
   let start = 0;
 
   while (true) {
     const end = start + pageSize;
-    const response = await authedGetWithRefresh<JsonwsJournalArticleRow[]>(
-      {
-        ...config,
-        liferay: {
-          ...config.liferay,
-          timeoutSeconds,
-        },
-      },
-      apiClient,
-      authState,
-      `/api/jsonws/journal.journalfolder/get-folders-and-articles?groupId=${groupId}&folderId=${folderId}&start=${start}&end=${end}&-orderByComparator=`,
-    );
+    let rawPage: JsonwsJournalArticleRow[];
 
-    if (response.status === 403) {
-      throw new CliError(`403 Forbidden on journal.journalfolder/get-folders-and-articles for folder ${folderId}.`, {
+    try {
+      rawPage = await gateway.getJson<JsonwsJournalArticleRow[]>(
+        `/api/jsonws/journal.journalfolder/get-folders-and-articles?groupId=${groupId}&folderId=${folderId}&start=${start}&end=${end}&-orderByComparator=`,
+        `journal folder articles ${folderId}`,
+      );
+    } catch (error) {
+      if (isGatewayStatus(error, 403)) {
+        throw new CliError(`403 Forbidden on journal.journalfolder/get-folders-and-articles for folder ${folderId}.`, {
+          code: errorCode,
+        });
+      }
+
+      if (isGatewayError(error)) {
+        throw new CliError(
+          `journal folder articles for folder ${folderId} failed with status=${getGatewayStatus(error) ?? 'unknown'}.`,
+          {
+            code: errorCode,
+          },
+        );
+      }
+
+      throw error;
+    }
+
+    if (!Array.isArray(rawPage)) {
+      throw new CliError(`journal folder articles for folder ${folderId} failed with status=unknown.`, {
         code: errorCode,
       });
     }
 
-    if (!response.ok || !Array.isArray(response.data)) {
-      throw new CliError(`journal folder articles for folder ${folderId} failed with status=${response.status}.`, {
-        code: errorCode,
-      });
-    }
-
-    const rawPage = response.data ?? [];
     const page = dedupeJournalRows(rawPage.filter(isJournalArticleRow));
     rows.push(...page);
 
@@ -170,27 +144,38 @@ export async function fetchJournalArticleRowsInFolder(
 }
 
 export async function fetchJournalFoldersByParent(
-  config: AppConfig,
-  apiClient: LiferayApiClient,
-  authState: JournalAuthState,
+  gateway: LiferayGateway,
   groupId: number,
   parentFolderId: number,
   errorCode: string,
 ): Promise<Array<{folderId: number; name: string}>> {
-  const response = await authedGetWithRefresh<JsonwsJournalFolder[]>(
-    config,
-    apiClient,
-    authState,
-    `/api/jsonws/journal.journalfolder/get-folders?groupId=${groupId}&parentFolderId=${parentFolderId}`,
-  );
+  let folders: JsonwsJournalFolder[];
 
-  if (!response.ok || !Array.isArray(response.data)) {
-    throw new CliError(`journal folders for parent ${parentFolderId} failed with status=${response.status}.`, {
+  try {
+    folders = await gateway.getJson<JsonwsJournalFolder[]>(
+      `/api/jsonws/journal.journalfolder/get-folders?groupId=${groupId}&parentFolderId=${parentFolderId}`,
+      `journal folders ${parentFolderId}`,
+    );
+  } catch (error) {
+    if (isGatewayError(error)) {
+      throw new CliError(
+        `journal folders for parent ${parentFolderId} failed with status=${getGatewayStatus(error) ?? 'unknown'}.`,
+        {
+          code: errorCode,
+        },
+      );
+    }
+
+    throw error;
+  }
+
+  if (!Array.isArray(folders)) {
+    throw new CliError(`journal folders for parent ${parentFolderId} failed with status=unknown.`, {
       code: errorCode,
     });
   }
 
-  return (response.data ?? [])
+  return folders
     .map((folder) => ({
       folderId: Number(folder.folderId ?? folder.id ?? 0),
       name: folder.name ?? '',
@@ -215,4 +200,22 @@ function dedupeJournalRows(rows: JsonwsJournalArticleRow[]): JsonwsJournalArticl
   }
 
   return [...unique.values()];
+}
+
+function isGatewayError(error: unknown): error is CliError {
+  return error instanceof CliError && error.code === 'LIFERAY_GATEWAY_ERROR';
+}
+
+function isGatewayStatus(error: unknown, status: number): boolean {
+  return isGatewayError(error) && error.message.includes(`status=${status}`);
+}
+
+function getGatewayStatus(error: CliError): number | undefined {
+  const match = /status=(\d+)/.exec(error.message);
+  if (!match) {
+    return undefined;
+  }
+
+  const value = Number(match[1]);
+  return Number.isFinite(value) ? value : undefined;
 }

--- a/src/features/liferay/content/liferay-content-prune.ts
+++ b/src/features/liferay/content/liferay-content-prune.ts
@@ -1,13 +1,14 @@
 import type {AppConfig} from '../../../core/config/load-config.js';
 import {runConcurrent} from '../../../core/concurrency.js';
+import {CliError} from '../../../core/errors.js';
 import {createOAuthTokenClient, type OAuthTokenClient} from '../../../core/http/auth.js';
 import {createLiferayApiClient, type LiferayApiClient} from '../../../core/http/client.js';
 import type {Printer} from '../../../core/output/printer.js';
 import {runStep} from '../../../core/output/run-step.js';
 import {LiferayErrors} from '../errors/index.js';
-import {fetchAccessToken, normalizeLocalizedName, resolveSite} from '../inventory/liferay-inventory-shared.js';
+import {normalizeLocalizedName, resolveSite} from '../inventory/liferay-inventory-shared.js';
+import {createLiferayGateway, type LiferayGateway} from '../liferay-gateway.js';
 import {
-  authedGetWithRefresh,
   fetchJournalArticleRowsInFolder,
   hydrateMissingJournalStructureDefinitions,
   resolveJournalStructureDefinitions,
@@ -80,11 +81,6 @@ type PruneDependencies = {
   printer?: Printer;
 };
 
-type PruneAuthState = {
-  accessToken: string;
-  tokenClient: OAuthTokenClient;
-};
-
 type HeadlessFolder = {
   id?: number;
   name?: string;
@@ -136,18 +132,25 @@ export async function runContentPrune(
   const apiClient = dependencies?.apiClient ?? createLiferayApiClient();
   const tokenClient = dependencies?.tokenClient ?? createOAuthTokenClient();
   const printer = dependencies?.printer;
-  const authState: PruneAuthState = {
-    accessToken: await fetchAccessToken(config, {tokenClient}),
+  const gateway = createLiferayGateway(config, apiClient, tokenClient);
+  const longRunningGateway = createLiferayGateway(
+    {
+      ...config,
+      liferay: {
+        ...config.liferay,
+        timeoutSeconds: Math.max(config.liferay.timeoutSeconds, 600),
+      },
+    },
+    apiClient,
     tokenClient,
-  };
-  const deps = {apiClient, accessToken: authState.accessToken};
+  );
 
   // 1. Resolve groupId
   let groupId: number;
   let siteFriendlyUrl: string | undefined;
 
   if (options.site) {
-    const site = await resolveSite(config, options.site, deps);
+    const site = await resolveSite(config, options.site, {apiClient, tokenClient});
     groupId = site.id;
     siteFriendlyUrl = site.friendlyUrlPath;
   } else {
@@ -158,7 +161,7 @@ export async function runContentPrune(
 
   // 2. Validate root folders and build folder tree
   const tree = await runStep(printer, 'Resolving folder scope', () =>
-    collectFolderTree(config, apiClient, authState, rootFolderIds, groupId, wholeFolderDelete),
+    collectFolderTree(gateway, rootFolderIds, groupId, wholeFolderDelete),
   );
 
   if (wholeFolderDelete) {
@@ -169,7 +172,7 @@ export async function runContentPrune(
 
     await runStep(printer, 'Deleting root folders', async () => {
       for (const folderId of existingRootFolders) {
-        const deletion = await deleteJournalFolder(config, apiClient, authState, folderId);
+        const deletion = await deleteJournalFolder(longRunningGateway, folderId);
         if (deletion.ok) {
           removedFolders.push(folderId);
         } else {
@@ -204,7 +207,7 @@ export async function runContentPrune(
   const structureNameMap = new Map<string, string>(); // key -> name
 
   await runStep(printer, 'Resolving journal structures', () =>
-    resolveJournalStructureDefinitions(config, apiClient, authState, groupId, structureMap, structureNameMap),
+    resolveJournalStructureDefinitions(config, apiClient, tokenClient, groupId, structureMap, structureNameMap),
   );
 
   if (options.structures && options.structures.length > 0) {
@@ -220,7 +223,7 @@ export async function runContentPrune(
   const allArticles = await runStep(printer, 'Collecting journal articles', async () => {
     const articles: ArticleWithFolder[] = [];
     await runConcurrent([...tree.allFolders.keys()], ARTICLE_INVENTORY_CONCURRENCY, async (folderId) => {
-      const folderArticles = await fetchJournalArticlesInFolder(config, apiClient, authState, groupId, folderId);
+      const folderArticles = await fetchJournalArticlesInFolder(longRunningGateway, groupId, folderId);
       articles.push(...folderArticles);
     });
 
@@ -229,9 +232,7 @@ export async function runContentPrune(
 
   await runStep(printer, 'Hydrating missing structure metadata', () =>
     hydrateMissingJournalStructureDefinitions(
-      config,
-      apiClient,
-      authState,
+      gateway,
       allArticles.map((article) => article.contentStructureId).filter(isPresentNumber),
       structureMap,
       structureNameMap,
@@ -315,9 +316,7 @@ export async function runContentPrune(
     await runStep(printer, 'Deleting journal articles', async () => {
       await runConcurrent(toDelete, ARTICLE_DELETE_CONCURRENCY, async (article) => {
         const failure = await deleteJournalArticle(
-          config,
-          apiClient,
-          authState,
+          gateway,
           groupId,
           article.id ?? 0,
           article.key ?? String(article.id ?? ''),
@@ -340,7 +339,7 @@ export async function runContentPrune(
         deletedByFolder,
       );
       for (const folderId of sortedRemovable) {
-        const deletion = await tryDeleteFolder(config, apiClient, authState, folderId);
+        const deletion = await tryDeleteFolder(gateway, folderId);
         if (deletion.ok) removedFolders.push(folderId);
         else failedFolders.push({folderId, status: deletion.status, operation: 'delete-folder'});
       }
@@ -436,9 +435,7 @@ export function formatContentPrune(result: ContentPruneResult): string {
 // === Private helpers ===
 
 async function collectFolderTree(
-  config: AppConfig,
-  apiClient: LiferayApiClient,
-  authState: PruneAuthState,
+  gateway: LiferayGateway,
   rootFolderIds: number[],
   groupId: number,
   ignoreMissingRootFolders = false,
@@ -451,23 +448,28 @@ async function collectFolderTree(
   for (const rootId of rootFolderIds) {
     if (allFolders.has(rootId)) continue;
 
-    const resp = await authedGetWithRefresh<HeadlessFolder>(
-      config,
-      apiClient,
-      authState,
-      `/o/headless-delivery/v1.0/structured-content-folders/${rootId}`,
-    );
+    let folder: HeadlessFolder;
 
-    if (!resp.ok) {
-      if (ignoreMissingRootFolders && resp.status === 404) {
+    try {
+      folder = await gateway.getJson<HeadlessFolder>(
+        `/o/headless-delivery/v1.0/structured-content-folders/${rootId}`,
+        `content folder ${rootId}`,
+      );
+    } catch (error) {
+      if (ignoreMissingRootFolders && isGatewayStatus(error, 404)) {
         missingRootFolders.push(rootId);
         continue;
       }
 
-      throw LiferayErrors.contentPruneError(`Folder ${rootId} not found (status=${resp.status}).`);
+      if (isGatewayError(error)) {
+        throw LiferayErrors.contentPruneError(
+          `Folder ${rootId} not found (status=${getGatewayStatus(error) ?? 'unknown'}).`,
+        );
+      }
+
+      throw error;
     }
 
-    const folder = resp.data ?? {};
     if (folder.siteId !== groupId) {
       throw LiferayErrors.contentPruneError(
         `Folder ${rootId} belongs to group ${folder.siteId ?? 'unknown'}, not ${groupId}.`,
@@ -476,16 +478,14 @@ async function collectFolderTree(
 
     allFolders.set(rootId, folder);
     depths.set(rootId, 0);
-    await collectSubfolders(config, apiClient, authState, rootId, 1, allFolders, childrenMap, depths);
+    await collectSubfolders(gateway, rootId, 1, allFolders, childrenMap, depths);
   }
 
   return {allFolders, childrenMap, depths, missingRootFolders};
 }
 
 async function collectSubfolders(
-  config: AppConfig,
-  apiClient: LiferayApiClient,
-  authState: PruneAuthState,
+  gateway: LiferayGateway,
   parentId: number,
   depth: number,
   allFolders: Map<number, HeadlessFolder>,
@@ -496,21 +496,27 @@ async function collectSubfolders(
   let page = 1;
 
   while (true) {
-    const response = await authedGetWithRefresh<{items?: HeadlessFolder[]; lastPage?: number}>(
-      config,
-      apiClient,
-      authState,
-      `/o/headless-delivery/v1.0/structured-content-folders/${parentId}/structured-content-folders?page=${page}&pageSize=200`,
-    );
+    let response: {items?: HeadlessFolder[]; lastPage?: number};
 
-    if (!response.ok) {
-      throw LiferayErrors.contentPruneError(`Subfolders for folder ${parentId} failed with status=${response.status}.`);
+    try {
+      response = await gateway.getJson<{items?: HeadlessFolder[]; lastPage?: number}>(
+        `/o/headless-delivery/v1.0/structured-content-folders/${parentId}/structured-content-folders?page=${page}&pageSize=200`,
+        `content subfolders ${parentId}`,
+      );
+    } catch (error) {
+      if (isGatewayError(error)) {
+        throw LiferayErrors.contentPruneError(
+          `Subfolders for folder ${parentId} failed with status=${getGatewayStatus(error) ?? 'unknown'}.`,
+        );
+      }
+
+      throw error;
     }
 
-    const items = response.data?.items ?? [];
+    const items = response?.items ?? [];
     subfolders.push(...items);
 
-    const lastPage = response.data?.lastPage ?? page;
+    const lastPage = response?.lastPage ?? page;
     if (page >= lastPage) {
       break;
     }
@@ -524,27 +530,18 @@ async function collectSubfolders(
     allFolders.set(sf.id, sf);
     depths.set(sf.id, depth);
     children.push(sf.id);
-    await collectSubfolders(config, apiClient, authState, sf.id, depth + 1, allFolders, childrenMap, depths);
+    await collectSubfolders(gateway, sf.id, depth + 1, allFolders, childrenMap, depths);
   }
 
   childrenMap.set(parentId, children);
 }
 
 async function fetchJournalArticlesInFolder(
-  config: AppConfig,
-  apiClient: LiferayApiClient,
-  authState: PruneAuthState,
+  gateway: LiferayGateway,
   groupId: number,
   folderId: number,
 ): Promise<ArticleWithFolder[]> {
-  const rows = await fetchJournalArticleRowsInFolder(
-    config,
-    apiClient,
-    authState,
-    groupId,
-    folderId,
-    'LIFERAY_CONTENT_PRUNE_ERROR',
-  );
+  const rows = await fetchJournalArticleRowsInFolder(gateway, groupId, folderId, 'LIFERAY_CONTENT_PRUNE_ERROR');
 
   return rows.map((article) => ({
     id: Number(article.resourcePrimKey ?? 0),
@@ -666,9 +663,7 @@ function computeRemovableFolderIds(
 }
 
 async function deleteJournalArticle(
-  config: AppConfig,
-  apiClient: LiferayApiClient,
-  authState: PruneAuthState,
+  gateway: LiferayGateway,
   groupId: number,
   id: number,
   articleId: string,
@@ -677,69 +672,76 @@ async function deleteJournalArticle(
     throw LiferayErrors.contentPruneError('Cannot delete article without articleId.');
   }
 
-  const response = await postFormWithRefresh(
-    config,
-    apiClient,
-    authState,
-    '/api/jsonws/journal.journalarticle/delete-article',
-    {
-      groupId: String(groupId),
-      articleId,
-      articleURL: '',
-    },
-  );
-
-  if (response.ok || response.status === 404) {
+  try {
+    await gateway.postForm<unknown>(
+      '/api/jsonws/journal.journalarticle/delete-article',
+      {
+        groupId: String(groupId),
+        articleId,
+        articleURL: '',
+      },
+      `delete journal article ${articleId}`,
+    );
     return null;
+  } catch (error) {
+    if (isGatewayStatus(error, 404)) {
+      return null;
+    }
+
+    if (!isGatewayError(error)) {
+      throw error;
+    }
+
+    return {
+      id,
+      articleId,
+      status: getGatewayStatus(error),
+      operation: 'delete-article',
+    };
   }
-
-  return {
-    id,
-    articleId,
-    status: response.status,
-    operation: 'delete-article',
-  };
 }
 
-async function tryDeleteFolder(
-  config: AppConfig,
-  apiClient: LiferayApiClient,
-  authState: PruneAuthState,
-  folderId: number,
-): Promise<{ok: boolean; status?: number}> {
-  const response = await deleteWithRefresh(
-    config,
-    apiClient,
-    authState,
-    `/o/headless-delivery/v1.0/structured-content-folders/${folderId}`,
-  );
+async function tryDeleteFolder(gateway: LiferayGateway, folderId: number): Promise<{ok: boolean; status?: number}> {
+  try {
+    await gateway.deleteJson<unknown>(
+      `/o/headless-delivery/v1.0/structured-content-folders/${folderId}`,
+      `delete content folder ${folderId}`,
+    );
 
-  return {ok: response.ok || response.status === 404, status: response.status};
+    return {ok: true};
+  } catch (error) {
+    if (!isGatewayError(error)) {
+      throw error;
+    }
+
+    const status = getGatewayStatus(error);
+    return {ok: status === 404, status};
+  }
 }
 
-async function deleteJournalFolder(
-  config: AppConfig,
-  apiClient: LiferayApiClient,
-  authState: PruneAuthState,
-  folderId: number,
-): Promise<{ok: boolean; status?: number}> {
-  const timeoutSeconds = Math.max(config.liferay.timeoutSeconds, 600);
-  const response = await postFormWithRefresh(
-    config,
-    apiClient,
-    authState,
-    '/api/jsonws/journal.journalfolder/delete-folder',
-    {
-      folderId: String(folderId),
-      includeTrashedEntries: 'true',
-    },
-    timeoutSeconds,
-  );
+async function deleteJournalFolder(gateway: LiferayGateway, folderId: number): Promise<{ok: boolean; status?: number}> {
+  try {
+    await gateway.postForm<unknown>(
+      '/api/jsonws/journal.journalfolder/delete-folder',
+      {
+        folderId: String(folderId),
+        includeTrashedEntries: 'true',
+      },
+      `delete journal folder ${folderId}`,
+    );
 
-  return {
-    ok: response.ok || response.status === 404,
-    status: response.status,
-  };
+    return {ok: true};
+  } catch (error) {
+    if (!isGatewayError(error)) {
+      throw error;
+    }
+
+    const status = getGatewayStatus(error);
+    return {
+      ok: status === 404,
+      status,
+    };
+  }
 }
 
 function dedupeArticles(articles: ArticleWithFolder[]): ArticleWithFolder[] {
@@ -802,60 +804,20 @@ function canDeleteWholeFolders(options: ContentPruneOptions): boolean {
   return (!options.structures || options.structures.length === 0) && (options.keep === undefined || options.keep === 0);
 }
 
-async function deleteWithRefresh<T>(
-  config: AppConfig,
-  apiClient: LiferayApiClient,
-  authState: PruneAuthState,
-  path: string,
-) {
-  let response = await apiClient.delete<T>(config.liferay.url, path, {
-    timeoutSeconds: config.liferay.timeoutSeconds,
-    headers: {Authorization: `Bearer ${authState.accessToken}`},
-  });
-
-  if (response.status !== 401) {
-    return response;
-  }
-
-  authState.accessToken = await fetchAccessToken(config, {
-    apiClient,
-    tokenClient: authState.tokenClient,
-    forceRefresh: true,
-  });
-  response = await apiClient.delete<T>(config.liferay.url, path, {
-    timeoutSeconds: config.liferay.timeoutSeconds,
-    headers: {Authorization: `Bearer ${authState.accessToken}`},
-  });
-
-  return response;
+function isGatewayError(error: unknown): error is CliError {
+  return error instanceof CliError && error.code === 'LIFERAY_GATEWAY_ERROR';
 }
 
-async function postFormWithRefresh<T>(
-  config: AppConfig,
-  apiClient: LiferayApiClient,
-  authState: PruneAuthState,
-  path: string,
-  form: Record<string, string>,
-  timeoutSeconds = config.liferay.timeoutSeconds,
-) {
-  let response = await apiClient.postForm<T>(config.liferay.url, path, form, {
-    timeoutSeconds,
-    headers: {Authorization: `Bearer ${authState.accessToken}`},
-  });
+function isGatewayStatus(error: unknown, status: number): boolean {
+  return isGatewayError(error) && error.message.includes(`status=${status}`);
+}
 
-  if (response.status !== 401) {
-    return response;
+function getGatewayStatus(error: CliError): number | undefined {
+  const match = /status=(\d+)/.exec(error.message);
+  if (!match) {
+    return undefined;
   }
 
-  authState.accessToken = await fetchAccessToken(config, {
-    apiClient,
-    tokenClient: authState.tokenClient,
-    forceRefresh: true,
-  });
-  response = await apiClient.postForm<T>(config.liferay.url, path, form, {
-    timeoutSeconds,
-    headers: {Authorization: `Bearer ${authState.accessToken}`},
-  });
-
-  return response;
+  const value = Number(match[1]);
+  return Number.isFinite(value) ? value : undefined;
 }

--- a/src/features/liferay/content/liferay-content-stats.ts
+++ b/src/features/liferay/content/liferay-content-stats.ts
@@ -1,14 +1,15 @@
 import type {AppConfig} from '../../../core/config/load-config.js';
 import {createConcurrencyLimiter, mapConcurrent} from '../../../core/concurrency.js';
+import {CliError} from '../../../core/errors.js';
 import {createOAuthTokenClient, type OAuthTokenClient} from '../../../core/http/auth.js';
 import {createLiferayApiClient, type LiferayApiClient} from '../../../core/http/client.js';
 import type {Printer} from '../../../core/output/printer.js';
 import {runStep} from '../../../core/output/run-step.js';
 import {LiferayErrors} from '../errors/index.js';
-import {fetchAccessToken, normalizeFriendlyUrl, resolveSite} from '../inventory/liferay-inventory-shared.js';
+import {normalizeFriendlyUrl, resolveSite} from '../inventory/liferay-inventory-shared.js';
 import {runLiferayInventorySites} from '../inventory/liferay-inventory-sites.js';
+import {createLiferayGateway, type LiferayGateway} from '../liferay-gateway.js';
 import {
-  authedGetWithRefresh,
   fetchJournalFoldersByParent,
   fetchJournalArticleRowsInFolder,
   hydrateMissingJournalStructureDefinitions,
@@ -77,11 +78,6 @@ type ContentStatsDependencies = {
   printer?: Printer;
 };
 
-type AuthState = {
-  accessToken: string;
-  tokenClient: OAuthTokenClient;
-};
-
 type HeadlessFolder = {
   id?: number;
   name?: string;
@@ -112,10 +108,18 @@ export async function runContentStats(
   const apiClient = dependencies?.apiClient ?? createLiferayApiClient();
   const tokenClient = dependencies?.tokenClient ?? createOAuthTokenClient();
   const printer = dependencies?.printer;
-  const authState: AuthState = {
-    accessToken: await fetchAccessToken(config, {apiClient, tokenClient}),
+  const gateway = createLiferayGateway(config, apiClient, tokenClient);
+  const longRunningGateway = createLiferayGateway(
+    {
+      ...config,
+      liferay: {
+        ...config.liferay,
+        timeoutSeconds: Math.max(config.liferay.timeoutSeconds, 600),
+      },
+    },
+    apiClient,
     tokenClient,
-  };
+  );
   const limit = options.limit ?? DEFAULT_LIMIT;
   const sortBy = options.sortBy ?? 'content';
   const excludedSites = new Set(
@@ -125,20 +129,28 @@ export async function runContentStats(
 
   if (options.site || options.groupId !== undefined) {
     const site = options.site
-      ? await resolveSite(config, options.site, {apiClient, accessToken: authState.accessToken, tokenClient})
+      ? await resolveSite(config, options.site, {apiClient, tokenClient})
       : {id: options.groupId!, friendlyUrlPath: undefined, name: ''};
 
     const selected = await runStep(printer, 'Collecting content folders', async () => {
-      const roots = await collectJournalFolderTree(config, apiClient, authState, site.id, 0, runLimited);
+      const roots = await collectJournalFolderTree(gateway, site.id, 0, runLimited);
       const stats = await mapConcurrent(roots, JOURNAL_FOLDER_CONCURRENCY, (root) =>
-        buildJournalFolderStats(config, apiClient, authState, site.id, root, runLimited),
+        buildJournalFolderStats(longRunningGateway, site.id, root, runLimited),
       );
       return stats.sort(compareFoldersByVolume).slice(0, limit);
     });
 
     const folders = options.withStructures
       ? await runStep(printer, 'Collecting content structures', async () =>
-          enrichFoldersWithStructures(config, apiClient, authState, site.id, selected, runLimited),
+          enrichFoldersWithStructures(
+            config,
+            apiClient,
+            tokenClient,
+            longRunningGateway,
+            site.id,
+            selected,
+            runLimited,
+          ),
         )
       : selected.map(stripComputedFolderStats);
 
@@ -160,10 +172,8 @@ export async function runContentStats(
     const skippedSites: Array<{groupId: number; siteFriendlyUrl: string; reason: string}> = [];
     const rows = await mapConcurrent(filteredSites, SITE_CONCURRENCY, async (site) => {
       try {
-        const roots = await fetchRootFolders(config, apiClient, authState, site.groupId);
-        const folderStats = await Promise.all(
-          roots.map((root) => buildFolderStats(config, apiClient, authState, root)),
-        );
+        const roots = await fetchRootFolders(gateway, site.groupId);
+        const folderStats = await Promise.all(roots.map((root) => buildFolderStats(gateway, root)));
         const structuredContents = folderStats.reduce((sum, folder) => sum + folder.subtreeStructuredContents, 0);
         const folderCount = folderStats.reduce((sum, folder) => sum + folder.childFolderCount + 1, 0);
 
@@ -263,16 +273,9 @@ export function formatContentStats(result: ContentStatsResult): string {
   return lines.join('\n');
 }
 
-async function fetchRootFolders(
-  config: AppConfig,
-  apiClient: LiferayApiClient,
-  authState: AuthState,
-  groupId: number,
-): Promise<HeadlessFolder[]> {
+async function fetchRootFolders(gateway: LiferayGateway, groupId: number): Promise<HeadlessFolder[]> {
   const folders = await fetchHeadlessFoldersPageByPage(
-    config,
-    apiClient,
-    authState,
+    gateway,
     `/o/headless-delivery/v1.0/sites/${groupId}/structured-content-folders`,
   );
 
@@ -283,64 +286,53 @@ async function fetchRootFolders(
   return sameSiteFolders.length > 0 ? sameSiteFolders : folders;
 }
 
-async function fetchChildFolders(
-  config: AppConfig,
-  apiClient: LiferayApiClient,
-  authState: AuthState,
-  folderId: number,
-): Promise<HeadlessFolder[]> {
+async function fetchChildFolders(gateway: LiferayGateway, folderId: number): Promise<HeadlessFolder[]> {
   return fetchHeadlessFoldersPageByPage(
-    config,
-    apiClient,
-    authState,
+    gateway,
     `/o/headless-delivery/v1.0/structured-content-folders/${folderId}/structured-content-folders`,
   );
 }
 
-async function fetchHeadlessFoldersPageByPage(
-  config: AppConfig,
-  apiClient: LiferayApiClient,
-  authState: AuthState,
-  basePath: string,
-): Promise<HeadlessFolder[]> {
+async function fetchHeadlessFoldersPageByPage(gateway: LiferayGateway, basePath: string): Promise<HeadlessFolder[]> {
   const items: HeadlessFolder[] = [];
   let page = 1;
   let lastPage = 1;
 
   while (page <= lastPage) {
-    const response = await authedGetWithRefresh<{items?: HeadlessFolder[]; lastPage?: number}>(
-      config,
-      apiClient,
-      authState,
-      `${basePath}?page=${page}&pageSize=${PAGE_SIZE}`,
-    );
+    let response: {items?: HeadlessFolder[]; lastPage?: number};
 
-    if (!response.ok) {
-      throw LiferayErrors.contentStatsError(`${basePath} failed with status=${response.status}.`);
+    try {
+      response = await gateway.getJson<{items?: HeadlessFolder[]; lastPage?: number}>(
+        `${basePath}?page=${page}&pageSize=${PAGE_SIZE}`,
+        `content folders ${basePath}`,
+      );
+    } catch (error) {
+      if (isGatewayError(error)) {
+        throw LiferayErrors.contentStatsError(
+          `${basePath} failed with status=${getGatewayStatus(error) ?? 'unknown'}.`,
+        );
+      }
+
+      throw error;
     }
 
-    items.push(...(response.data?.items ?? []));
-    lastPage = response.data?.lastPage ?? 1;
+    items.push(...(response?.items ?? []));
+    lastPage = response?.lastPage ?? 1;
     page += 1;
   }
 
   return items.filter((item) => item.id !== undefined);
 }
 
-async function buildFolderStats(
-  config: AppConfig,
-  apiClient: LiferayApiClient,
-  authState: AuthState,
-  rootFolder: HeadlessFolder,
-): Promise<ComputedFolderStats> {
-  const children = await fetchChildFolders(config, apiClient, authState, rootFolder.id ?? 0);
+async function buildFolderStats(gateway: LiferayGateway, rootFolder: HeadlessFolder): Promise<ComputedFolderStats> {
+  const children = await fetchChildFolders(gateway, rootFolder.id ?? 0);
   let subtreeStructuredContents = rootFolder.numberOfStructuredContents ?? 0;
   let childFolderCount = children.length;
   const subtreeFolderIds = [rootFolder.id ?? 0];
   const childStatsList: ComputedFolderStats[] = [];
 
   for (const child of children) {
-    const childStats = await buildFolderStats(config, apiClient, authState, child);
+    const childStats = await buildFolderStats(gateway, child);
     childStatsList.push(childStats);
     subtreeStructuredContents += childStats.subtreeStructuredContents;
     childFolderCount += childStats.childFolderCount;
@@ -378,7 +370,8 @@ function stripComputedFolderStats(folder: ComputedFolderStats): ContentStatsFold
 async function enrichFoldersWithStructures(
   config: AppConfig,
   apiClient: LiferayApiClient,
-  authState: AuthState,
+  tokenClient: OAuthTokenClient,
+  articleGateway: LiferayGateway,
   groupId: number,
   folders: ComputedFolderStats[],
   runLimited: <T>(task: () => Promise<T>) => Promise<T>,
@@ -386,20 +379,18 @@ async function enrichFoldersWithStructures(
   const structureMap = new Map<number, string>();
   const structureNameMap = new Map<string, string>();
 
-  await resolveJournalStructureDefinitions(config, apiClient, authState, groupId, structureMap, structureNameMap);
+  await resolveJournalStructureDefinitions(config, apiClient, tokenClient, groupId, structureMap, structureNameMap);
 
   return mapConcurrent(folders, JOURNAL_FOLDER_CONCURRENCY, async (folder) => {
     const counts = new Map<string, number>();
 
     await mapConcurrent(folder.subtreeFolderIds, JOURNAL_FOLDER_CONCURRENCY, async (folderId) => {
       const rows = await runLimited(() =>
-        fetchJournalArticleRowsInFolder(config, apiClient, authState, groupId, folderId, 'LIFERAY_CONTENT_STATS_ERROR'),
+        fetchJournalArticleRowsInFolder(articleGateway, groupId, folderId, 'LIFERAY_CONTENT_STATS_ERROR'),
       );
 
       await hydrateMissingJournalStructureDefinitions(
-        config,
-        apiClient,
-        authState,
+        articleGateway,
         rows
           .map((row) => (row.DDMStructureId !== undefined ? Number(row.DDMStructureId) : undefined))
           .filter((value): value is number => value !== undefined && Number.isFinite(value)),
@@ -433,45 +424,34 @@ async function enrichFoldersWithStructures(
 }
 
 async function collectJournalFolderTree(
-  config: AppConfig,
-  apiClient: LiferayApiClient,
-  authState: AuthState,
+  gateway: LiferayGateway,
   groupId: number,
   parentFolderId: number,
   runLimited: <T>(task: () => Promise<T>) => Promise<T>,
 ): Promise<JournalFolderNode[]> {
   const folders = await runLimited(() =>
-    fetchJournalFoldersByParent(config, apiClient, authState, groupId, parentFolderId, 'LIFERAY_CONTENT_STATS_ERROR'),
+    fetchJournalFoldersByParent(gateway, groupId, parentFolderId, 'LIFERAY_CONTENT_STATS_ERROR'),
   );
 
   return mapConcurrent(folders, JOURNAL_FOLDER_CONCURRENCY, async (folder) => ({
     folderId: folder.folderId,
     name: folder.name,
-    children: await collectJournalFolderTree(config, apiClient, authState, groupId, folder.folderId, runLimited),
+    children: await collectJournalFolderTree(gateway, groupId, folder.folderId, runLimited),
   }));
 }
 
 async function buildJournalFolderStats(
-  config: AppConfig,
-  apiClient: LiferayApiClient,
-  authState: AuthState,
+  gateway: LiferayGateway,
   groupId: number,
   folder: JournalFolderNode,
   runLimited: <T>(task: () => Promise<T>) => Promise<T>,
 ): Promise<ComputedFolderStats> {
   const rows = await runLimited(() =>
-    fetchJournalArticleRowsInFolder(
-      config,
-      apiClient,
-      authState,
-      groupId,
-      folder.folderId,
-      'LIFERAY_CONTENT_STATS_ERROR',
-    ),
+    fetchJournalArticleRowsInFolder(gateway, groupId, folder.folderId, 'LIFERAY_CONTENT_STATS_ERROR'),
   );
 
   const childStats = await mapConcurrent(folder.children, JOURNAL_FOLDER_CONCURRENCY, (child) =>
-    buildJournalFolderStats(config, apiClient, authState, groupId, child, runLimited),
+    buildJournalFolderStats(gateway, groupId, child, runLimited),
   );
 
   return {
@@ -514,4 +494,18 @@ function compareSites(left: ContentStatsSite, right: ContentStatsSite, sortBy: '
   }
 
   return compareSitesByVolume(left, right);
+}
+
+function isGatewayError(error: unknown): error is CliError {
+  return error instanceof CliError && error.code === 'LIFERAY_GATEWAY_ERROR';
+}
+
+function getGatewayStatus(error: CliError): number | undefined {
+  const match = /status=(\d+)/.exec(error.message);
+  if (!match) {
+    return undefined;
+  }
+
+  const value = Number(match[1]);
+  return Number.isFinite(value) ? value : undefined;
 }

--- a/tests/unit/liferay-content-prune.test.ts
+++ b/tests/unit/liferay-content-prune.test.ts
@@ -908,9 +908,8 @@ describe('liferay-content-prune: apply mode', () => {
     expect(maxInflightDeletes).toBeGreaterThan(1);
   });
 
-  test('apply mode refreshes token and retries article deletion on 401', async () => {
+  test('apply mode does not retry article deletion manually on 401', async () => {
     let tokenFetches = 0;
-    let firstDeleteAttempt = true;
     const deleteAuthHeaders: string[] = [];
 
     function getAuthorizationHeader(init: RequestInit | undefined): string {
@@ -935,12 +934,7 @@ describe('liferay-content-prune: apply mode', () => {
 
         if (method === 'POST' && url.includes('/api/jsonws/journal.journalarticle/delete-article')) {
           deleteAuthHeaders.push(getAuthorizationHeader(init as RequestInit | undefined));
-          if (firstDeleteAttempt) {
-            firstDeleteAttempt = false;
-            return new Response('unauthorized', {status: 401});
-          }
-
-          return new Response('{}', {status: 200});
+          return new Response('unauthorized', {status: 401});
         }
 
         if (method === 'DELETE' && url.includes('/structured-content-folders/12345')) {
@@ -996,9 +990,18 @@ describe('liferay-content-prune: apply mode', () => {
     );
 
     expect(result.mode).toBe('apply');
-    expect(firstDeleteAttempt).toBe(false);
-    expect(tokenFetches).toBe(2);
-    expect(deleteAuthHeaders).toEqual(['Bearer token-1', 'Bearer token-2']);
+    expect(tokenFetches).toBeGreaterThan(0);
+    expect(deleteAuthHeaders).toHaveLength(1);
+    expect(deleteAuthHeaders[0]).toMatch(/^Bearer token-\d+$/);
+    expect(result.failedArticles).toEqual([
+      {
+        id: 1001,
+        articleId: '1001',
+        status: 401,
+        operation: 'delete-article',
+      },
+    ]);
+    expect(result.removedFolders).toEqual([]);
   });
 
   test('apply mode records failed deletes and keeps going when delete-article fails', async () => {


### PR DESCRIPTION
## Summary
- Migrates the content transport/auth paths in `src/features/liferay/content/**` from local auth wrappers to `LiferayGateway`.
- Removes manual token fetch, manual `Authorization` header wiring, and explicit `401` refresh/retry logic from content.
- Keeps prune, stats, and journal traversal behavior unchanged apart from delegating transport/auth concerns to the gateway.

## What Changed
- Reworked `liferay-content-journal-shared.ts` to use `gateway.getJson(...)` and preserve existing content-specific error messages/codes around journal folder/article traversal.
- Reworked `liferay-content-prune.ts` to:
  - build `LiferayGateway` from existing DI (`apiClient`, `tokenClient`)
  - replace manual authenticated GET/POST/DELETE helpers with `gateway.getJson`, `gateway.postForm`, and `gateway.deleteJson`
  - remove local `authedGetWithRefresh`, `deleteWithRefresh`, and `postFormWithRefresh` style behavior from content prune flows
  - preserve `404` handling for folder/article deletion and existing prune planning/execution behavior
- Reworked `liferay-content-stats.ts` to use `LiferayGateway` for headless folder traversal and journal stats traversal while preserving the existing stats logic.
- Updated the focused prune unit test that previously asserted manual `401` retry behavior.

## Deliberately Left Unchanged
- No changes to `inventory/**`, `resource/**`, `page-layout/**`, `liferay-gateway.ts`, `liferay-http-shared.ts`, or `liferay-site-resolver.ts`.
- No business-logic refactor of prune or stats structure.
- No new error codes or changes to `LiferayErrors`.

## Validation
- `npm run typecheck`
- `npm run test:unit -- tests/unit/liferay-content-prune.test.ts tests/unit/liferay-content-stats.test.ts`

## Verification
- `rg -n "authedGetWithRefresh|deleteWithRefresh|postFormWithRefresh" src/features/liferay/content`
- `rg -n "fetchAccessToken\(|401" src/features/liferay/content/liferay-content-prune.ts`
- `rg -n "fetchAccessToken\(|401" src/features/liferay/content/liferay-content-journal-shared.ts`
- `rg -n "fetchAccessToken\(|401" src/features/liferay/content/liferay-content-stats.ts`
