### PR TITLE
refactor(page-layout): migrate export transport to LiferayGateway

### DIFF
--- a/src/features/liferay/page-layout/liferay-page-layout-export.ts
+++ b/src/features/liferay/page-layout/liferay-page-layout-export.ts
@@ -2,13 +2,14 @@ import fs from 'fs-extra';
 import path from 'node:path';
 
 import type {AppConfig} from '../../../core/config/load-config.js';
+import {CliError} from '../../../core/errors.js';
 import type {OAuthTokenClient} from '../../../core/http/auth.js';
 import type {LiferayApiClient} from '../../../core/http/client.js';
 import {createLiferayApiClient} from '../../../core/http/client.js';
 import {trimLeadingSlash} from '../../../core/utils/text.js';
 import {LiferayErrors} from '../errors/index.js';
+import {createLiferayGateway, type LiferayGateway} from '../liferay-gateway.js';
 import {resolveRegularLayoutPage} from '../inventory/liferay-inventory-page.js';
-import {authedGet, fetchAccessToken} from '../inventory/liferay-inventory-shared.js';
 import {buildLayoutConfigureUrl} from './liferay-page-admin-urls.js';
 
 const EXPORT_KIND = 'liferay-page-layout-export';
@@ -63,14 +64,8 @@ export async function runLiferayPageLayoutExport(
 ): Promise<LiferayPageLayoutExport> {
   const regularPage = await resolveExportableRegularPage(config, options, dependencies);
   const apiClient = dependencies?.apiClient ?? createLiferayApiClient();
-  const accessToken = await fetchAccessToken(config, dependencies);
-  const headlessSitePage = await fetchSitePage(
-    config,
-    apiClient,
-    accessToken,
-    regularPage.groupId,
-    regularPage.friendlyUrl,
-  );
+  const gateway = createLiferayGateway(config, apiClient, dependencies?.tokenClient);
+  const headlessSitePage = await fetchSitePage(gateway, regularPage.groupId, regularPage.friendlyUrl);
 
   if (headlessSitePage === null) {
     throw LiferayErrors.pageLayoutError(
@@ -78,13 +73,7 @@ export async function runLiferayPageLayoutExport(
     );
   }
 
-  const experiences = await fetchSitePageExperiences(
-    config,
-    apiClient,
-    accessToken,
-    regularPage.groupId,
-    regularPage.friendlyUrl,
-  );
+  const experiences = await fetchSitePageExperiences(gateway, regularPage.groupId, regularPage.friendlyUrl);
 
   return {
     kind: EXPORT_KIND,
@@ -187,41 +176,50 @@ async function resolveExportableRegularPage(
 }
 
 async function fetchSitePage(
-  config: AppConfig,
-  apiClient: LiferayApiClient,
-  accessToken: string,
+  gateway: LiferayGateway,
   siteId: number,
   friendlyUrl: string,
 ): Promise<Record<string, unknown> | null> {
   const slug = trimLeadingSlash(friendlyUrl);
-  const response = await authedGet<Record<string, unknown>>(
-    config,
-    apiClient,
-    accessToken,
-    `/o/headless-delivery/v1.0/sites/${siteId}/site-pages/${slug}?fields=actions,friendlyUrlPath,id,pageDefinition,pageType,siteId,title,uuid`,
-  );
+  let data: Record<string, unknown> | null;
 
-  if (!response.ok || response.data === null || Array.isArray(response.data)) {
+  try {
+    data = await gateway.getJson<Record<string, unknown> | null>(
+      `/o/headless-delivery/v1.0/sites/${siteId}/site-pages/${slug}?fields=actions,friendlyUrlPath,id,pageDefinition,pageType,siteId,title,uuid`,
+      `fetch site page ${siteId}/${slug}`,
+    );
+  } catch (error) {
+    if (error instanceof CliError && error.code === 'LIFERAY_GATEWAY_ERROR') {
+      return null;
+    }
+
+    throw error;
+  }
+
+  if (data === null || Array.isArray(data)) {
     return null;
   }
 
-  return response.data;
+  return data;
 }
 
 async function fetchSitePageExperiences(
-  config: AppConfig,
-  apiClient: LiferayApiClient,
-  accessToken: string,
+  gateway: LiferayGateway,
   siteId: number,
   friendlyUrl: string,
 ): Promise<unknown | null> {
   const slug = trimLeadingSlash(friendlyUrl);
-  const response = await authedGet<unknown>(
-    config,
-    apiClient,
-    accessToken,
-    `/o/headless-delivery/v1.0/sites/${siteId}/site-pages/${slug}/experiences`,
-  );
 
-  return response.ok ? response.data : null;
+  try {
+    return await gateway.getJson<unknown>(
+      `/o/headless-delivery/v1.0/sites/${siteId}/site-pages/${slug}/experiences`,
+      `fetch site page experiences ${siteId}/${slug}`,
+    );
+  } catch (error) {
+    if (error instanceof CliError && error.code === 'LIFERAY_GATEWAY_ERROR') {
+      return null;
+    }
+
+    throw error;
+  }
 }

--- a/tests/unit/liferay-page-layout-export.test.ts
+++ b/tests/unit/liferay-page-layout-export.test.ts
@@ -107,6 +107,59 @@ describe('liferay page-layout export', () => {
     });
   });
 
+  test('keeps experiences as best-effort and omits them when the endpoint fails', async () => {
+    const apiClient = createLiferayApiClient({
+      fetchImpl: async (input) => {
+        const url = String(input);
+
+        if (url.includes('/by-friendly-url-path/guest')) {
+          return new Response('{"id":20121,"friendlyUrlPath":"/guest","name":"Guest"}', {status: 200});
+        }
+
+        if (url.includes('/api/jsonws/layout/get-layouts?') && url.includes('parentLayoutId=0')) {
+          return new Response(
+            '[{"layoutId":11,"plid":1011,"type":"content","nameCurrentValue":"Home","friendlyURL":"/home","hidden":false}]',
+            {status: 200},
+          );
+        }
+
+        if (url.includes('/api/jsonws/layout/get-layouts?') && url.includes('parentLayoutId=11')) {
+          return new Response('[]', {status: 200});
+        }
+
+        if (url.includes('/site-pages/home?fields=')) {
+          return new Response(
+            '{"id":5001,"uuid":"uuid-1","friendlyUrlPath":"home","pageType":"Content Layout","siteId":20121,"title":"Home","pageDefinition":{"widgets":[]}}',
+            {status: 200},
+          );
+        }
+
+        if (url.endsWith('/site-pages/home/experiences')) {
+          return new Response('{"message":"not available"}', {status: 404});
+        }
+
+        if (url.includes('/api/jsonws/classname/fetch-class-name?value=com.liferay.portal.kernel.model.Layout')) {
+          return new Response('{"classNameId":20006}', {status: 200});
+        }
+
+        throw new Error(`Unexpected URL ${url}`);
+      },
+    });
+
+    const result = await runLiferayPageLayoutExport(
+      CONFIG,
+      {url: '/web/guest/home'},
+      {
+        apiClient,
+        tokenClient: TOKEN_CLIENT,
+        now: () => new Date('2026-03-26T12:00:00.000Z'),
+      },
+    );
+
+    expect(result.headlessSitePage).toMatchObject({id: 5001});
+    expect(result).not.toHaveProperty('experiences');
+  });
+
   test('writes export to a file and creates parent directories', async () => {
     const dir = createTempDir('dev-cli-page-layout-export-');
     const filePath = path.join(dir, 'nested', 'page-layout.json');
@@ -180,5 +233,44 @@ describe('liferay page-layout export', () => {
     await expect(
       runLiferayPageLayoutExport(CONFIG, {url: '/web/guest/home'}, {apiClient, tokenClient: TOKEN_CLIENT}),
     ).rejects.toThrow('layoutType=content');
+  });
+
+  test('keeps the export failure message when headless delivery does not return a usable page object', async () => {
+    const apiClient = createLiferayApiClient({
+      fetchImpl: async (input) => {
+        const url = String(input);
+
+        if (url.includes('/by-friendly-url-path/guest')) {
+          return new Response('{"id":20121,"friendlyUrlPath":"/guest","name":"Guest"}', {status: 200});
+        }
+
+        if (url.includes('/api/jsonws/layout/get-layouts?') && url.includes('parentLayoutId=0')) {
+          return new Response(
+            '[{"layoutId":11,"plid":1011,"type":"content","nameCurrentValue":"Home","friendlyURL":"/home","hidden":false}]',
+            {status: 200},
+          );
+        }
+
+        if (url.includes('/api/jsonws/layout/get-layouts?') && url.includes('parentLayoutId=11')) {
+          return new Response('[]', {status: 200});
+        }
+
+        if (url.includes('/site-pages/home?fields=')) {
+          return new Response('[]', {status: 200});
+        }
+
+        if (url.includes('/api/jsonws/classname/fetch-class-name?value=com.liferay.portal.kernel.model.Layout')) {
+          return new Response('{"classNameId":20006}', {status: 200});
+        }
+
+        throw new Error(`Unexpected URL ${url}`);
+      },
+    });
+
+    await expect(
+      runLiferayPageLayoutExport(CONFIG, {url: '/web/guest/home'}, {apiClient, tokenClient: TOKEN_CLIENT}),
+    ).rejects.toThrow(
+      'The page cannot be exported through Headless Delivery or could not be resolved as a content page.',
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Migrates page-layout export from the manual `fetchAccessToken` plus `authedGet` pattern to a local `LiferayGateway`.
- Preserves the export JSON contract and the existing visible error messages.
- Keeps `resolveRegularLayoutPage` unchanged and retains the current semantics for non-exportable pages.

## What Changed
- `src/features/liferay/page-layout/liferay-page-layout-export.ts`
  - creates a local `LiferayGateway` from the existing DI
  - replaces manual token fetch and authenticated GET calls with `gateway.getJson(...)`
  - preserves `fetchSitePage(...)` behavior by returning `null` when Headless Delivery does not return a usable object
  - preserves `fetchSitePageExperiences(...)` as best-effort and non-fatal by returning `null` on gateway failure
- `tests/unit/liferay-page-layout-export.test.ts`
  - adds coverage for best-effort `experiences`
  - adds coverage for the existing export failure message when Headless Delivery returns a non-usable payload

## Deliberately Left Out
- No scope expansion to page-layout diff.
- No redesign of `resolveRegularLayoutPage`.
- No changes to `liferay-http-shared`, `liferay-gateway`, or broader page-layout transport abstractions.
- No changes to the serialized export shape: `kind`, `schemaVersion`, `generatedAt`, `source`, `adminUrls`, `headlessSitePage`, `experiences`, and `layoutStructure`.

## Validation
- `npm run typecheck`
- `npm run test:unit -- liferay-page-layout-export.test.ts liferay-page-layout-diff.test.ts`
- `rg -n "fetchAccessToken\(|authedGet\(" src/features/liferay/page-layout/liferay-page-layout-export.ts`

## Compatibility Notes
- `experiences` remains best-effort and is still omitted when the endpoint fails.
- The export still fails with the existing message when the resolved page cannot be exported through Headless Delivery.
