### PR TITLE
refactor(liferay): migrate health check transport to LiferayGateway

### DIFF
--- a/src/features/liferay/liferay-audit.ts
+++ b/src/features/liferay/liferay-audit.ts
@@ -2,6 +2,7 @@ import type {AppConfig} from '../../core/config/load-config.js';
 import {createOAuthTokenClient, type OAuthTokenClient} from '../../core/http/auth.js';
 import {createLiferayApiClient, type LiferayApiClient} from '../../core/http/client.js';
 import {fetchPagedItems, resolveSite} from './inventory/liferay-inventory-shared.js';
+import {createLiferayGateway} from './liferay-gateway.js';
 import {performLiferayHealthCheck} from './liferay-health.js';
 
 export type LiferayAuditResult = {
@@ -36,7 +37,7 @@ export async function runLiferayAudit(
   const siteInput = options?.site ?? '/global';
   const pageSize = options?.pageSize ?? 200;
 
-  const health = await performLiferayHealthCheck(config, token.accessToken, apiClient);
+  const health = await performLiferayHealthCheck(createLiferayGateway(config, apiClient, tokenClient));
   const site = await resolveSite(config, siteInput, {apiClient, tokenClient});
   const [structures, templates] = await Promise.all([
     fetchPagedItems(config, `/o/data-engine/v2.0/sites/${site.id}/data-definitions/by-content-type/journal`, pageSize, {

--- a/src/features/liferay/liferay-gateway.ts
+++ b/src/features/liferay/liferay-gateway.ts
@@ -1,7 +1,7 @@
 import type {AppConfig} from '../../core/config/load-config.js';
 import type {OAuthTokenClient} from '../../core/http/auth.js';
 import {createOAuthTokenClient} from '../../core/http/auth.js';
-import type {HttpRequestOptions, LiferayApiClient} from '../../core/http/client.js';
+import type {HttpRequestOptions, HttpResponse, LiferayApiClient} from '../../core/http/client.js';
 import {createLiferayApiClient} from '../../core/http/client.js';
 import {buildAuthOptions, expectJsonSuccess} from './liferay-http-shared.js';
 
@@ -144,6 +144,16 @@ export class LiferayGateway {
 
     const success = await expectJsonSuccess(response, label, 'LIFERAY_GATEWAY_ERROR');
     return (success.data ?? null) as T;
+  }
+
+  /**
+   * GET /path, return the raw HTTP response without asserting ok status.
+   * Use when the caller needs to inspect specific status codes (e.g., 403, 404) instead of a unified error throw.
+   */
+  async getRaw<T>(path: string): Promise<HttpResponse<T>> {
+    const accessToken = await this.getAccessToken();
+    const authOptions = buildAuthOptions(this.config, accessToken);
+    return this.apiClient.get<T>(this.config.liferay.url, path, authOptions);
   }
 
   /**

--- a/src/features/liferay/liferay-health.ts
+++ b/src/features/liferay/liferay-health.ts
@@ -1,8 +1,8 @@
 import type {AppConfig} from '../../core/config/load-config.js';
 import {createOAuthTokenClient, type OAuthTokenClient} from '../../core/http/auth.js';
-import {createLiferayApiClient, type LiferayApiClient} from '../../core/http/client.js';
+import {type LiferayApiClient} from '../../core/http/client.js';
+import {createLiferayGateway, type LiferayGateway} from './liferay-gateway.js';
 import {LiferayErrors} from './errors/index.js';
-import {authedGet} from './inventory/liferay-inventory-shared.js';
 
 const HEALTH_PATH = '/o/headless-admin-user/v1.0/my-user-account';
 
@@ -29,7 +29,8 @@ export async function runLiferayHealth(
 ): Promise<LiferayHealthResult> {
   const tokenClient = dependencies?.tokenClient ?? createOAuthTokenClient();
   const token = await tokenClient.fetchClientCredentialsToken(config.liferay);
-  const health = await performLiferayHealthCheck(config, token.accessToken, dependencies?.apiClient);
+  const gateway = createLiferayGateway(config, dependencies?.apiClient, tokenClient);
+  const health = await performLiferayHealthCheck(gateway);
 
   return {
     ok: true,
@@ -45,12 +46,9 @@ export async function runLiferayHealth(
 }
 
 export async function performLiferayHealthCheck(
-  config: AppConfig,
-  accessToken: string,
-  apiClient?: LiferayApiClient,
+  gateway: LiferayGateway,
 ): Promise<{status: number; checkedPath: string; permissionDenied: boolean; probeUnavailable: boolean}> {
-  const client = apiClient ?? createLiferayApiClient();
-  const response = await authedGet(config, client, accessToken, HEALTH_PATH);
+  const response = await gateway.getRaw<unknown>(HEALTH_PATH);
 
   if (response.ok) {
     return {


### PR DESCRIPTION
## Summary

Migrates `liferay-health.ts` from manual token fetch + `authedGet` (imported from `inventory/liferay-inventory-shared`) to `LiferayGateway`.

Removes the cross-module dependency on `authedGet` from inventory-shared and routes the health probe through a gateway instance instead. The gateway handles Bearer token acquisition and header injection. Raw HTTP response inspection (needed for 403/404 partials) is exposed via a new `getRaw` method on `LiferayGateway` that returns the response without asserting success status.

## What Changed

**`src/features/liferay/liferay-gateway.ts`**
- Added `getRaw<T>(path: string): Promise<HttpResponse<T>>`  fetches token via internal cache, builds auth headers, returns the raw `HttpResponse<T>` without calling `expectJsonSuccess`. Needed because the health check must distinguish 403 (permissionDenied) and 404 (probeUnavailable) from an error.

**`src/features/liferay/liferay-health.ts`**
- Removed `import {authedGet} from './inventory/liferay-inventory-shared.js'`  the cross-module coupling is gone.
- `runLiferayHealth` builds a `LiferayGateway` from injected `apiClient` + `tokenClient` (same DI shape as before) and passes it to `performLiferayHealthCheck`.
- `performLiferayHealthCheck` now accepts `(gateway: LiferayGateway)` instead of `(config, accessToken, apiClient?)` and calls `gateway.getRaw<unknown>(HEALTH_PATH)`.
- All status branches (ok, 403, 404, throw) are unchanged.
- `HealthDependencies` shape is unchanged: `{apiClient?, tokenClient?}`.

**`src/features/liferay/liferay-audit.ts`**
- Updated the single call site of `performLiferayHealthCheck` to the new signature: `performLiferayHealthCheck(createLiferayGateway(config, apiClient, tokenClient))`. One-line mechanical update.

## Explicitly Left Out

- No changes to content, inventory, resource, page-layout, preflight, or any other module.
- No changes to CLI public API or serialized output contracts.
- No new error codes, no changes to error messages or status semantics.
- `HealthDependencies` external shape is unchanged (`apiClient?`, `tokenClient?`).
- The `formatLiferayHealth` function is untouched.

## Trade-off noted

`runLiferayHealth` calls `tokenClient.fetchClientCredentialsToken` once manually (to read `tokenType` and `expiresIn` for the output) and the gateway calls it again internally on `getRaw`. This means two token-endpoint calls per health check. Acceptable for a one-shot diagnostic command; fixing it properly would require exposing token metadata from the gateway cache, which is out of scope for this PR.

## Validation

- `npm run typecheck`  pass (clean)
- `npm run test:unit -- tests/unit/liferay-check.test.ts`  809 tests, 78 files, all passing
- `rg -n "fetchAccessToken\(|authedGet\(" src/features/liferay/liferay-health.ts`  no output (empty)
