### PR TITLE
refactor(resource): migrate get-structure transport to LiferayGateway

### DIFF
--- a/src/features/liferay/resource/liferay-resource-get-structure.ts
+++ b/src/features/liferay/resource/liferay-resource-get-structure.ts
@@ -1,9 +1,9 @@
 import type {AppConfig} from '../../../core/config/load-config.js';
 import type {OAuthTokenClient} from '../../../core/http/auth.js';
 import type {LiferayApiClient} from '../../../core/http/client.js';
-import {createLiferayApiClient} from '../../../core/http/client.js';
 import {LiferayErrors} from '../errors/index.js';
-import {authedGet, fetchAccessToken, normalizeLocalizedName} from '../inventory/liferay-inventory-shared.js';
+import {createLiferayGateway} from '../liferay-gateway.js';
+import {normalizeLocalizedName} from '../inventory/liferay-inventory-shared.js';
 import {buildResourceSiteChain, resolveResourceSite} from './liferay-resource-shared.js';
 import type {DataDefinitionPayload} from './liferay-resource-payloads.js';
 
@@ -27,8 +27,7 @@ export async function runLiferayResourceGetStructure(
   options: {site?: string; key?: string; id?: string},
   dependencies?: ResourceDependencies,
 ): Promise<LiferayResourceStructureResult> {
-  const apiClient = dependencies?.apiClient ?? createLiferayApiClient();
-  const accessToken = await fetchAccessToken(config, dependencies);
+  const gateway = createLiferayGateway(config, dependencies?.apiClient, dependencies?.tokenClient);
   let site = await resolveResourceSite(config, options.site ?? '/global', dependencies);
   const identifier = String(options.key ?? options.id ?? '').trim();
   if (identifier === '') {
@@ -39,10 +38,7 @@ export async function runLiferayResourceGetStructure(
   let lastKeyLookupStatus: number | null = null;
 
   if (options.id || /^\d+$/.test(identifier)) {
-    const byIdResponse = await authedGet<DataDefinitionPayload>(
-      config,
-      apiClient,
-      accessToken,
+    const byIdResponse = await gateway.getRaw<DataDefinitionPayload>(
       `/o/data-engine/v2.0/data-definitions/${encodeURIComponent(String(options.id ?? identifier))}`,
     );
 
@@ -56,10 +52,7 @@ export async function runLiferayResourceGetStructure(
     const siteChain = await buildResourceSiteChain(config, options.site ?? '/global', dependencies);
 
     for (const candidate of siteChain) {
-      const response = await authedGet<DataDefinitionPayload>(
-        config,
-        apiClient,
-        accessToken,
+      const response = await gateway.getRaw<DataDefinitionPayload>(
         `/o/data-engine/v2.0/sites/${candidate.siteId}/data-definitions/by-content-type/journal/by-data-definition-key/${encodedKey}`,
       );
       if (!response.ok) {


### PR DESCRIPTION
## Summary

Migrates `liferay-resource-get-structure.ts` from `fetchAccessToken` + `authedGet` to `LiferayGateway.getRaw`, removing the cross-module dependency on `liferay-inventory-shared` transport helpers.

The lookup logic  by id, by key traversing `buildResourceSiteChain`, `lastKeyLookupStatus` tracking, and error messages  is unchanged. Only the transport layer changed.

## What Changed

**`src/features/liferay/resource/liferay-resource-get-structure.ts`** (only file touched)
- Removed imports: `createLiferayApiClient`, `authedGet`, `fetchAccessToken` from `liferay-inventory-shared`.
- Added import: `createLiferayGateway` from `liferay-gateway`.
- Removed local `apiClient` and `accessToken` variables.
- Added `const gateway = createLiferayGateway(config, dependencies?.apiClient, dependencies?.tokenClient)`.
- Replaced each `authedGet(config, apiClient, accessToken, path)` call with `gateway.getRaw<DataDefinitionPayload>(path)`  same raw-response semantics needed for inspecting `response.ok` and `response.status`.

## Lookup semantics preserved

- **By id**: `gateway.getRaw` on `/o/data-engine/v2.0/data-definitions/{id}`  uses `response.ok` to set `payload`, identical to before.
- **By key**: iterates `buildResourceSiteChain` candidates; `gateway.getRaw` on the by-key endpoint; on non-ok, records `lastKeyLookupStatus = response.status` and continues  identical to before.
- **Error paths**: `lastKeyLookupStatus` and the fallback `resourceError` messages are untouched.
- **`resolveResourceSite` / `buildResourceSiteChain`**: still called with `dependencies` unchanged.

## Explicitly Left Out

- No changes to `liferay-resource-shared.ts`, `liferay-gateway.ts`, or any other file.
- No changes to structure migration, fragments, or any other resource sub-module.
- No changes to CLI public API, output contracts, or error messages.

## Validation

- `npm run typecheck`  pass (clean)
- `npm run test:unit -- tests/unit/liferay-resource-export.test.ts`  809 tests, 78 files, all passing
- `rg -n "fetchAccessToken\(|authedGet\(" liferay-resource-get-structure.ts`  no output (empty)
