### PR TITLE
refactor(resource): migrate read helpers in resource-shared to LiferayGateway

### DIFF
--- a/src/features/liferay/liferay-gateway.ts
+++ b/src/features/liferay/liferay-gateway.ts
@@ -33,17 +33,19 @@ export class LiferayGateway {
     private tokenClient: OAuthTokenClient,
   ) {}
 
+  private getCacheKey(): string {
+    return [this.config.liferay.url, this.config.liferay.oauth2ClientId, this.config.liferay.oauth2ClientSecret].join(
+      '|',
+    );
+  }
+
   /**
    * Fetch or return cached access token.
    * Cache key includes url + clientId + clientSecret to support multi-instance scenarios.
    * TTL: 1 hour (refreshed when expired).
    */
   private async getAccessToken(): Promise<string> {
-    const cacheKey = [
-      this.config.liferay.url,
-      this.config.liferay.oauth2ClientId,
-      this.config.liferay.oauth2ClientSecret,
-    ].join('|');
+    const cacheKey = this.getCacheKey();
 
     const now = Date.now();
     const cached = this.accessTokenCache.get(cacheKey);
@@ -56,6 +58,14 @@ export class LiferayGateway {
     this.accessTokenCache.set(cacheKey, {token: accessToken, cachedAt: now});
 
     return accessToken;
+  }
+
+  /**
+   * Seed the gateway token cache with a caller-provided access token.
+   * Useful during incremental migration from helpers that already receive a token.
+   */
+  seedAccessToken(accessToken: string): void {
+    this.accessTokenCache.set(this.getCacheKey(), {token: accessToken, cachedAt: Date.now()});
   }
 
   /**

--- a/src/features/liferay/resource/liferay-resource-shared.ts
+++ b/src/features/liferay/resource/liferay-resource-shared.ts
@@ -3,8 +3,8 @@ import type {OAuthTokenClient} from '../../../core/http/auth.js';
 import type {LiferayApiClient} from '../../../core/http/client.js';
 import {createLiferayApiClient} from '../../../core/http/client.js';
 import {LiferayErrors} from '../errors/index.js';
+import {createLiferayGateway} from '../liferay-gateway.js';
 import {
-  authedGet,
   expectJsonSuccess,
   fetchAccessToken,
   resolveSite,
@@ -42,6 +42,16 @@ type ClassNamePayload = {
 type GroupPayload = {
   companyId?: number;
 };
+
+function createResourceReadGateway(config: AppConfig, apiClient: LiferayApiClient, accessToken?: string) {
+  const gateway = createLiferayGateway(config, apiClient);
+
+  if (accessToken) {
+    gateway.seedAccessToken(accessToken);
+  }
+
+  return gateway;
+}
 
 export async function resolveResourceSite(
   config: AppConfig,
@@ -152,10 +162,8 @@ export async function listFragmentCollections(
 ): Promise<FragmentCollectionPayload[]> {
   const apiClient = dependencies?.apiClient ?? createLiferayApiClient();
   const accessToken = await fetchAccessToken(config, dependencies);
-  const response = await authedGet<unknown[]>(
-    config,
-    apiClient,
-    accessToken,
+  const gateway = createResourceReadGateway(config, apiClient, accessToken);
+  const response = await gateway.getRaw<unknown[]>(
     `/api/jsonws/fragment.fragmentcollection/get-fragment-collections?groupId=${siteId}`,
   );
   const success = await expectJsonSuccess(response, 'fragment collections');
@@ -169,10 +177,8 @@ export async function listFragments(
 ): Promise<FragmentEntryPayload[]> {
   const apiClient = dependencies?.apiClient ?? createLiferayApiClient();
   const accessToken = await fetchAccessToken(config, dependencies);
-  const response = await authedGet<unknown[]>(
-    config,
-    apiClient,
-    accessToken,
+  const gateway = createResourceReadGateway(config, apiClient, accessToken);
+  const response = await gateway.getRaw<unknown[]>(
     `/api/jsonws/fragment.fragmententry/get-fragment-entries?fragmentCollectionId=${collectionId}`,
   );
   const success = await expectJsonSuccess(response, 'fragments');
@@ -190,10 +196,8 @@ async function fetchClassNameId(
   const cached = classNameIdLookupCache.get(cacheKey, forceRefresh);
   if (cached) return cached;
 
-  const response = await authedGet<ClassNamePayload>(
-    config,
-    apiClient,
-    accessToken,
+  const gateway = createResourceReadGateway(config, apiClient, accessToken);
+  const response = await gateway.getRaw<ClassNamePayload>(
     `/api/jsonws/classname/fetch-class-name?value=${encodeURIComponent(className)}`,
   );
   const success = await expectJsonSuccess(response, `classname ${className}`);
@@ -266,13 +270,14 @@ export async function fetchGroupInfo(
 ): Promise<GroupInfo | null> {
   const apiClient = dependencies?.apiClient ?? createLiferayApiClient();
   const accessToken = await fetchAccessToken(config, dependencies);
-  const response = await authedGet<{
+  const gateway = createResourceReadGateway(config, apiClient, accessToken);
+  const response = await gateway.getRaw<{
     friendlyURL?: string;
     friendlyUrl?: string;
     nameCurrentValue?: string;
     name?: string;
     parentGroupId?: number;
-  }>(config, apiClient, accessToken, `/api/jsonws/group/get-group?groupId=${groupId}`);
+  }>(`/api/jsonws/group/get-group?groupId=${groupId}`);
 
   if (!response.ok || !response.data) {
     return null;
@@ -297,12 +302,8 @@ async function resolveCompanyId(
   accessToken: string,
   siteId: number,
 ): Promise<number> {
-  const groupResponse = await authedGet<GroupPayload>(
-    config,
-    apiClient,
-    accessToken,
-    `/api/jsonws/group/get-group?groupId=${siteId}`,
-  );
+  const gateway = createResourceReadGateway(config, apiClient, accessToken);
+  const groupResponse = await gateway.getRaw<GroupPayload>(`/api/jsonws/group/get-group?groupId=${siteId}`);
 
   if (groupResponse.ok) {
     const companyId = groupResponse.data?.companyId ?? -1;
@@ -311,12 +312,7 @@ async function resolveCompanyId(
     }
   }
 
-  const companiesResponse = await authedGet<Array<{companyId?: number}>>(
-    config,
-    apiClient,
-    accessToken,
-    '/api/jsonws/company/get-companies',
-  );
+  const companiesResponse = await gateway.getRaw<Array<{companyId?: number}>>('/api/jsonws/company/get-companies');
 
   if (!companiesResponse.ok || !Array.isArray(companiesResponse.data) || companiesResponse.data.length === 0) {
     return -1;
@@ -335,10 +331,8 @@ async function fetchDdmTemplates(
   resourceClassNameId: number,
 ): Promise<DdmTemplatePayload[]> {
   const groupQuery = groupId === null ? '0' : String(groupId);
-  const response = await authedGet<unknown[]>(
-    config,
-    apiClient,
-    accessToken,
+  const gateway = createResourceReadGateway(config, apiClient, accessToken);
+  const response = await gateway.getRaw<unknown[]>(
     `/api/jsonws/ddm.ddmtemplate/get-templates?companyId=${companyId}&groupId=${groupQuery}&classNameId=${classNameId}&resourceClassNameId=${resourceClassNameId}&status=0`,
   );
 


### PR DESCRIPTION
## Summary

Phase 1 migration of a safe read-only subset in `liferay-resource-shared.ts` from manual `fetchAccessToken` + `authedGet` transport to `LiferayGateway`.

This PR is intentionally narrow: it only moves the selected read helpers and preserves the current contracts, fallbacks, cache behavior, and visible error semantics. It does **not** attempt a full resource-shared cleanup.

## Migrated subset

Moved to `LiferayGateway.getRaw(...)`:
- `fetchClassNameId`
- `fetchGroupInfo`
- `resolveCompanyId`
- `fetchDdmTemplates`
- `listFragmentCollections`
- `listFragments`

## What changed

**`src/features/liferay/resource/liferay-resource-shared.ts`**
- Added a tiny local helper `createResourceReadGateway(config, apiClient, accessToken?)`.
- That helper creates a `LiferayGateway` and seeds it with the already-available token when one was passed in via existing flows.
- Replaced manual `authedGet(...)` calls in the six helpers above with `gateway.getRaw(...)`.
- Kept `expectJsonSuccess(...)` in place where the current behavior already throws, so the visible error semantics stay aligned with the existing resource/inventory behavior.
- Kept tolerant branches unchanged:
  - `fetchGroupInfo(...)` still returns `null` on non-ok / missing payload.
  - `resolveCompanyId(...)` still falls back to `company/get-companies` and still returns `-1` when both lookups fail.
  - `fetchDdmTemplates(...)` still returns `[]` on non-ok.
- Kept the `classNameIdLookupCache` path exactly intact.

**`src/features/liferay/liferay-gateway.ts`**
- Added a small `seedAccessToken(accessToken)` method so incremental migrations can preserve callers that already hold a token and avoid forcing a second token fetch.
- Refactored the internal cache-key construction into a private helper used by both `getAccessToken()` and `seedAccessToken()`.

## Deliberately left out

Not moved in this phase:
- `resolveResourceSite`
- `fetchStructureTemplateClassIds`
- `fetchClassNameIdForValue`
- `fetchAdtResourceClassNameId`
- `listDdmTemplates`
- `listDdmTemplatesByClassName`

Reason: those are public wrappers and orchestration entry points that still depend on the old `fetchAccessToken(...)` path or would pull more of resource-shared into the migration at once. This PR keeps phase 1 small and reversible.

## Validation

- `npm run typecheck`  pass
- `npm run test:unit -- tests/unit/liferay-resource-export.test.ts tests/unit/liferay-resource-shared-cache.test.ts`  pass (78 files / 809 tests green in the run)
- `rg -n "fetchAccessToken\(" src/features/liferay/resource/liferay-resource-shared.ts`
  - still returns matches, expected for this phase because non-migrated wrappers remain on the old flow

## Natural phase 2

Migrate the remaining public wrappers that still orchestrate read paths through manual token fetch:
- `fetchStructureTemplateClassIds`
- `fetchClassNameIdForValue`
- `fetchAdtResourceClassNameId`
- `listDdmTemplates`
- `listDdmTemplatesByClassName`

That would complete the read-side gateway adoption in `resource-shared` before tackling write paths or larger resource refactors.
