### PR TITLE
refactor(inventory): remove residual access token from page flow

### DIFF
--- a/src/features/liferay/inventory/liferay-inventory-page-fetch.ts
+++ b/src/features/liferay/inventory/liferay-inventory-page-fetch.ts
@@ -159,7 +159,6 @@ export async function fetchDisplayPageInventory(
   config: AppConfig,
   gateway: LiferayGateway,
   apiClient: LiferayApiClient,
-  accessToken: string,
   site: ResolvedSite,
   urlTitle: string,
 ): Promise<LiferayInventoryPageResult> {
@@ -172,7 +171,7 @@ export async function fetchDisplayPageInventory(
     article.contentStructureId = structuredContent.contentStructureId;
   }
 
-  const journalArticle = await buildJournalArticleSummary(gateway, config, apiClient, accessToken, articleRef, {
+  const journalArticle = await buildJournalArticleSummary(gateway, config, apiClient, articleRef, {
     article: jsonwsArticle,
     structuredContent,
     fallbackSite: site,
@@ -180,9 +179,7 @@ export async function fetchDisplayPageInventory(
     fallbackContentStructureId: article.contentStructureId,
     includeHeadlessInventoryFields: true,
   });
-  const contentStructures = await collectLayoutContentStructures(gateway, config, apiClient, accessToken, [
-    journalArticle,
-  ]);
+  const contentStructures = await collectLayoutContentStructures(gateway, config, apiClient, [journalArticle]);
   const articleClassPK = Number(article.id ?? jsonwsArticle?.resourcePrimKey ?? jsonwsArticle?.id ?? -1);
   const articleClassNameId = await resolveClassNameId(config, gateway, CLASS_NAME_JOURNAL_ARTICLE);
   const articleAdminUrls =
@@ -224,7 +221,6 @@ export async function fetchRegularPageInventory(
   config: AppConfig,
   gateway: LiferayGateway,
   apiClient: LiferayApiClient,
-  accessToken: string,
   site: ResolvedSite,
   friendlyUrl: string,
   privateLayout: boolean,
@@ -261,7 +257,7 @@ export async function fetchRegularPageInventory(
     configurationTabs = buildRegularPageConfigurationTabs(layout, layoutDetails, privateLayout, pageMetadata);
     fragmentEntryLinks = collectPageElements(pageElement, rawFragmentLinks, matchedLocale);
     enrichRegularPageFragmentSummaries(fragmentEntryLinks);
-    await enrichFragmentEntryExportPaths(config, accessToken, site.friendlyUrlPath, fragmentEntryLinks, apiClient);
+    await enrichFragmentEntryExportPaths(config, gateway, site.friendlyUrlPath, fragmentEntryLinks, apiClient);
     widgets = fragmentEntryLinks
       .filter((entry) => entry.type === 'widget' && entry.widgetName)
       .map((entry) => ({
@@ -269,15 +265,8 @@ export async function fetchRegularPageInventory(
         ...(entry.portletId ? {portletId: entry.portletId} : {}),
         ...(entry.configuration ? {configuration: entry.configuration} : {}),
       }));
-    journalArticles = await collectLayoutJournalArticles(
-      gateway,
-      config,
-      apiClient,
-      accessToken,
-      site.id,
-      rawFragmentLinks,
-    );
-    contentStructures = await collectLayoutContentStructures(gateway, config, apiClient, accessToken, journalArticles);
+    journalArticles = await collectLayoutJournalArticles(gateway, config, apiClient, site.id, rawFragmentLinks);
+    contentStructures = await collectLayoutContentStructures(gateway, config, apiClient, journalArticles);
   }
 
   function buildRegularPageSummary(
@@ -692,7 +681,6 @@ export async function resolveRegularLayoutPageData(
   config: AppConfig,
   gateway: LiferayGateway,
   apiClient: LiferayApiClient,
-  accessToken: string,
   site: ResolvedSite,
   friendlyUrl: string,
   privateLayout: boolean,
@@ -965,7 +953,6 @@ async function collectLayoutJournalArticles(
   gateway: LiferayGateway,
   config: AppConfig,
   apiClient: LiferayApiClient,
-  accessToken: string,
   defaultGroupId: number,
   fragmentEntryLinks: Array<Record<string, unknown>>,
 ): Promise<JournalArticleSummary[]> {
@@ -973,7 +960,7 @@ async function collectLayoutJournalArticles(
   const result: JournalArticleSummary[] = [];
 
   for (const ref of refs.values()) {
-    result.push(await buildJournalArticleSummary(gateway, config, apiClient, accessToken, ref));
+    result.push(await buildJournalArticleSummary(gateway, config, apiClient, ref));
   }
 
   return result;
@@ -983,7 +970,6 @@ async function buildJournalArticleSummary(
   gateway: LiferayGateway,
   config: AppConfig,
   apiClient: LiferayApiClient,
-  accessToken: string,
   ref: ArticleRef,
   options?: {
     article?: Record<string, unknown> | null;
@@ -996,7 +982,7 @@ async function buildJournalArticleSummary(
 ): Promise<JournalArticleSummary> {
   const article = options?.article ?? (await fetchLatestJournalArticle(gateway, ref.groupId, ref.articleId));
   const articleSite =
-    (await safeFetchGroupInfo(config, ref.groupId, {apiClient, accessToken})) ??
+    (await safeFetchGroupInfo(config, ref.groupId, {apiClient, gateway})) ??
     (options?.fallbackSite
       ? {
           friendlyUrl: options.fallbackSite.friendlyUrlPath,
@@ -1067,7 +1053,6 @@ async function buildJournalArticleSummary(
       gateway,
       config,
       apiClient,
-      accessToken,
       articleSite.friendlyUrl,
       summary.ddmStructureKey,
     );
@@ -1085,7 +1070,7 @@ async function buildJournalArticleSummary(
   if (articleSite?.friendlyUrl && ddmTemplateKey) {
     const templateSite = await resolveTemplateSiteByKey(config, articleSite.friendlyUrl, ddmTemplateKey, {
       apiClient,
-      accessToken,
+      gateway,
     });
     if (templateSite) {
       summary.ddmTemplateSiteFriendlyUrl = templateSite;
@@ -1100,7 +1085,6 @@ async function collectLayoutContentStructures(
   gateway: LiferayGateway,
   config: AppConfig,
   apiClient: LiferayApiClient,
-  accessToken: string,
   journalArticles: JournalArticleSummary[],
 ): Promise<ContentStructureSummary[]> {
   const seen = new Set<number>();
@@ -1295,11 +1279,10 @@ async function resolveStructureSiteByKey(
   gateway: LiferayGateway,
   config: AppConfig,
   apiClient: LiferayApiClient,
-  accessToken: string,
   startSite: string,
   structureKey: string,
 ): Promise<{siteFriendlyUrl: string} | null> {
-  const siteChain = await buildResourceSiteChain(config, startSite, {apiClient, accessToken});
+  const siteChain = await buildResourceSiteChain(config, startSite, {apiClient, gateway});
   for (const site of siteChain) {
     const response = await safeGatewayGet<Record<string, unknown>>(
       gateway,
@@ -1316,7 +1299,7 @@ async function resolveStructureSiteByKey(
 async function safeFetchGroupInfo(
   config: AppConfig,
   groupId: number,
-  dependencies: {apiClient: LiferayApiClient; accessToken: string},
+  dependencies: {apiClient: LiferayApiClient; gateway: LiferayGateway},
 ) {
   try {
     return await fetchGroupInfo(config, groupId, dependencies);
@@ -1329,7 +1312,7 @@ async function resolveTemplateSiteByKey(
   config: AppConfig,
   startSite: string,
   templateKey: string,
-  dependencies: {apiClient: LiferayApiClient; accessToken: string},
+  dependencies: {apiClient: LiferayApiClient; gateway: LiferayGateway},
 ): Promise<string | null> {
   const siteChain = await buildResourceSiteChain(config, startSite, dependencies);
   for (const candidate of siteChain) {
@@ -1362,7 +1345,7 @@ function buildTemplateExportPath(config: AppConfig, siteFriendlyUrl: string, key
 
 async function enrichFragmentEntryExportPaths(
   config: AppConfig,
-  accessToken: string,
+  gateway: LiferayGateway,
   startSite: string,
   entries: PageFragmentEntry[],
   apiClient: LiferayApiClient,
@@ -1380,7 +1363,7 @@ async function enrichFragmentEntryExportPaths(
         fragmentKey,
         await findFragmentExportPath(config, startSite, fragmentKey, {
           apiClient,
-          accessToken,
+          gateway,
         }),
       );
     }
@@ -1396,7 +1379,7 @@ async function findFragmentExportPath(
   config: AppConfig,
   startSite: string,
   fragmentKey: string,
-  dependencies: {apiClient: LiferayApiClient; accessToken: string},
+  dependencies: {apiClient: LiferayApiClient; gateway: LiferayGateway},
 ): Promise<{siteFriendlyUrl: string; exportPath: string} | null> {
   const baseDirs = await resolveFragmentSearchBaseDirs(config);
   const siteChain = await safeBuildFragmentSiteChain(config, startSite, dependencies);
@@ -1429,7 +1412,7 @@ async function resolveFragmentSearchBaseDirs(config: AppConfig): Promise<string[
 async function safeBuildFragmentSiteChain(
   config: AppConfig,
   startSite: string,
-  dependencies: {apiClient: LiferayApiClient; accessToken: string},
+  dependencies: {apiClient: LiferayApiClient; gateway: LiferayGateway},
 ): Promise<Array<{siteFriendlyUrl: string}>> {
   try {
     return await buildResourceSiteChain(config, startSite, dependencies);

--- a/src/features/liferay/inventory/liferay-inventory-page.ts
+++ b/src/features/liferay/inventory/liferay-inventory-page.ts
@@ -4,7 +4,7 @@ import type {OAuthTokenClient} from '../../../core/http/auth.js';
 import type {LiferayApiClient} from '../../../core/http/client.js';
 import {createLiferayApiClient} from '../../../core/http/client.js';
 import {LiferayErrors} from '../errors/index.js';
-import {createInventoryGateway, fetchAccessToken, resolveSite} from './liferay-inventory-shared.js';
+import {createInventoryGateway, resolveSite} from './liferay-inventory-shared.js';
 import {resolveInventoryPageRequest} from './liferay-inventory-page-url.js';
 import {buildPageUrl} from '../page-layout/liferay-layout-shared.js';
 import {
@@ -170,9 +170,8 @@ export async function runLiferayInventoryPage(
   const request = resolveInventoryPageRequest(options);
   const effectiveConfig = config;
   const apiClient = dependencies?.apiClient ?? createLiferayApiClient();
-  const accessToken = await fetchAccessToken(effectiveConfig, dependencies);
-  const gateway = createInventoryGateway(effectiveConfig, apiClient, {...dependencies, accessToken});
-  const siteDependencies = {...dependencies, accessToken, gateway};
+  const gateway = createInventoryGateway(effectiveConfig, apiClient, dependencies);
+  const siteDependencies = {...dependencies, gateway};
 
   if (request.route === 'portalHome') {
     const homeRequest = await resolvePortalHomeRequest(effectiveConfig);
@@ -182,7 +181,6 @@ export async function runLiferayInventoryPage(
         effectiveConfig,
         gateway,
         apiClient,
-        accessToken,
         site,
         homeRequest.friendlyUrl,
         homeRequest.privateLayout,
@@ -202,7 +200,6 @@ export async function runLiferayInventoryPage(
           effectiveConfig,
           gateway,
           apiClient,
-          accessToken,
           site,
           redirectedRequest.friendlyUrl,
           redirectedRequest.privateLayout,
@@ -215,14 +212,7 @@ export async function runLiferayInventoryPage(
 
   if (request.route === 'displayPage') {
     return finalizeResult(
-      await fetchDisplayPageInventory(
-        effectiveConfig,
-        gateway,
-        apiClient,
-        accessToken,
-        site,
-        request.displayPageUrlTitle ?? '',
-      ),
+      await fetchDisplayPageInventory(effectiveConfig, gateway, apiClient, site, request.displayPageUrlTitle ?? ''),
     );
   }
 
@@ -231,7 +221,6 @@ export async function runLiferayInventoryPage(
       effectiveConfig,
       gateway,
       apiClient,
-      accessToken,
       site,
       request.friendlyUrl,
       request.privateLayout,
@@ -334,19 +323,10 @@ export async function resolveRegularLayoutPage(
   }
 
   const apiClient = dependencies?.apiClient ?? createLiferayApiClient();
-  const accessToken = await fetchAccessToken(config, dependencies);
-  const gateway = createInventoryGateway(config, apiClient, {...dependencies, accessToken});
-  const site = await resolveSite(config, request.siteSlug, {...dependencies, accessToken, gateway});
+  const gateway = createInventoryGateway(config, apiClient, dependencies);
+  const site = await resolveSite(config, request.siteSlug, {...dependencies, gateway});
 
-  return resolveRegularLayoutPageData(
-    config,
-    gateway,
-    apiClient,
-    accessToken,
-    site,
-    request.friendlyUrl,
-    request.privateLayout,
-  );
+  return resolveRegularLayoutPageData(config, gateway, apiClient, site, request.friendlyUrl, request.privateLayout);
 }
 
 export function formatLiferayInventoryPage(result: LiferayInventoryPageResult, verbose = false): string {

--- a/src/features/liferay/resource/liferay-resource-shared.ts
+++ b/src/features/liferay/resource/liferay-resource-shared.ts
@@ -3,7 +3,7 @@ import type {OAuthTokenClient} from '../../../core/http/auth.js';
 import type {LiferayApiClient} from '../../../core/http/client.js';
 import {createLiferayApiClient} from '../../../core/http/client.js';
 import {LiferayErrors} from '../errors/index.js';
-import {createLiferayGateway} from '../liferay-gateway.js';
+import {createLiferayGateway, type LiferayGateway} from '../liferay-gateway.js';
 import {
   expectJsonSuccess,
   fetchAccessToken,
@@ -27,6 +27,7 @@ const ADT_RESOURCE_CLASS_NAME = 'com.liferay.portlet.display.template.PortletDis
 type ResourceDependencies = {
   apiClient?: LiferayApiClient;
   tokenClient?: OAuthTokenClient;
+  gateway?: LiferayGateway;
   accessToken?: string;
   forceRefresh?: boolean;
 };
@@ -43,11 +44,19 @@ type GroupPayload = {
   companyId?: number;
 };
 
-function createResourceReadGateway(config: AppConfig, apiClient: LiferayApiClient, accessToken?: string) {
-  const gateway = createLiferayGateway(config, apiClient);
+function createResourceReadGateway(
+  config: AppConfig,
+  apiClient: LiferayApiClient,
+  dependencies?: Pick<ResourceDependencies, 'gateway' | 'tokenClient' | 'accessToken'>,
+) {
+  if (dependencies?.gateway) {
+    return dependencies.gateway;
+  }
 
-  if (accessToken) {
-    gateway.seedAccessToken(accessToken);
+  const gateway = createLiferayGateway(config, apiClient, dependencies?.tokenClient);
+
+  if (dependencies?.accessToken) {
+    gateway.seedAccessToken(dependencies.accessToken);
   }
 
   return gateway;
@@ -59,9 +68,9 @@ export async function resolveResourceSite(
   dependencies?: ResourceDependencies,
 ): Promise<ResolvedResourceSite> {
   const apiClient = dependencies?.apiClient ?? createLiferayApiClient();
-  const accessToken = await fetchAccessToken(config, dependencies);
-  const resolvedSite = await resolveSite(config, site, dependencies);
-  const companyId = await resolveCompanyId(config, apiClient, accessToken, resolvedSite.id);
+  const gateway = createResourceReadGateway(config, apiClient, dependencies);
+  const resolvedSite = await resolveSite(config, site, {...dependencies, gateway});
+  const companyId = await resolveCompanyId(gateway, resolvedSite.id);
 
   if (companyId <= 0) {
     throw LiferayErrors.resourceError(`site sin companyId valido: ${site}`);
@@ -78,8 +87,26 @@ export async function fetchStructureTemplateClassIds(
   dependencies?: ResourceDependencies,
 ): Promise<{classNameId: number; resourceClassNameId: number}> {
   const apiClient = dependencies?.apiClient ?? createLiferayApiClient();
-  const accessToken = await fetchAccessToken(config, dependencies);
   const forceRefresh = dependencies?.forceRefresh;
+
+  if (dependencies?.gateway) {
+    const classNameId = await fetchClassNameIdWithGateway(
+      config,
+      dependencies.gateway,
+      DDM_STRUCTURE_CLASS_NAME,
+      forceRefresh,
+    );
+    const resourceClassNameId = await fetchClassNameIdWithGateway(
+      config,
+      dependencies.gateway,
+      JOURNAL_ARTICLE_CLASS_NAME,
+      forceRefresh,
+    );
+
+    return {classNameId, resourceClassNameId};
+  }
+
+  const accessToken = await fetchAccessToken(config, dependencies);
 
   const classNameId = await fetchClassNameId(config, apiClient, accessToken, DDM_STRUCTURE_CLASS_NAME, forceRefresh);
   const resourceClassNameId = await fetchClassNameId(
@@ -99,6 +126,11 @@ export async function fetchClassNameIdForValue(
   dependencies?: ResourceDependencies,
 ): Promise<number> {
   const apiClient = dependencies?.apiClient ?? createLiferayApiClient();
+
+  if (dependencies?.gateway) {
+    return fetchClassNameIdWithGateway(config, dependencies.gateway, className, dependencies?.forceRefresh);
+  }
+
   const accessToken = await fetchAccessToken(config, dependencies);
   return fetchClassNameId(config, apiClient, accessToken, className, dependencies?.forceRefresh);
 }
@@ -117,18 +149,10 @@ export async function listDdmTemplates(
   options?: {includeCompanyFallback?: boolean},
 ): Promise<DdmTemplatePayload[]> {
   const apiClient = dependencies?.apiClient ?? createLiferayApiClient();
-  const accessToken = await fetchAccessToken(config, dependencies);
+  const gateway = createResourceReadGateway(config, apiClient, dependencies);
   const {classNameId, resourceClassNameId} = await fetchStructureTemplateClassIds(config, dependencies);
 
-  const siteTemplates = await fetchDdmTemplates(
-    config,
-    apiClient,
-    accessToken,
-    site.companyId,
-    site.id,
-    classNameId,
-    resourceClassNameId,
-  );
+  const siteTemplates = await fetchDdmTemplates(gateway, site.companyId, site.id, classNameId, resourceClassNameId);
 
   if (siteTemplates.length > 0) {
     return siteTemplates;
@@ -138,7 +162,7 @@ export async function listDdmTemplates(
     return [];
   }
 
-  return fetchDdmTemplates(config, apiClient, accessToken, site.companyId, null, classNameId, resourceClassNameId);
+  return fetchDdmTemplates(gateway, site.companyId, null, classNameId, resourceClassNameId);
 }
 
 export async function listDdmTemplatesByClassName(
@@ -149,10 +173,22 @@ export async function listDdmTemplatesByClassName(
   dependencies?: ResourceDependencies,
 ): Promise<DdmTemplatePayload[]> {
   const apiClient = dependencies?.apiClient ?? createLiferayApiClient();
+
+  if (dependencies?.gateway) {
+    const classNameId = await fetchClassNameIdWithGateway(
+      config,
+      dependencies.gateway,
+      className,
+      dependencies?.forceRefresh,
+    );
+    return fetchDdmTemplates(dependencies.gateway, site.companyId, site.id, classNameId, resourceClassNameId);
+  }
+
   const accessToken = await fetchAccessToken(config, dependencies);
+  const gateway = createResourceReadGateway(config, apiClient, {...dependencies, accessToken});
   const classNameId = await fetchClassNameId(config, apiClient, accessToken, className, dependencies?.forceRefresh);
 
-  return fetchDdmTemplates(config, apiClient, accessToken, site.companyId, site.id, classNameId, resourceClassNameId);
+  return fetchDdmTemplates(gateway, site.companyId, site.id, classNameId, resourceClassNameId);
 }
 
 export async function listFragmentCollections(
@@ -162,7 +198,7 @@ export async function listFragmentCollections(
 ): Promise<FragmentCollectionPayload[]> {
   const apiClient = dependencies?.apiClient ?? createLiferayApiClient();
   const accessToken = await fetchAccessToken(config, dependencies);
-  const gateway = createResourceReadGateway(config, apiClient, accessToken);
+  const gateway = createResourceReadGateway(config, apiClient, {...dependencies, accessToken});
   const response = await gateway.getRaw<unknown[]>(
     `/api/jsonws/fragment.fragmentcollection/get-fragment-collections?groupId=${siteId}`,
   );
@@ -177,7 +213,7 @@ export async function listFragments(
 ): Promise<FragmentEntryPayload[]> {
   const apiClient = dependencies?.apiClient ?? createLiferayApiClient();
   const accessToken = await fetchAccessToken(config, dependencies);
-  const gateway = createResourceReadGateway(config, apiClient, accessToken);
+  const gateway = createResourceReadGateway(config, apiClient, {...dependencies, accessToken});
   const response = await gateway.getRaw<unknown[]>(
     `/api/jsonws/fragment.fragmententry/get-fragment-entries?fragmentCollectionId=${collectionId}`,
   );
@@ -196,7 +232,29 @@ async function fetchClassNameId(
   const cached = classNameIdLookupCache.get(cacheKey, forceRefresh);
   if (cached) return cached;
 
-  const gateway = createResourceReadGateway(config, apiClient, accessToken);
+  const gateway = createResourceReadGateway(config, apiClient, {accessToken});
+  const response = await gateway.getRaw<ClassNamePayload>(
+    `/api/jsonws/classname/fetch-class-name?value=${encodeURIComponent(className)}`,
+  );
+  const success = await expectJsonSuccess(response, `classname ${className}`);
+  const classNameId = success.data?.classNameId ?? -1;
+  if (classNameId <= 0) {
+    throw LiferayErrors.resourceError(`classNameId no resuelto para ${className}`);
+  }
+  classNameIdLookupCache.set(cacheKey, classNameId);
+  return classNameId;
+}
+
+async function fetchClassNameIdWithGateway(
+  config: AppConfig,
+  gateway: LiferayGateway,
+  className: string,
+  forceRefresh?: boolean,
+): Promise<number> {
+  const cacheKey = `${config.liferay.url}|${className}`;
+  const cached = classNameIdLookupCache.get(cacheKey, forceRefresh);
+  if (cached) return cached;
+
   const response = await gateway.getRaw<ClassNamePayload>(
     `/api/jsonws/classname/fetch-class-name?value=${encodeURIComponent(className)}`,
   );
@@ -269,8 +327,7 @@ export async function fetchGroupInfo(
   dependencies?: ResourceDependencies,
 ): Promise<GroupInfo | null> {
   const apiClient = dependencies?.apiClient ?? createLiferayApiClient();
-  const accessToken = await fetchAccessToken(config, dependencies);
-  const gateway = createResourceReadGateway(config, apiClient, accessToken);
+  const gateway = createResourceReadGateway(config, apiClient, dependencies);
   const response = await gateway.getRaw<{
     friendlyURL?: string;
     friendlyUrl?: string;
@@ -296,13 +353,7 @@ export async function fetchGroupInfo(
   };
 }
 
-async function resolveCompanyId(
-  config: AppConfig,
-  apiClient: LiferayApiClient,
-  accessToken: string,
-  siteId: number,
-): Promise<number> {
-  const gateway = createResourceReadGateway(config, apiClient, accessToken);
+async function resolveCompanyId(gateway: LiferayGateway, siteId: number): Promise<number> {
   const groupResponse = await gateway.getRaw<GroupPayload>(`/api/jsonws/group/get-group?groupId=${siteId}`);
 
   if (groupResponse.ok) {
@@ -322,16 +373,13 @@ async function resolveCompanyId(
 }
 
 async function fetchDdmTemplates(
-  config: AppConfig,
-  apiClient: LiferayApiClient,
-  accessToken: string,
+  gateway: LiferayGateway,
   companyId: number,
   groupId: number | null,
   classNameId: number,
   resourceClassNameId: number,
 ): Promise<DdmTemplatePayload[]> {
   const groupQuery = groupId === null ? '0' : String(groupId);
-  const gateway = createResourceReadGateway(config, apiClient, accessToken);
   const response = await gateway.getRaw<unknown[]>(
     `/api/jsonws/ddm.ddmtemplate/get-templates?companyId=${companyId}&groupId=${groupQuery}&classNameId=${classNameId}&resourceClassNameId=${resourceClassNameId}&status=0`,
   );


### PR DESCRIPTION
## Summary
- Removes the residual `fetchAccessToken` usage from `liferay-inventory-page.ts` now that the main inventory page transport already runs on `LiferayGateway`.
- Preserves the single effective token fetch guarantee by reusing the same gateway through downstream enrichment helpers instead of materializing a raw token string in the inventory page entry flow.
- Keeps serialized contracts, unauthenticated redirect detection, visible messages, and enrichment/fallback semantics unchanged.

## What Changed
- `src/features/liferay/inventory/liferay-inventory-page.ts`
  - Removed the residual `fetchAccessToken(...)` calls from both `runLiferayInventoryPage(...)` and `resolveRegularLayoutPage(...)`.
  - Reuses `createInventoryGateway(...)` directly and passes the shared gateway into `resolveSite(...)` and downstream page fetch helpers.
- `src/features/liferay/inventory/liferay-inventory-page-fetch.ts`
  - Removed the `accessToken` parameter from inventory page fetch/enrichment helpers used by `inventory page`.
  - Switched downstream enrichment lookups to pass `{apiClient, gateway}` instead of `{apiClient, accessToken}`.
  - Preserved display-page and regular-page enrichment behavior while delegating auth reuse to the shared gateway.
- `src/features/liferay/resource/liferay-resource-shared.ts`
  - Added optional `gateway` support to the minimal resource helpers used by inventory page enrichments.
  - Reused the provided gateway for group info, site-chain, company-id, template lookup, and classNameId lookup paths when available.
  - Avoided fallback token fetching in those gateway-backed paths so inventory page no longer needs a raw token.

## Explicitly Left Out
- No typing-debt cleanup.
- No general resource cleanup outside the minimum required for inventory page enrichment.
- No changes to content or page-layout modules.
- No changes to serialized output contracts or redirect detection behavior.

## Validation
- `npm run typecheck`
- `npm run test:unit -- liferay-inventory-page.test.ts liferay-inventory-pages.test.ts liferay-inventory.test.ts`
- Push hook passed full verification:
  - `npm run lint`
  - `npm run format:check`
  - `npm run typecheck`
  - `npm run test:unit`
  - `npm run build`
  - `npm run test:smoke`

## Verification
- `rg -n "fetchAccessToken\(" src/features/liferay/inventory/liferay-inventory-page.ts`
- Result: no matches

## Result
The residual raw `accessToken` usage in `liferay-inventory-page.ts` was eliminated completely.
