### PR TITLE
refactor(resource): migrate fragment sync to SyncEngine/SyncStrategy

### DIFF
--- a/src/features/liferay/resource/liferay-resource-sync-fragments-api.ts
+++ b/src/features/liferay/resource/liferay-resource-sync-fragments-api.ts
@@ -11,48 +11,86 @@ import {
   type FragmentEntryPayload,
 } from './liferay-resource-payloads.js';
 
+export type FragmentSyncRuntimeState = {
+  collectionsByKey?: Map<string, FragmentCollectionPayload>;
+  fragmentsByCollectionId: Map<number, Map<string, FragmentEntryPayload>>;
+};
+
+export function createFragmentSyncRuntimeState(): FragmentSyncRuntimeState {
+  return {
+    fragmentsByCollectionId: new Map(),
+  };
+}
+
 export async function listRuntimeCollectionsByKey(
   config: AppConfig,
   groupId: number,
   dependencies?: ResourceSyncDependencies,
+  runtimeState?: FragmentSyncRuntimeState,
 ): Promise<Map<string, FragmentCollectionPayload>> {
+  if (runtimeState?.collectionsByKey) {
+    return runtimeState.collectionsByKey;
+  }
+
   const collections = await listFragmentCollections(config, groupId, dependencies);
   const byKey = new Map<string, FragmentCollectionPayload>();
 
   for (const collection of collections) {
-    const key = String(collection.fragmentCollectionKey ?? '').trim();
-    const name = String(collection.name ?? '').trim();
-    if (key !== '') {
-      byKey.set(key.toLowerCase(), collection);
-    }
-    if (name !== '') {
-      byKey.set(sanitizeFileToken(name).toLowerCase(), collection);
-    }
+    cacheRuntimeCollection(byKey, collection);
+  }
+
+  if (runtimeState) {
+    runtimeState.collectionsByKey = byKey;
   }
 
   return byKey;
+}
+
+export async function findRuntimeCollection(
+  config: AppConfig,
+  groupId: number,
+  collectionSlug: string,
+  dependencies?: ResourceSyncDependencies,
+  runtimeState?: FragmentSyncRuntimeState,
+): Promise<FragmentCollectionPayload | null> {
+  const byKey = await listRuntimeCollectionsByKey(config, groupId, dependencies, runtimeState);
+  return byKey.get(collectionSlug.toLowerCase()) ?? null;
 }
 
 export async function listRuntimeFragmentsByKey(
   config: AppConfig,
   fragmentCollectionId: number,
   dependencies?: ResourceSyncDependencies,
+  runtimeState?: FragmentSyncRuntimeState,
 ): Promise<Map<string, FragmentEntryPayload>> {
+  const cached = runtimeState?.fragmentsByCollectionId.get(fragmentCollectionId);
+  if (cached) {
+    return cached;
+  }
+
   const runtimeFragments = await listFragments(config, fragmentCollectionId, dependencies);
   const byKey = new Map<string, FragmentEntryPayload>();
 
   for (const runtimeFragment of runtimeFragments) {
-    const runtimeKey = String(runtimeFragment.fragmentEntryKey ?? '').trim();
-    const runtimeName = String(runtimeFragment.name ?? '').trim();
-    if (runtimeKey !== '') {
-      byKey.set(runtimeKey.toLowerCase(), runtimeFragment);
-    }
-    if (runtimeName !== '') {
-      byKey.set(sanitizeFileToken(runtimeName).toLowerCase(), runtimeFragment);
-    }
+    cacheRuntimeFragment(byKey, runtimeFragment);
+  }
+
+  if (runtimeState) {
+    runtimeState.fragmentsByCollectionId.set(fragmentCollectionId, byKey);
   }
 
   return byKey;
+}
+
+export async function findRuntimeFragment(
+  config: AppConfig,
+  fragmentCollectionId: number,
+  fragmentSlug: string,
+  dependencies?: ResourceSyncDependencies,
+  runtimeState?: FragmentSyncRuntimeState,
+): Promise<FragmentEntryPayload | null> {
+  const byKey = await listRuntimeFragmentsByKey(config, fragmentCollectionId, dependencies, runtimeState);
+  return byKey.get(fragmentSlug.toLowerCase()) ?? null;
 }
 
 export async function createFragmentCollection(
@@ -60,6 +98,7 @@ export async function createFragmentCollection(
   groupId: number,
   collection: LocalFragmentCollection,
   dependencies?: ResourceSyncDependencies,
+  runtimeState?: FragmentSyncRuntimeState,
 ): Promise<FragmentCollectionPayload> {
   const base = {
     groupId: String(groupId),
@@ -89,7 +128,14 @@ export async function createFragmentCollection(
     dependencies,
   );
 
-  return toFragmentCollectionPayload(response);
+  const payload = toFragmentCollectionPayload({
+    ...response,
+    fragmentCollectionKey: collection.slug,
+    name: collection.name,
+    description: collection.description,
+  });
+  cacheRuntimeCollection(ensureCollectionRuntimeCache(runtimeState), payload);
+  return payload;
 }
 
 export async function updateFragmentCollection(
@@ -97,6 +143,7 @@ export async function updateFragmentCollection(
   fragmentCollectionId: number,
   collection: LocalFragmentCollection,
   dependencies?: ResourceSyncDependencies,
+  runtimeState?: FragmentSyncRuntimeState,
 ): Promise<void> {
   if (fragmentCollectionId <= 0) {
     return;
@@ -122,6 +169,12 @@ export async function updateFragmentCollection(
       'fragment-collection-update',
       dependencies,
     );
+    cacheRuntimeCollection(ensureCollectionRuntimeCache(runtimeState), {
+      fragmentCollectionId,
+      fragmentCollectionKey: collection.slug,
+      name: collection.name,
+      description: collection.description,
+    });
   } catch {
     // Legacy command ignored collection metadata update failures.
   }
@@ -133,6 +186,7 @@ export async function createFragmentEntry(
   fragmentCollectionId: number,
   fragment: LocalFragment,
   dependencies?: ResourceSyncDependencies,
+  runtimeState?: FragmentSyncRuntimeState,
 ): Promise<FragmentEntryPayload> {
   const base = fragmentEntryBaseForm(groupId, fragmentCollectionId, fragment);
 
@@ -153,7 +207,13 @@ export async function createFragmentEntry(
     dependencies,
   );
 
-  return toFragmentEntryPayload(response);
+  const payload = toFragmentEntryPayload({
+    ...response,
+    fragmentEntryKey: fragment.slug,
+    name: fragment.name,
+  });
+  cacheFragmentInRuntimeState(runtimeState, fragmentCollectionId, payload);
+  return payload;
 }
 
 export async function updateFragmentEntry(
@@ -163,6 +223,7 @@ export async function updateFragmentEntry(
   fragmentEntryId: number,
   fragment: LocalFragment,
   dependencies?: ResourceSyncDependencies,
+  runtimeState?: FragmentSyncRuntimeState,
 ): Promise<FragmentEntryPayload> {
   if (fragmentEntryId <= 0) {
     throw LiferayErrors.resourceError(`fragmentEntryId invalido para ${fragment.slug}`);
@@ -198,7 +259,69 @@ export async function updateFragmentEntry(
     dependencies,
   );
 
-  return toFragmentEntryPayload(response);
+  const payload = toFragmentEntryPayload({
+    ...response,
+    fragmentEntryId,
+    fragmentEntryKey: fragment.slug,
+    name: fragment.name,
+  });
+  cacheFragmentInRuntimeState(runtimeState, fragmentCollectionId, payload);
+  return payload;
+}
+
+function cacheRuntimeCollection(
+  byKey: Map<string, FragmentCollectionPayload> | undefined,
+  collection: FragmentCollectionPayload,
+): void {
+  if (!byKey) {
+    return;
+  }
+
+  const key = String(collection.fragmentCollectionKey ?? '').trim();
+  const name = String(collection.name ?? '').trim();
+  if (key !== '') {
+    byKey.set(key.toLowerCase(), collection);
+  }
+  if (name !== '') {
+    byKey.set(sanitizeFileToken(name).toLowerCase(), collection);
+  }
+}
+
+function ensureCollectionRuntimeCache(
+  runtimeState: FragmentSyncRuntimeState | undefined,
+): Map<string, FragmentCollectionPayload> | undefined {
+  if (!runtimeState) {
+    return undefined;
+  }
+
+  runtimeState.collectionsByKey ??= new Map<string, FragmentCollectionPayload>();
+  return runtimeState.collectionsByKey;
+}
+
+function cacheFragmentInRuntimeState(
+  runtimeState: FragmentSyncRuntimeState | undefined,
+  fragmentCollectionId: number,
+  fragment: FragmentEntryPayload,
+): void {
+  if (!runtimeState) {
+    return;
+  }
+
+  const byKey =
+    runtimeState.fragmentsByCollectionId.get(fragmentCollectionId) ?? new Map<string, FragmentEntryPayload>();
+  cacheRuntimeFragment(byKey, fragment);
+  runtimeState.fragmentsByCollectionId.set(fragmentCollectionId, byKey);
+}
+
+function cacheRuntimeFragment(byKey: Map<string, FragmentEntryPayload>, fragment: FragmentEntryPayload): void {
+  const runtimeKey = String(fragment.fragmentEntryKey ?? '').trim();
+  const runtimeName = String(fragment.name ?? '').trim();
+  if (runtimeKey !== '') {
+    byKey.set(runtimeKey.toLowerCase(), fragment);
+  }
+  if (runtimeName !== '') {
+    byKey.set(sanitizeFileToken(runtimeName).toLowerCase(), fragment);
+  }
 }
 
 function fragmentEntryBaseForm(

--- a/src/features/liferay/resource/liferay-resource-sync-fragments-hash.ts
+++ b/src/features/liferay/resource/liferay-resource-sync-fragments-hash.ts
@@ -1,0 +1,51 @@
+import type {FragmentCollectionPayload, FragmentEntryPayload} from './liferay-resource-payloads.js';
+import type {LocalFragment, LocalFragmentCollection} from './liferay-resource-sync-fragments-types.js';
+
+export function normalizeFragmentCollectionForHash(
+  collection: Pick<LocalFragmentCollection, 'slug' | 'name' | 'description'> | FragmentCollectionPayload,
+): string {
+  return JSON.stringify({
+    key: String(('slug' in collection ? collection.slug : collection.fragmentCollectionKey) ?? ''),
+    name: String(collection.name ?? ''),
+    description: String(collection.description ?? ''),
+  });
+}
+
+export function normalizeFragmentEntryForHash(
+  fragment:
+    | Pick<LocalFragment, 'slug' | 'name' | 'html' | 'css' | 'js' | 'configuration' | 'icon' | 'type'>
+    | FragmentEntryPayload,
+): string {
+  return JSON.stringify({
+    key: String(('slug' in fragment ? fragment.slug : fragment.fragmentEntryKey) ?? ''),
+    name: String(fragment.name ?? ''),
+    html: String(fragment.html ?? ''),
+    css: String(fragment.css ?? ''),
+    js: String(fragment.js ?? ''),
+    configuration: normalizeConfigurationForHash(fragment.configuration),
+    icon: String(fragment.icon ?? ''),
+    type: Number(fragment.type ?? 0),
+  });
+}
+
+export function canVerifyFragmentEntryContent(fragment: FragmentEntryPayload): boolean {
+  return (
+    fragment.html !== undefined ||
+    fragment.css !== undefined ||
+    fragment.js !== undefined ||
+    fragment.configuration !== undefined
+  );
+}
+
+function normalizeConfigurationForHash(value: string | undefined): string {
+  const text = String(value ?? '').trim();
+  if (text === '') {
+    return '';
+  }
+
+  try {
+    return JSON.stringify(JSON.parse(text));
+  } catch {
+    return text;
+  }
+}

--- a/src/features/liferay/resource/liferay-resource-sync-fragments-importer.ts
+++ b/src/features/liferay/resource/liferay-resource-sync-fragments-importer.ts
@@ -1,22 +1,21 @@
 import type {AppConfig} from '../../../core/config/load-config.js';
 import {LiferayErrors} from '../errors/index.js';
+import type {ResolvedSite} from '../inventory/liferay-site-resolver.js';
 import type {ResourceSyncDependencies} from './liferay-resource-sync-shared.js';
-import {
-  createFragmentCollection,
-  createFragmentEntry,
-  listRuntimeCollectionsByKey,
-  listRuntimeFragmentsByKey,
-  updateFragmentCollection,
-  updateFragmentEntry,
-} from './liferay-resource-sync-fragments-api.js';
+import {createFragmentSyncRuntimeState} from './liferay-resource-sync-fragments-api.js';
 import {toErrorMessage} from './liferay-resource-sync-fragments-local.js';
 import type {
   LiferayResourceSyncFragmentItemResult,
   LiferayResourceSyncFragmentsSingleResult,
+  LocalFragment,
+  LocalFragmentCollection,
   LocalFragmentsProject,
 } from './liferay-resource-sync-fragments-types.js';
+import {syncArtifact} from './sync-engine.js';
+import {fragmentCollectionSyncStrategy} from './sync-strategies/fragment-collection-sync-strategy.js';
+import {fragmentEntrySyncStrategy} from './sync-strategies/fragment-entry-sync-strategy.js';
 
-export async function runFragmentsImportLegacy(
+export async function runFragmentsImport(
   config: AppConfig,
   groupId: number,
   siteFriendlyUrl: string,
@@ -24,53 +23,35 @@ export async function runFragmentsImportLegacy(
   project: LocalFragmentsProject,
   dependencies?: ResourceSyncDependencies,
 ): Promise<LiferayResourceSyncFragmentsSingleResult> {
-  const collectionByKey = await listRuntimeCollectionsByKey(config, groupId, dependencies);
-
+  const site = toResolvedSite(groupId, siteFriendlyUrl);
+  const runtimeState = createFragmentSyncRuntimeState();
   let imported = 0;
   let errors = 0;
   const fragmentResults: LiferayResourceSyncFragmentItemResult[] = [];
 
   for (const localCollection of project.collections) {
     try {
-      let runtimeCollection = collectionByKey.get(localCollection.slug.toLowerCase());
-      if (!runtimeCollection) {
-        runtimeCollection = await createFragmentCollection(config, groupId, localCollection, dependencies);
-        collectionByKey.set(localCollection.slug.toLowerCase(), runtimeCollection);
-      } else {
-        await updateFragmentCollection(
-          config,
-          Number(runtimeCollection.fragmentCollectionId ?? -1),
-          localCollection,
-          dependencies,
-        );
-      }
-
-      const collectionId = Number(runtimeCollection.fragmentCollectionId ?? -1);
-      if (collectionId <= 0) {
+      const collectionId = await syncFragmentCollection(config, site, localCollection, runtimeState, dependencies);
+      if (!Number.isFinite(collectionId) || collectionId <= 0) {
         throw LiferayErrors.resourceError(`fragmentCollectionId invalido para ${localCollection.slug}`);
       }
 
-      const runtimeByKey = await listRuntimeFragmentsByKey(config, collectionId, dependencies);
-
       for (const localFragment of localCollection.fragments) {
         try {
-          const runtimeFragment = runtimeByKey.get(localFragment.slug.toLowerCase());
-          const syncedFragment = runtimeFragment
-            ? await updateFragmentEntry(
-                config,
-                groupId,
-                collectionId,
-                Number(runtimeFragment.fragmentEntryId ?? -1),
-                localFragment,
-                dependencies,
-              )
-            : await createFragmentEntry(config, groupId, collectionId, localFragment, dependencies);
+          const syncedFragmentId = await syncFragmentEntry(
+            config,
+            site,
+            collectionId,
+            localFragment,
+            runtimeState,
+            dependencies,
+          );
 
           fragmentResults.push({
             collection: localCollection.slug,
             fragment: localFragment.slug,
             status: 'imported',
-            fragmentEntryId: Number(syncedFragment.fragmentEntryId ?? -1),
+            fragmentEntryId: syncedFragmentId,
           });
           imported += 1;
         } catch (error) {
@@ -109,5 +90,66 @@ export async function runFragmentsImportLegacy(
     },
     fragmentResults,
     pageTemplateResults: [],
+  };
+}
+
+export const runFragmentsImportLegacy = runFragmentsImport;
+
+async function syncFragmentCollection(
+  config: AppConfig,
+  site: ResolvedSite,
+  collection: LocalFragmentCollection,
+  runtimeState: ReturnType<typeof createFragmentSyncRuntimeState>,
+  dependencies?: ResourceSyncDependencies,
+): Promise<number> {
+  const result = await syncArtifact(
+    config,
+    site,
+    fragmentCollectionSyncStrategy,
+    {
+      createMissing: true,
+      strategyOptions: {
+        collection,
+        runtimeState,
+      },
+    },
+    dependencies,
+  );
+
+  return Number(result.id);
+}
+
+async function syncFragmentEntry(
+  config: AppConfig,
+  site: ResolvedSite,
+  collectionId: number,
+  fragment: LocalFragment,
+  runtimeState: ReturnType<typeof createFragmentSyncRuntimeState>,
+  dependencies?: ResourceSyncDependencies,
+): Promise<number> {
+  const result = await syncArtifact(
+    config,
+    site,
+    fragmentEntrySyncStrategy,
+    {
+      createMissing: true,
+      strategyOptions: {
+        collectionId,
+        fragment,
+        runtimeState,
+      },
+    },
+    dependencies,
+  );
+
+  const fragmentEntryId = Number(result.id);
+  return Number.isFinite(fragmentEntryId) ? fragmentEntryId : -1;
+}
+
+function toResolvedSite(groupId: number, siteFriendlyUrl: string): ResolvedSite {
+  return {
+    id: groupId,
+    friendlyUrlPath: siteFriendlyUrl,
+    name: siteFriendlyUrl,
   };
 }

--- a/src/features/liferay/resource/liferay-resource-sync-fragments.ts
+++ b/src/features/liferay/resource/liferay-resource-sync-fragments.ts
@@ -6,7 +6,7 @@ import {runLiferayInventorySitesIncludingGlobal} from '../inventory/liferay-inve
 import {resolveSiteToken} from './liferay-resource-paths.js';
 import {resolveResourceSite} from './liferay-resource-shared.js';
 import {readLocalFragmentsProject, resolveFragmentsProjectDir} from './liferay-resource-sync-fragments-local.js';
-import {runFragmentsImportLegacy} from './liferay-resource-sync-fragments-importer.js';
+import {runFragmentsImport as runFragmentsImportWithSyncEngine} from './liferay-resource-sync-fragments-importer.js';
 import type {ResourceSyncDependencies} from './liferay-resource-sync-shared.js';
 import type {
   LiferayResourceSyncFragmentsAllSitesResult,
@@ -107,5 +107,5 @@ async function runFragmentsImport(
   dependencies?: ResourceSyncDependencies,
 ): Promise<LiferayResourceSyncFragmentsSingleResult> {
   const project = await readLocalFragmentsProject(projectDir, fragmentFilter);
-  return runFragmentsImportLegacy(config, groupId, siteFriendlyUrl, projectDir, project, dependencies);
+  return runFragmentsImportWithSyncEngine(config, groupId, siteFriendlyUrl, projectDir, project, dependencies);
 }

--- a/src/features/liferay/resource/sync-strategies/fragment-collection-sync-strategy.ts
+++ b/src/features/liferay/resource/sync-strategies/fragment-collection-sync-strategy.ts
@@ -1,0 +1,110 @@
+import type {AppConfig} from '../../../../core/config/load-config.js';
+import type {ResolvedSite} from '../../inventory/liferay-site-resolver.js';
+import type {FragmentCollectionPayload} from '../liferay-resource-payloads.js';
+import {
+  createFragmentCollection,
+  findRuntimeCollection,
+  updateFragmentCollection,
+  type FragmentSyncRuntimeState,
+} from '../liferay-resource-sync-fragments-api.js';
+import {normalizeFragmentCollectionForHash} from '../liferay-resource-sync-fragments-hash.js';
+import type {LocalFragmentCollection} from '../liferay-resource-sync-fragments-types.js';
+import {sha256, type ResourceSyncDependencies} from '../liferay-resource-sync-shared.js';
+import type {LocalArtifact, RemoteArtifact, SyncStrategy} from '../sync-engine.js';
+
+type FragmentCollectionLocalData = {
+  collection: LocalFragmentCollection;
+};
+
+type FragmentCollectionRemoteData = FragmentCollectionPayload;
+
+type FragmentCollectionSyncOptions = {
+  collection: LocalFragmentCollection;
+  runtimeState: FragmentSyncRuntimeState;
+};
+
+export const fragmentCollectionSyncStrategy: SyncStrategy<FragmentCollectionLocalData, FragmentCollectionRemoteData> = {
+  async resolveLocal(
+    _config: AppConfig,
+    _site: ResolvedSite,
+    options: Record<string, unknown>,
+  ): Promise<LocalArtifact<FragmentCollectionLocalData>> {
+    const opts = options as FragmentCollectionSyncOptions;
+    const normalizedContent = normalizeFragmentCollectionForHash(opts.collection);
+
+    return {
+      id: opts.collection.slug,
+      normalizedContent,
+      contentHash: sha256(normalizedContent),
+      data: {collection: opts.collection},
+    };
+  },
+
+  async findRemote(
+    config: AppConfig,
+    site: ResolvedSite,
+    localArtifact: LocalArtifact<FragmentCollectionLocalData>,
+    options: Record<string, unknown>,
+    dependencies?: ResourceSyncDependencies,
+  ): Promise<RemoteArtifact<FragmentCollectionRemoteData> | null> {
+    const opts = options as FragmentCollectionSyncOptions;
+    const runtimeCollection = await findRuntimeCollection(
+      config,
+      site.id,
+      localArtifact.id,
+      dependencies,
+      opts.runtimeState,
+    );
+
+    if (!runtimeCollection) {
+      return null;
+    }
+
+    return {
+      id: String(runtimeCollection.fragmentCollectionId ?? ''),
+      name: localArtifact.id,
+      data: runtimeCollection,
+    };
+  },
+
+  async upsert(
+    config: AppConfig,
+    site: ResolvedSite,
+    localArtifact: LocalArtifact<FragmentCollectionLocalData>,
+    remoteArtifact: RemoteArtifact<FragmentCollectionRemoteData> | null,
+    options: Record<string, unknown>,
+    dependencies?: ResourceSyncDependencies,
+  ): Promise<RemoteArtifact<FragmentCollectionRemoteData>> {
+    const opts = options as FragmentCollectionSyncOptions;
+
+    if (!remoteArtifact) {
+      const created = await createFragmentCollection(
+        config,
+        site.id,
+        localArtifact.data.collection,
+        dependencies,
+        opts.runtimeState,
+      );
+
+      return {
+        id: String(created.fragmentCollectionId ?? ''),
+        name: localArtifact.id,
+        data: created,
+      };
+    }
+
+    await updateFragmentCollection(
+      config,
+      Number(remoteArtifact.data.fragmentCollectionId ?? -1),
+      localArtifact.data.collection,
+      dependencies,
+      opts.runtimeState,
+    );
+
+    return remoteArtifact;
+  },
+
+  async verify(): Promise<void> {
+    // Collection metadata updates remain best-effort for backward compatibility.
+  },
+};

--- a/src/features/liferay/resource/sync-strategies/fragment-entry-sync-strategy.ts
+++ b/src/features/liferay/resource/sync-strategies/fragment-entry-sync-strategy.ts
@@ -1,0 +1,147 @@
+import type {AppConfig} from '../../../../core/config/load-config.js';
+import {LiferayErrors} from '../../errors/index.js';
+import type {ResolvedSite} from '../../inventory/liferay-site-resolver.js';
+import type {FragmentEntryPayload} from '../liferay-resource-payloads.js';
+import {
+  createFragmentEntry,
+  findRuntimeFragment,
+  updateFragmentEntry,
+  type FragmentSyncRuntimeState,
+} from '../liferay-resource-sync-fragments-api.js';
+import {canVerifyFragmentEntryContent, normalizeFragmentEntryForHash} from '../liferay-resource-sync-fragments-hash.js';
+import type {LocalFragment} from '../liferay-resource-sync-fragments-types.js';
+import {sha256, type ResourceSyncDependencies} from '../liferay-resource-sync-shared.js';
+import type {LocalArtifact, RemoteArtifact, SyncStrategy} from '../sync-engine.js';
+
+type FragmentEntryLocalData = {
+  collectionId: number;
+  fragment: LocalFragment;
+};
+
+type FragmentEntryRemoteData = FragmentEntryPayload & {
+  collectionId: number;
+};
+
+type FragmentEntrySyncOptions = {
+  collectionId: number;
+  fragment: LocalFragment;
+  runtimeState: FragmentSyncRuntimeState;
+};
+
+export const fragmentEntrySyncStrategy: SyncStrategy<FragmentEntryLocalData, FragmentEntryRemoteData> = {
+  async resolveLocal(
+    _config: AppConfig,
+    _site: ResolvedSite,
+    options: Record<string, unknown>,
+  ): Promise<LocalArtifact<FragmentEntryLocalData>> {
+    const opts = options as FragmentEntrySyncOptions;
+    const normalizedContent = normalizeFragmentEntryForHash(opts.fragment);
+
+    return {
+      id: opts.fragment.slug,
+      normalizedContent,
+      contentHash: sha256(normalizedContent),
+      data: {
+        collectionId: opts.collectionId,
+        fragment: opts.fragment,
+      },
+    };
+  },
+
+  async findRemote(
+    config: AppConfig,
+    _site: ResolvedSite,
+    localArtifact: LocalArtifact<FragmentEntryLocalData>,
+    options: Record<string, unknown>,
+    dependencies?: ResourceSyncDependencies,
+  ): Promise<RemoteArtifact<FragmentEntryRemoteData> | null> {
+    const opts = options as FragmentEntrySyncOptions;
+    const runtimeFragment = await findRuntimeFragment(
+      config,
+      opts.collectionId,
+      localArtifact.id,
+      dependencies,
+      opts.runtimeState,
+    );
+
+    if (!runtimeFragment) {
+      return null;
+    }
+
+    return {
+      id: String(runtimeFragment.fragmentEntryId ?? ''),
+      name: localArtifact.id,
+      data: {
+        ...runtimeFragment,
+        collectionId: opts.collectionId,
+      },
+    };
+  },
+
+  async upsert(
+    config: AppConfig,
+    site: ResolvedSite,
+    localArtifact: LocalArtifact<FragmentEntryLocalData>,
+    remoteArtifact: RemoteArtifact<FragmentEntryRemoteData> | null,
+    options: Record<string, unknown>,
+    dependencies?: ResourceSyncDependencies,
+  ): Promise<RemoteArtifact<FragmentEntryRemoteData>> {
+    const opts = options as FragmentEntrySyncOptions;
+
+    if (!remoteArtifact) {
+      const created = await createFragmentEntry(
+        config,
+        site.id,
+        opts.collectionId,
+        localArtifact.data.fragment,
+        dependencies,
+        opts.runtimeState,
+      );
+
+      return {
+        id: String(created.fragmentEntryId ?? ''),
+        name: localArtifact.id,
+        data: {
+          ...created,
+          collectionId: opts.collectionId,
+        },
+      };
+    }
+
+    const fragmentEntryId = Number(remoteArtifact.data.fragmentEntryId ?? -1);
+    const updated = await updateFragmentEntry(
+      config,
+      site.id,
+      opts.collectionId,
+      fragmentEntryId,
+      localArtifact.data.fragment,
+      dependencies,
+      opts.runtimeState,
+    );
+
+    return {
+      id: String(updated.fragmentEntryId ?? fragmentEntryId),
+      name: localArtifact.id,
+      data: {
+        ...updated,
+        collectionId: opts.collectionId,
+      },
+    };
+  },
+
+  async verify(
+    _config: AppConfig,
+    _site: ResolvedSite,
+    localArtifact: LocalArtifact<FragmentEntryLocalData>,
+    remoteArtifact: RemoteArtifact<FragmentEntryRemoteData>,
+  ): Promise<void> {
+    if (!canVerifyFragmentEntryContent(remoteArtifact.data)) {
+      return;
+    }
+
+    const runtimeHash = sha256(normalizeFragmentEntryForHash(remoteArtifact.data));
+    if (runtimeHash !== localArtifact.contentHash) {
+      throw LiferayErrors.resourceError(`Hash mismatch fragment '${remoteArtifact.name}'`);
+    }
+  },
+};

--- a/tests/unit/liferay-resource-sync-fragments.test.ts
+++ b/tests/unit/liferay-resource-sync-fragments.test.ts
@@ -420,4 +420,179 @@ describe('liferay resource fragments-sync', () => {
     });
     expect(formatLiferayResourceSyncFragments(result)).toBe('sites=1 imported=1 errors=0 mode=all-sites');
   });
+
+  test('verify passes when API echoes back content matching local files', async () => {
+    const {config, repoRoot} = await createRepoFixture();
+    const projectDir = path.join(repoRoot, 'liferay', 'fragments', 'sites', 'global');
+
+    // Write a fragment with a known configuration that normalizes predictably.
+    const collectionDir = path.join(projectDir, 'src', 'verify-col');
+    const fragmentDir = path.join(collectionDir, 'fragments', 'verify-frag');
+    await fs.ensureDir(fragmentDir);
+    await fs.writeFile(
+      path.join(collectionDir, 'collection.json'),
+      JSON.stringify({name: 'Verify Col', description: ''}),
+    );
+    await fs.writeFile(path.join(fragmentDir, 'index.html'), '<div>hello</div>');
+    await fs.writeFile(path.join(fragmentDir, 'index.css'), '.hello {}');
+    await fs.writeFile(path.join(fragmentDir, 'index.js'), '// noop');
+    // {"fieldSets":[]} normalizes to itself; avoids default-config expansion.
+    await fs.writeFile(path.join(fragmentDir, 'configuration.json'), '{"fieldSets":[]}');
+    await fs.writeFile(
+      path.join(fragmentDir, 'fragment.json'),
+      JSON.stringify({
+        htmlPath: 'index.html',
+        cssPath: 'index.css',
+        jsPath: 'index.js',
+        configurationPath: 'configuration.json',
+        icon: 'check',
+        name: 'Verify Frag',
+        type: 'component',
+      }),
+    );
+
+    const apiClient = createLiferayApiClient({
+      fetchImpl: async (input) => {
+        const url = String(input);
+
+        if (url.includes('/by-friendly-url-path/global')) {
+          return new Response('{"id":20121,"friendlyUrlPath":"/global","name":"Global"}', {status: 200});
+        }
+        if (url.includes('/api/jsonws/group/get-group?groupId=20121')) {
+          return new Response('{"companyId":10157}', {status: 200});
+        }
+        if (url.includes('/api/jsonws/fragment.fragmentcollection/get-fragment-collections?groupId=20121')) {
+          return new Response('[]', {status: 200});
+        }
+        if (url.includes('/api/jsonws/fragment.fragmentcollection/add-fragment-collection')) {
+          return new Response('{"fragmentCollectionId":700,"fragmentCollectionKey":"verify-col"}', {status: 200});
+        }
+        if (url.includes('/api/jsonws/fragment.fragmententry/get-fragment-entries?fragmentCollectionId=700')) {
+          return new Response('[]', {status: 200});
+        }
+        if (url.includes('/api/jsonws/fragment.fragmententry/add-fragment-entry')) {
+          // Liferay echoes back content matching what was sent; verify should pass.
+          return new Response(
+            JSON.stringify({
+              fragmentEntryId: 800,
+              fragmentEntryKey: 'verify-frag',
+              name: 'Verify Frag',
+              html: '<div>hello</div>',
+              css: '.hello {}',
+              js: '// noop',
+              configuration: '{"fieldSets":[]}',
+              icon: 'check',
+              type: 0,
+            }),
+            {status: 200},
+          );
+        }
+
+        throw new Error(`Unexpected URL ${url}`);
+      },
+    });
+
+    const result = await runLiferayResourceSyncFragments(
+      config,
+      {site: '/global'},
+      {apiClient, tokenClient: TOKEN_CLIENT},
+    );
+
+    expect(result.mode).toBe('oauth-jsonws-import');
+    if (result.mode !== 'oauth-jsonws-import') throw new Error('unexpected mode');
+    expect(result.summary.importedFragments).toBe(1);
+    expect(result.summary.errors).toBe(0);
+    expect(result.fragmentResults[0]).toMatchObject({
+      collection: 'verify-col',
+      fragment: 'verify-frag',
+      status: 'imported',
+      fragmentEntryId: 800,
+    });
+  });
+
+  test('verify detects hash mismatch and reports fragment as error', async () => {
+    const {config, repoRoot} = await createRepoFixture();
+    const projectDir = path.join(repoRoot, 'liferay', 'fragments', 'sites', 'global');
+
+    const collectionDir = path.join(projectDir, 'src', 'verify-col');
+    const fragmentDir = path.join(collectionDir, 'fragments', 'verify-frag');
+    await fs.ensureDir(fragmentDir);
+    await fs.writeFile(
+      path.join(collectionDir, 'collection.json'),
+      JSON.stringify({name: 'Verify Col', description: ''}),
+    );
+    await fs.writeFile(path.join(fragmentDir, 'index.html'), '<div>hello</div>');
+    await fs.writeFile(path.join(fragmentDir, 'index.css'), '.hello {}');
+    await fs.writeFile(path.join(fragmentDir, 'index.js'), '// noop');
+    await fs.writeFile(path.join(fragmentDir, 'configuration.json'), '{"fieldSets":[]}');
+    await fs.writeFile(
+      path.join(fragmentDir, 'fragment.json'),
+      JSON.stringify({
+        htmlPath: 'index.html',
+        cssPath: 'index.css',
+        jsPath: 'index.js',
+        configurationPath: 'configuration.json',
+        icon: 'check',
+        name: 'Verify Frag',
+        type: 'component',
+      }),
+    );
+
+    const apiClient = createLiferayApiClient({
+      fetchImpl: async (input) => {
+        const url = String(input);
+
+        if (url.includes('/by-friendly-url-path/global')) {
+          return new Response('{"id":20121,"friendlyUrlPath":"/global","name":"Global"}', {status: 200});
+        }
+        if (url.includes('/api/jsonws/group/get-group?groupId=20121')) {
+          return new Response('{"companyId":10157}', {status: 200});
+        }
+        if (url.includes('/api/jsonws/fragment.fragmentcollection/get-fragment-collections?groupId=20121')) {
+          return new Response('[]', {status: 200});
+        }
+        if (url.includes('/api/jsonws/fragment.fragmentcollection/add-fragment-collection')) {
+          return new Response('{"fragmentCollectionId":700,"fragmentCollectionKey":"verify-col"}', {status: 200});
+        }
+        if (url.includes('/api/jsonws/fragment.fragmententry/get-fragment-entries?fragmentCollectionId=700')) {
+          return new Response('[]', {status: 200});
+        }
+        if (url.includes('/api/jsonws/fragment.fragmententry/add-fragment-entry')) {
+          // Liferay returns different HTML than what was sent; verify should detect the mismatch.
+          return new Response(
+            JSON.stringify({
+              fragmentEntryId: 800,
+              fragmentEntryKey: 'verify-frag',
+              name: 'Verify Frag',
+              html: '<div>TRANSFORMED BY SERVER</div>',
+              css: '.hello {}',
+              js: '// noop',
+              configuration: '{"fieldSets":[]}',
+              icon: 'check',
+              type: 0,
+            }),
+            {status: 200},
+          );
+        }
+
+        throw new Error(`Unexpected URL ${url}`);
+      },
+    });
+
+    const result = await runLiferayResourceSyncFragments(
+      config,
+      {site: '/global'},
+      {apiClient, tokenClient: TOKEN_CLIENT},
+    );
+
+    expect(result.mode).toBe('oauth-jsonws-import');
+    if (result.mode !== 'oauth-jsonws-import') throw new Error('unexpected mode');
+    expect(result.summary.importedFragments).toBe(0);
+    expect(result.summary.errors).toBe(1);
+    expect(result.fragmentResults[0]).toMatchObject({
+      collection: 'verify-col',
+      fragment: 'verify-frag',
+      status: 'error',
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Migrates the fragment sync family (`liferay-resource-sync-fragments-*`) from a manual loop with direct API calls to the `SyncEngine`/`SyncStrategy` pattern, aligning it with structures, templates, and ADT.

## What Changed

**Added:**
- `liferay-resource-sync-fragments-hash.ts`  content normalization helpers for SHA256 hash computation of collection metadata and entry content; `normalizeFragmentCollectionForHash`, `normalizeFragmentEntryForHash`, `canVerifyFragmentEntryContent`
- `sync-strategies/fragment-collection-sync-strategy.ts`  `SyncStrategy<FragmentCollectionLocalData, FragmentCollectionRemoteData>` for fragment collections; `verify` is intentionally no-op (best-effort legacy compat for metadata updates)
- `sync-strategies/fragment-entry-sync-strategy.ts`  `SyncStrategy<FragmentEntryLocalData, FragmentEntryRemoteData>` for fragment entries with hash verification guarded by `canVerifyFragmentEntryContent`

**Modified:**
- `liferay-resource-sync-fragments-api.ts`
  - `FragmentSyncRuntimeState` type and `createFragmentSyncRuntimeState()` factory for scoped collection/entry cache within a sync run
  - `listRuntimeCollectionsByKey` / `listRuntimeFragmentsByKey` with optional `runtimeState` caching
  - `findRuntimeCollection` / `findRuntimeFragment` focused lookup helpers
  - `runtimeState` threading through all CRUD operations; cache updated after each write
- `liferay-resource-sync-fragments-importer.ts`
  - Replaced direct API loop with `syncArtifact` calls via `syncFragmentCollection` + `syncFragmentEntry` helpers
  - `toResolvedSite` adapter bridges `(groupId, siteFriendlyUrl)` to `ResolvedSite` for the 2-level collectionentries hierarchy
  - `NaN` guard added: `!Number.isFinite(collectionId) || collectionId <= 0`
  - `runFragmentsImportLegacy` alias preserved for backward compat
- `liferay-resource-sync-fragments.ts`  import alias rename only (local `runFragmentsImport` vs imported `runFragmentsImportWithSyncEngine`)
- `tests/unit/liferay-resource-sync-fragments.test.ts`
  - Added `verify passes when API echoes back content matching local files`
  - Added `verify detects hash mismatch and reports fragment as error`

## Design Notes

**collectionentries 2-level hierarchy:**
The `SyncEngine` is single-artifact. The importer loops over collections and for each collection loops over entries, calling `syncArtifact` independently per level. No changes to the engine. `toResolvedSite` is the minimal adapter needed.

**`postFormCandidates` preserved:**
All create/update API calls still go through `postFormCandidates`, maintaining cross-version Liferay API compatibility (some endpoints require `serviceContext`, others reject it).

**`FragmentSyncRuntimeState`:**
`collectionsByKey` starts as `undefined` (not empty Map) so the first `findRemote` call triggers the actual API list fetch. `ensureCollectionRuntimeCache` lazily initializes on first write.

**Hash verification guard:**
`canVerifyFragmentEntryContent` skips verify when the JSONWS response does not include content fields (common for some Liferay versions that omit HTML/CSS/JS in the create/update response).

## Preserved

- `postFormCandidates` multi-candidate cross-version compatibility
- Local fragment directory format unchanged
- All public CLI API contracts unchanged (`runLiferayResourceSyncFragments`, formatter, exit code, output types)
- `runFragmentsImportLegacy` alias for backward compatibility

## Residual Risks

- **Verify false positives**: If Liferay transforms content in the create/update response, `verify` will throw a hash mismatch even though the sync succeeded. Mitigation: `canVerifyFragmentEntryContent` guard already skips verify when the response omits content fields.
- **`updateFragmentCollection` silences errors**: Legacy behavior preserved. Collection metadata update failures do not surface in the sync result.

## Validation

- `npm run typecheck`  clean
- `npm run test:unit -- tests/unit/liferay-resource-sync-fragments.test.ts tests/unit/liferay-resource-export.test.ts`  811/811 passed (2 new tests)
