### PR TITLE
refactor(inventory/page-layout): phase 2 typed payloads and fallback consolidation

### DIFF
--- a/src/features/liferay/inventory/liferay-inventory-page-assemble.ts
+++ b/src/features/liferay/inventory/liferay-inventory-page-assemble.ts
@@ -1,5 +1,6 @@
 /* eslint-disable max-lines -- shared assembly helpers kept together for inventory readability */
 import {firstNonBlank, firstString as firstStringUtil} from '../../../core/utils/text.js';
+import type {HeadlessPageElementPayload} from '../page-layout/liferay-site-page-shared.js';
 
 export type StructuredContent = {
   id?: number;
@@ -91,7 +92,7 @@ export type PageFragmentEntry = {
 };
 
 export function collectPageElements(
-  pageElement: Record<string, unknown> | null,
+  pageElement: HeadlessPageElementPayload | null,
   fragmentEntryLinks: Array<Record<string, unknown>>,
   locale: string | null = null,
 ): PageFragmentEntry[] {
@@ -112,7 +113,7 @@ export function collectPageElements(
 }
 
 function collectPageElementsRecursive(
-  element: Record<string, unknown> | null,
+  element: HeadlessPageElementPayload | null,
   result: PageFragmentEntry[],
   locale: string | null = null,
 ): void {
@@ -248,6 +249,8 @@ function extractFragmentEditableFields(fragmentFields: unknown, locale: string |
     const text = asRecord(value.text);
     const i18n = asRecord(text.value_i18n);
     // Prefer the matched locale, then ca_ES, then es_ES, then any available
+    // TODO: consider improving locale matching logic if needed in the future
+    // Not hardcoded locales
     const textValue = String(
       (locale ? i18n[locale] : undefined) ??
         i18n['ca_ES'] ??

--- a/src/features/liferay/inventory/liferay-inventory-page-fetch-components.ts
+++ b/src/features/liferay/inventory/liferay-inventory-page-fetch-components.ts
@@ -1,46 +1,11 @@
-import {trimLeadingSlash} from '../../../core/utils/text.js';
 import type {LiferayGateway} from '../liferay-gateway.js';
-import {asRecord} from './liferay-inventory-page-assemble.js';
-import {safeGatewayGet} from './liferay-inventory-page-fetch-http.js';
+import {
+  fetchHeadlessSitePageElement,
+  fetchHeadlessSitePageMetadata,
+  type HeadlessPageElementPayload,
+  type HeadlessSitePagePayload,
+} from '../page-layout/liferay-site-page-shared.js';
 import {tryFetchFragmentEntryLinks} from './liferay-inventory-page-fetch-fragments.js';
-
-async function fetchSitePageElement(
-  gateway: LiferayGateway,
-  siteId: number,
-  friendlyUrl: string,
-): Promise<Record<string, unknown> | null> {
-  const slug = trimLeadingSlash(friendlyUrl);
-  const response = await safeGatewayGet<Record<string, unknown>>(
-    gateway,
-    `/o/headless-delivery/v1.0/sites/${siteId}/site-pages/${encodeURIComponent(slug)}?fields=pageDefinition`,
-    'fetch-site-page-element',
-  );
-  if (!response.ok) {
-    return null;
-  }
-  return asRecord(asRecord(response.data).pageDefinition).pageElement as Record<string, unknown> | null;
-}
-
-async function tryFetchSitePageMetadata(
-  gateway: LiferayGateway,
-  siteId: number,
-  friendlyUrl: string,
-): Promise<Record<string, unknown> | null> {
-  try {
-    const slug = trimLeadingSlash(friendlyUrl);
-    const response = await safeGatewayGet<Record<string, unknown>>(
-      gateway,
-      `/o/headless-delivery/v1.0/sites/${siteId}/site-pages/${encodeURIComponent(slug)}?nestedFields=taxonomyCategoryBriefs`,
-      'fetch-site-page-metadata',
-    );
-    if (!response.ok || !response.data) {
-      return null;
-    }
-    return asRecord(response.data);
-  } catch {
-    return null;
-  }
-}
 
 export async function fetchComponentPageData(
   gateway: LiferayGateway,
@@ -48,12 +13,12 @@ export async function fetchComponentPageData(
   canonicalFriendlyUrl: string,
   plid: number,
 ): Promise<{
-  pageElement: Record<string, unknown> | null;
-  pageMetadata: Record<string, unknown> | null;
+  pageElement: HeadlessPageElementPayload | null;
+  pageMetadata: HeadlessSitePagePayload | null;
   rawFragmentLinks: Array<Record<string, unknown>>;
 }> {
-  const pageElement = await fetchSitePageElement(gateway, siteId, canonicalFriendlyUrl);
-  const pageMetadata = await tryFetchSitePageMetadata(gateway, siteId, canonicalFriendlyUrl);
+  const pageElement = await fetchHeadlessSitePageElement(gateway, siteId, canonicalFriendlyUrl);
+  const pageMetadata = await fetchHeadlessSitePageMetadata(gateway, siteId, canonicalFriendlyUrl);
   const rawFragmentLinks = await tryFetchFragmentEntryLinks(gateway, siteId, plid);
 
   return {pageElement, pageMetadata, rawFragmentLinks};

--- a/src/features/liferay/inventory/liferay-inventory-page-fetch.ts
+++ b/src/features/liferay/inventory/liferay-inventory-page-fetch.ts
@@ -13,7 +13,6 @@ import {
 import type {LiferayGateway} from '../liferay-gateway.js';
 import {buildJournalArticleAdminUrls, buildLayoutAdminUrls} from '../page-layout/liferay-page-admin-urls.js';
 import {
-  asRecord,
   collectPageElements,
   type ContentStructureSummary,
   type JournalArticleSummary,
@@ -21,10 +20,21 @@ import {
 } from './liferay-inventory-page-assemble.js';
 import {KNOWN_LOCALES} from './liferay-inventory-page-url.js';
 import type {
+  InventoryPageConfigurationCustomMetaTags,
+  InventoryPageConfigurationDesign,
+  InventoryPageConfigurationGeneral,
+  InventoryPageConfigurationOpenGraph,
+  InventoryPageConfigurationSeo,
+  InventoryPageConfigurationTabs,
+  InventoryPageRawLayout,
   LiferayInventoryPageResult,
   PagePortletSummary,
   ResolvedRegularLayoutPage,
 } from './liferay-inventory-page.js';
+import type {
+  HeadlessSitePagePayload,
+  HeadlessSitePageSettingsPayload,
+} from '../page-layout/liferay-site-page-shared.js';
 import {classNameIdLookupCache} from '../lookup-cache.js';
 import {resolveDisplayPageArticle, resolveStructuredContentData} from './liferay-inventory-page-fetch-article.js';
 import {safeGatewayGet} from './liferay-inventory-page-fetch-http.js';
@@ -150,7 +160,7 @@ export async function fetchRegularPageInventory(
   const pageUrl = buildPageUrl(site.friendlyUrlPath, canonicalFriendlyUrl, privateLayout);
   const componentInspectionSupported = String(layout.type ?? '').toLowerCase() === 'content';
   const layoutClassNameId = await resolveClassNameId(config, gateway, CLASS_NAME_LAYOUT);
-  let pageMetadata: Record<string, unknown> | null = null;
+  let pageMetadata: HeadlessSitePagePayload | null = null;
   let fragmentEntryLinks: PageFragmentEntry[] = [];
   let widgets: Array<{widgetName: string; portletId?: string; configuration?: Record<string, string>}> = [];
   let journalArticles: JournalArticleSummary[] = [];
@@ -365,35 +375,34 @@ function resolveRegularPageUiType(layoutType: string | undefined): string {
  */
 function extractConfigurationMetadata(
   layout: Layout,
-  pageMetadata?: Record<string, unknown> | null,
+  pageMetadata?: HeadlessSitePagePayload | null,
 ): {
-  typeSettings: Record<string, unknown>;
-  metadata: Record<string, unknown>;
-  metadataSettings: Record<string, unknown>;
-  customFieldsMap: Record<string, unknown>;
+  typeSettings: {[key: string]: string};
+  metadata: HeadlessSitePagePayload;
+  metadataSettings: HeadlessSitePageSettingsPayload;
+  customFieldsMap: {[key: string]: unknown};
   categories: string[];
   tags: string[];
 } {
   const typeSettings = parseTypeSettingsMap(layout.typeSettings ?? '');
-  const metadata = asRecord(pageMetadata ?? {});
-  const metadataSettings = asRecord(metadata.settings);
+  const metadata: HeadlessSitePagePayload = pageMetadata ?? {};
+  const metadataSettings: HeadlessSitePageSettingsPayload = metadata.settings ?? {};
 
-  const customFieldsMap: Record<string, unknown> = {};
-  for (const item of Array.isArray(metadata.customFields) ? metadata.customFields : []) {
-    const field = asRecord(item);
+  const customFieldsMap: {[key: string]: unknown} = {};
+  for (const field of metadata.customFields ?? []) {
     const name = String(field.name ?? '').trim();
     if (!name) {
       continue;
     }
-    customFieldsMap[name] = asRecord(field.customValue).data;
+    customFieldsMap[name] = field.customValue?.data;
   }
 
-  const categories = (Array.isArray(metadata.taxonomyCategoryBriefs) ? metadata.taxonomyCategoryBriefs : [])
-    .map((item) => asRecord(item).taxonomyCategoryName)
-    .filter((value): value is string => typeof value === 'string' && value.trim() !== '');
+  const categories = (metadata.taxonomyCategoryBriefs ?? [])
+    .map((item: {taxonomyCategoryName?: string}) => item.taxonomyCategoryName)
+    .filter((value: string | undefined): value is string => typeof value === 'string' && value.trim() !== '');
 
-  const tags = (Array.isArray(metadata.keywords) ? metadata.keywords : []).filter(
-    (item): item is string => typeof item === 'string' && item.trim() !== '',
+  const tags = (metadata.keywords ?? []).filter(
+    (item: string | undefined): item is string => typeof item === 'string' && item.trim() !== '',
   );
 
   return {typeSettings, metadata, metadataSettings, customFieldsMap, categories, tags};
@@ -403,20 +412,14 @@ function buildRegularPageConfigurationTabs(
   layout: Layout,
   layoutDetails: {layoutTemplateId?: string; targetUrl?: string},
   privateLayout: boolean,
-  pageMetadata?: Record<string, unknown> | null,
-): {
-  general: Record<string, unknown>;
-  design: Record<string, unknown>;
-  seo: Record<string, unknown>;
-  openGraph: Record<string, unknown>;
-  customMetaTags: Record<string, unknown>;
-} {
+  pageMetadata?: HeadlessSitePagePayload | null,
+): InventoryPageConfigurationTabs {
   const {typeSettings, metadata, metadataSettings, customFieldsMap, categories, tags} = extractConfigurationMetadata(
     layout,
     pageMetadata,
   );
 
-  const general: Record<string, unknown> = {
+  const general: InventoryPageConfigurationGeneral = {
     type: layout.type ?? '',
     name: layout.nameCurrentValue ?? '',
     hiddenInNavigation: toBooleanOrFalse(layout.hidden),
@@ -429,7 +432,7 @@ function buildRegularPageConfigurationTabs(
     privateLayout,
   };
 
-  const design: Record<string, unknown> = {
+  const design: InventoryPageConfigurationDesign = {
     theme: {
       useInheritedTheme: false,
       themeId: layout.themeId ?? '',
@@ -439,42 +442,40 @@ function buildRegularPageConfigurationTabs(
       faviconFileEntryId: Number(layout.faviconFileEntryId ?? 0),
     },
     themeFlags: {
-      showHeader: toBoolean(typeSettings['lfr-theme:regular:show-header']),
-      showFooter: toBoolean(typeSettings['lfr-theme:regular:show-footer']),
-      showHeaderSearch: toBoolean(typeSettings['lfr-theme:regular:show-header-search']),
-      wrapWidgetPageContent: toBoolean(typeSettings['lfr-theme:regular:wrap-widget-page-content']),
-      layoutUpdateable: toBoolean(typeSettings.layoutUpdateable),
-      published: toBoolean(typeSettings.published),
+      showHeader: toBoolean(typeSettings['lfr-theme:regular:show-header']) ?? undefined,
+      showFooter: toBoolean(typeSettings['lfr-theme:regular:show-footer']) ?? undefined,
+      showHeaderSearch: toBoolean(typeSettings['lfr-theme:regular:show-header-search']) ?? undefined,
+      wrapWidgetPageContent: toBoolean(typeSettings['lfr-theme:regular:wrap-widget-page-content']) ?? undefined,
+      layoutUpdateable: toBoolean(typeSettings.layoutUpdateable) ?? undefined,
+      published: toBoolean(typeSettings.published) ?? undefined,
     },
     customCss: layout.css ?? '',
     customJavascript: layout.javascript ?? '',
     customFields: customFieldsMap,
   };
 
-  const seo: Record<string, unknown> = {
+  const seo: InventoryPageConfigurationSeo = {
     title: layout.titleCurrentValue ?? '',
     description: layout.descriptionCurrentValue ?? '',
     keywords: layout.keywordsCurrentValue ?? '',
     robots: layout.robotsCurrentValue ?? layout.robots ?? '',
     sitemap: {
-      include: toBoolean(typeSettings['sitemap-include']),
+      include: toBoolean(typeSettings['sitemap-include']) ?? undefined,
       changefreq: typeSettings['sitemap-changefreq'] ?? '',
     },
   };
 
-  const openGraph: Record<string, unknown> = {
+  const openGraph: InventoryPageConfigurationOpenGraph = {
     title: firstNonEmptyString(metadataSettings.openGraphTitle, metadata.openGraphTitle),
     description: firstNonEmptyString(metadataSettings.openGraphDescription, metadata.openGraphDescription),
     type: firstNonEmptyString(metadataSettings.openGraphType, metadata.openGraphType),
     url: firstNonEmptyString(metadataSettings.openGraphUrl, metadata.openGraphUrl),
     imageAlt: firstNonEmptyString(metadataSettings.openGraphImageAlt, metadata.openGraphImageAlt),
-    imageFileEntryId: firstPositiveNumber(
-      metadataSettings.openGraphImageFileEntryId,
-      metadata.openGraphImageFileEntryId,
-    ),
+    imageFileEntryId:
+      firstPositiveNumber(metadataSettings.openGraphImageFileEntryId, metadata.openGraphImageFileEntryId) ?? undefined,
   };
 
-  const customMetaTags: Record<string, unknown> = {
+  const customMetaTags: InventoryPageConfigurationCustomMetaTags = {
     values: metadata.customMetaTags ?? metadataSettings.customMetaTags ?? typeSettings.customMetaTags ?? null,
   };
 
@@ -487,7 +488,7 @@ function buildRegularPageConfigurationTabs(
   };
 }
 
-function buildConfigurationRawLayout(layout: Layout): Record<string, unknown> {
+function buildConfigurationRawLayout(layout: Layout): InventoryPageRawLayout {
   return {
     layoutId: Number(layout.layoutId ?? -1),
     plid: Number(layout.plid ?? -1),
@@ -509,19 +510,10 @@ function buildConfigurationRawLayout(layout: Layout): Record<string, unknown> {
   };
 }
 
-function buildConfigurationRawSitePage(pageMetadata: Record<string, unknown>): Record<string, unknown> {
-  const metadata = asRecord(pageMetadata);
-  return {
-    id: firstPositiveNumber(metadata.id),
-    friendlyUrlPath: firstNonEmptyString(metadata.friendlyUrlPath),
-    title: firstNonEmptyString(metadata.title),
-    availableLanguages: Array.isArray(metadata.availableLanguages) ? metadata.availableLanguages : [],
-    taxonomyCategoryBriefs: Array.isArray(metadata.taxonomyCategoryBriefs) ? metadata.taxonomyCategoryBriefs : [],
-    keywords: Array.isArray(metadata.keywords) ? metadata.keywords : [],
-    customFields: Array.isArray(metadata.customFields) ? metadata.customFields : [],
-    settings: asRecord(metadata.settings),
-    viewableBy: asRecord(metadata.viewableBy),
-  };
+function buildConfigurationRawSitePage(pageMetadata: HeadlessSitePagePayload): HeadlessSitePagePayload {
+  // pageMetadata is already normalized by toHeadlessSitePagePayload — pass through directly
+  // to avoid introducing synthetic empty strings/arrays for absent fields.
+  return pageMetadata;
 }
 
 function parseTypeSettingsMap(rawTypeSettings: string): Record<string, string> {

--- a/src/features/liferay/inventory/liferay-inventory-page.ts
+++ b/src/features/liferay/inventory/liferay-inventory-page.ts
@@ -19,12 +19,106 @@ import type {
   JournalArticleSummary,
   PageFragmentEntry,
 } from './liferay-inventory-page-assemble.js';
+import type {HeadlessSitePagePayload} from '../page-layout/liferay-site-page-shared.js';
 
 export {resolveInventoryPageRequest};
 
 type InventoryPageDependencies = {
   apiClient?: LiferayApiClient;
   tokenClient?: OAuthTokenClient;
+};
+
+export type InventoryPageConfigurationGeneral = {
+  type: string;
+  name: string;
+  hiddenInNavigation: boolean;
+  friendlyUrl: string;
+  queryString: string;
+  targetType: string;
+  target: string;
+  categories: string[];
+  tags: string[];
+  privateLayout: boolean;
+};
+
+export type InventoryPageConfigurationDesign = {
+  theme: {
+    useInheritedTheme: boolean;
+    themeId: string;
+    colorSchemeId: string;
+    styleBookEntryId: number;
+    masterLayoutPlid: number;
+    faviconFileEntryId: number;
+  };
+  themeFlags: {
+    showHeader?: boolean;
+    showFooter?: boolean;
+    showHeaderSearch?: boolean;
+    wrapWidgetPageContent?: boolean;
+    layoutUpdateable?: boolean;
+    published?: boolean;
+  };
+  customCss: string;
+  customJavascript: string;
+  customFields: {[key: string]: unknown};
+};
+
+export type InventoryPageConfigurationSeo = {
+  title: string;
+  description: string;
+  keywords: string;
+  robots: string;
+  sitemap: {
+    include?: boolean;
+    changefreq: string;
+  };
+};
+
+export type InventoryPageConfigurationOpenGraph = {
+  title?: string;
+  description?: string;
+  type?: string;
+  url?: string;
+  imageAlt?: string;
+  imageFileEntryId?: number;
+};
+
+export type InventoryPageConfigurationCustomMetaTags = {
+  values: unknown;
+};
+
+export type InventoryPageConfigurationTabs = {
+  general: InventoryPageConfigurationGeneral;
+  design: InventoryPageConfigurationDesign;
+  seo: InventoryPageConfigurationSeo;
+  openGraph: InventoryPageConfigurationOpenGraph;
+  customMetaTags: InventoryPageConfigurationCustomMetaTags;
+};
+
+export type InventoryPageRawLayout = {
+  layoutId: number;
+  plid: number;
+  type: string;
+  nameCurrentValue: string;
+  titleCurrentValue: string;
+  descriptionCurrentValue: string;
+  keywordsCurrentValue: string;
+  robotsCurrentValue: string;
+  friendlyURL: string;
+  hidden: boolean;
+  themeId: string;
+  colorSchemeId: string;
+  styleBookEntryId: number;
+  masterLayoutPlid: number;
+  faviconFileEntryId: number;
+  css: string;
+  javascript: string;
+};
+
+export type InventoryPageConfigurationRaw = {
+  layout: InventoryPageRawLayout;
+  typeSettings: {[key: string]: string};
+  sitePageMetadata?: HeadlessSitePagePayload;
 };
 
 export type LiferayInventoryPageResult =
@@ -102,18 +196,8 @@ export type LiferayInventoryPageResult =
         configureCustomMetaTags: string;
         translate: string;
       };
-      configurationTabs?: {
-        general: Record<string, unknown>;
-        design: Record<string, unknown>;
-        seo: Record<string, unknown>;
-        openGraph: Record<string, unknown>;
-        customMetaTags: Record<string, unknown>;
-      };
-      configurationRaw?: {
-        layout: Record<string, unknown>;
-        typeSettings: Record<string, string>;
-        sitePageMetadata?: Record<string, unknown>;
-      };
+      configurationTabs?: InventoryPageConfigurationTabs;
+      configurationRaw?: InventoryPageConfigurationRaw;
       componentInspectionSupported?: boolean;
       portlets?: PagePortletSummary[];
       fragmentEntryLinks?: PageFragmentEntry[];

--- a/src/features/liferay/page-layout/liferay-page-layout-export.ts
+++ b/src/features/liferay/page-layout/liferay-page-layout-export.ts
@@ -11,6 +11,7 @@ import {LiferayErrors} from '../errors/index.js';
 import {createLiferayGateway, type LiferayGateway} from '../liferay-gateway.js';
 import {resolveRegularLayoutPage} from '../inventory/liferay-inventory-page.js';
 import {buildLayoutConfigureUrl} from './liferay-page-admin-urls.js';
+import {fetchHeadlessSitePage, type HeadlessSitePagePayload} from './liferay-site-page-shared.js';
 
 const EXPORT_KIND = 'liferay-page-layout-export';
 const EXPORT_SCHEMA_VERSION = 1;
@@ -48,7 +49,7 @@ export type LiferayPageLayoutExport = {
     configureOpenGraph: string;
     configureCustomMetaTags: string;
   };
-  headlessSitePage: Record<string, unknown>;
+  headlessSitePage: HeadlessSitePagePayload;
   experiences?: unknown;
   layoutStructure: {
     available: false;
@@ -65,7 +66,7 @@ export async function runLiferayPageLayoutExport(
   const regularPage = await resolveExportableRegularPage(config, options, dependencies);
   const apiClient = dependencies?.apiClient ?? createLiferayApiClient();
   const gateway = createLiferayGateway(config, apiClient, dependencies?.tokenClient);
-  const headlessSitePage = await fetchSitePage(gateway, regularPage.groupId, regularPage.friendlyUrl);
+  const headlessSitePage = await fetchHeadlessSitePage(gateway, regularPage.groupId, regularPage.friendlyUrl);
 
   if (headlessSitePage === null) {
     throw LiferayErrors.pageLayoutError(
@@ -173,34 +174,6 @@ async function resolveExportableRegularPage(
   }
 
   return page;
-}
-
-async function fetchSitePage(
-  gateway: LiferayGateway,
-  siteId: number,
-  friendlyUrl: string,
-): Promise<Record<string, unknown> | null> {
-  const slug = trimLeadingSlash(friendlyUrl);
-  let data: Record<string, unknown> | null;
-
-  try {
-    data = await gateway.getJson<Record<string, unknown> | null>(
-      `/o/headless-delivery/v1.0/sites/${siteId}/site-pages/${slug}?fields=actions,friendlyUrlPath,id,pageDefinition,pageType,siteId,title,uuid`,
-      `fetch site page ${siteId}/${slug}`,
-    );
-  } catch (error) {
-    if (error instanceof CliError && error.code === 'LIFERAY_GATEWAY_ERROR') {
-      return null;
-    }
-
-    throw error;
-  }
-
-  if (data === null || Array.isArray(data)) {
-    return null;
-  }
-
-  return data;
 }
 
 async function fetchSitePageExperiences(

--- a/src/features/liferay/page-layout/liferay-site-page-shared.ts
+++ b/src/features/liferay/page-layout/liferay-site-page-shared.ts
@@ -1,0 +1,376 @@
+import {CliError} from '../../../core/errors.js';
+import {trimLeadingSlash} from '../../../core/utils/text.js';
+import type {LiferayGateway} from '../liferay-gateway.js';
+
+export type HeadlessSitePageActions = {
+  [key: string]: unknown;
+};
+
+export type HeadlessSitePageTaxonomyCategoryBrief = {
+  taxonomyCategoryName?: string;
+  [key: string]: unknown;
+};
+
+export type HeadlessSitePageCustomValuePayload = {
+  data?: unknown;
+  [key: string]: unknown;
+};
+
+export type HeadlessSitePageCustomFieldPayload = {
+  name?: string;
+  customValue?: HeadlessSitePageCustomValuePayload;
+  [key: string]: unknown;
+};
+
+export type HeadlessSitePageSettingsPayload = {
+  openGraphTitle?: string;
+  openGraphDescription?: string;
+  openGraphType?: string;
+  openGraphUrl?: string;
+  openGraphImageAlt?: string;
+  openGraphImageFileEntryId?: number;
+  customMetaTags?: unknown;
+  [key: string]: unknown;
+};
+
+export type HeadlessPageElementPayload = {
+  type?: string;
+  name?: string;
+  definition?: {[key: string]: unknown};
+  cssClasses?: string[];
+  customCSS?: string;
+  pageElements?: HeadlessPageElementPayload[];
+  [key: string]: unknown;
+};
+
+export type HeadlessPageDefinitionPayload = {
+  pageElement?: HeadlessPageElementPayload | null;
+  widgets?: unknown[];
+  [key: string]: unknown;
+};
+
+export type HeadlessSitePagePayload = {
+  id?: number;
+  uuid?: string;
+  friendlyUrlPath?: string;
+  pageType?: string;
+  siteId?: number;
+  title?: string;
+  actions?: HeadlessSitePageActions;
+  pageDefinition?: HeadlessPageDefinitionPayload;
+  availableLanguages?: string[];
+  taxonomyCategoryBriefs?: HeadlessSitePageTaxonomyCategoryBrief[];
+  keywords?: string[];
+  customFields?: HeadlessSitePageCustomFieldPayload[];
+  settings?: HeadlessSitePageSettingsPayload;
+  viewableBy?: {[key: string]: unknown};
+  openGraphTitle?: string;
+  openGraphDescription?: string;
+  openGraphType?: string;
+  openGraphUrl?: string;
+  openGraphImageAlt?: string;
+  openGraphImageFileEntryId?: number;
+  [key: string]: unknown;
+};
+
+export function toHeadlessSitePagePayload(raw: unknown): HeadlessSitePagePayload | null {
+  const record = asObject(raw);
+  if (!record) {
+    return null;
+  }
+
+  const normalized = {...record} as HeadlessSitePagePayload;
+  const actions = asObject(record.actions);
+  const pageDefinition = toHeadlessPageDefinitionPayload(record.pageDefinition);
+  const settings = toHeadlessSitePageSettingsPayload(record.settings);
+  const viewableBy = asObject(record.viewableBy);
+  const taxonomyCategoryBriefs = Array.isArray(record.taxonomyCategoryBriefs)
+    ? record.taxonomyCategoryBriefs
+        .map((item) => toHeadlessSitePageTaxonomyCategoryBrief(item))
+        .filter((item): item is HeadlessSitePageTaxonomyCategoryBrief => item !== null)
+    : undefined;
+  const customFields = Array.isArray(record.customFields)
+    ? record.customFields
+        .map((item) => toHeadlessSitePageCustomFieldPayload(item))
+        .filter((item): item is HeadlessSitePageCustomFieldPayload => item !== null)
+    : undefined;
+  const availableLanguages = toStringArray(record.availableLanguages);
+  const keywords = toStringArray(record.keywords);
+
+  normalized.id = toPositiveNumber(record.id);
+  normalized.uuid = toStringOrUndefined(record.uuid);
+  normalized.friendlyUrlPath = toStringOrUndefined(record.friendlyUrlPath);
+  normalized.pageType = toStringOrUndefined(record.pageType);
+  normalized.siteId = toPositiveNumber(record.siteId);
+  normalized.title = toStringOrUndefined(record.title);
+  normalized.openGraphTitle = toStringOrUndefined(record.openGraphTitle);
+  normalized.openGraphDescription = toStringOrUndefined(record.openGraphDescription);
+  normalized.openGraphType = toStringOrUndefined(record.openGraphType);
+  normalized.openGraphUrl = toStringOrUndefined(record.openGraphUrl);
+  normalized.openGraphImageAlt = toStringOrUndefined(record.openGraphImageAlt);
+  normalized.openGraphImageFileEntryId = toPositiveNumber(record.openGraphImageFileEntryId);
+
+  if (actions) {
+    normalized.actions = actions;
+  } else {
+    delete normalized.actions;
+  }
+
+  if (pageDefinition) {
+    normalized.pageDefinition = pageDefinition;
+  } else {
+    delete normalized.pageDefinition;
+  }
+
+  if (availableLanguages) {
+    normalized.availableLanguages = availableLanguages;
+  } else {
+    delete normalized.availableLanguages;
+  }
+
+  if (taxonomyCategoryBriefs) {
+    normalized.taxonomyCategoryBriefs = taxonomyCategoryBriefs;
+  } else {
+    delete normalized.taxonomyCategoryBriefs;
+  }
+
+  if (keywords) {
+    normalized.keywords = keywords;
+  } else {
+    delete normalized.keywords;
+  }
+
+  if (customFields) {
+    normalized.customFields = customFields;
+  } else {
+    delete normalized.customFields;
+  }
+
+  if (settings) {
+    normalized.settings = settings;
+  } else {
+    delete normalized.settings;
+  }
+
+  if (viewableBy) {
+    normalized.viewableBy = viewableBy;
+  } else {
+    delete normalized.viewableBy;
+  }
+
+  return normalized;
+}
+
+export async function fetchHeadlessSitePage(
+  gateway: LiferayGateway,
+  siteId: number,
+  friendlyUrl: string,
+): Promise<HeadlessSitePagePayload | null> {
+  return fetchHeadlessSitePageWithQuery(
+    gateway,
+    siteId,
+    friendlyUrl,
+    '?fields=actions,friendlyUrlPath,id,pageDefinition,pageType,siteId,title,uuid',
+    'fetch-site-page',
+  );
+}
+
+export async function fetchHeadlessSitePageElement(
+  gateway: LiferayGateway,
+  siteId: number,
+  friendlyUrl: string,
+): Promise<HeadlessPageElementPayload | null> {
+  try {
+    const sitePage = await fetchHeadlessSitePageWithQuery(
+      gateway,
+      siteId,
+      friendlyUrl,
+      '?fields=pageDefinition',
+      'fetch-site-page-element',
+    );
+
+    return sitePage?.pageDefinition?.pageElement ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export async function fetchHeadlessSitePageMetadata(
+  gateway: LiferayGateway,
+  siteId: number,
+  friendlyUrl: string,
+): Promise<HeadlessSitePagePayload | null> {
+  try {
+    return await fetchHeadlessSitePageWithQuery(
+      gateway,
+      siteId,
+      friendlyUrl,
+      '?nestedFields=taxonomyCategoryBriefs',
+      'fetch-site-page-metadata',
+    );
+  } catch {
+    return null;
+  }
+}
+
+async function fetchHeadlessSitePageWithQuery(
+  gateway: LiferayGateway,
+  siteId: number,
+  friendlyUrl: string,
+  query: string,
+  label: string,
+): Promise<HeadlessSitePagePayload | null> {
+  const slug = trimLeadingSlash(friendlyUrl);
+
+  try {
+    const raw = await gateway.getJson<unknown>(
+      `/o/headless-delivery/v1.0/sites/${siteId}/site-pages/${encodeURIComponent(slug)}${query}`,
+      label,
+    );
+    return toHeadlessSitePagePayload(raw);
+  } catch (error) {
+    if (error instanceof CliError && error.code === 'LIFERAY_GATEWAY_ERROR') {
+      return null;
+    }
+
+    throw error;
+  }
+}
+
+function toHeadlessSitePageTaxonomyCategoryBrief(raw: unknown): HeadlessSitePageTaxonomyCategoryBrief | null {
+  const record = asObject(raw);
+  if (!record) {
+    return null;
+  }
+
+  const normalized = {...record} as HeadlessSitePageTaxonomyCategoryBrief;
+  normalized.taxonomyCategoryName = toStringOrUndefined(record.taxonomyCategoryName);
+  return normalized;
+}
+
+function toHeadlessSitePageCustomFieldPayload(raw: unknown): HeadlessSitePageCustomFieldPayload | null {
+  const record = asObject(raw);
+  if (!record) {
+    return null;
+  }
+
+  const normalized = {...record} as HeadlessSitePageCustomFieldPayload;
+  const customValue = asObject(record.customValue);
+
+  normalized.name = toStringOrUndefined(record.name);
+
+  if (customValue) {
+    normalized.customValue = {...customValue} as HeadlessSitePageCustomValuePayload;
+  } else {
+    delete normalized.customValue;
+  }
+
+  return normalized;
+}
+
+function toHeadlessSitePageSettingsPayload(raw: unknown): HeadlessSitePageSettingsPayload | null {
+  const record = asObject(raw);
+  if (!record) {
+    return null;
+  }
+
+  const normalized = {...record} as HeadlessSitePageSettingsPayload;
+  normalized.openGraphTitle = toStringOrUndefined(record.openGraphTitle);
+  normalized.openGraphDescription = toStringOrUndefined(record.openGraphDescription);
+  normalized.openGraphType = toStringOrUndefined(record.openGraphType);
+  normalized.openGraphUrl = toStringOrUndefined(record.openGraphUrl);
+  normalized.openGraphImageAlt = toStringOrUndefined(record.openGraphImageAlt);
+  normalized.openGraphImageFileEntryId = toPositiveNumber(record.openGraphImageFileEntryId);
+  return normalized;
+}
+
+function toHeadlessPageDefinitionPayload(raw: unknown): HeadlessPageDefinitionPayload | null {
+  const record = asObject(raw);
+  if (!record) {
+    return null;
+  }
+
+  const normalized = {...record} as HeadlessPageDefinitionPayload;
+  const pageElement = toHeadlessPageElementPayload(record.pageElement);
+  if (pageElement) {
+    normalized.pageElement = pageElement;
+  } else {
+    delete normalized.pageElement;
+  }
+  if (!Array.isArray(record.widgets)) {
+    delete normalized.widgets;
+  }
+  return normalized;
+}
+
+function toHeadlessPageElementPayload(raw: unknown): HeadlessPageElementPayload | null {
+  const record = asObject(raw);
+  if (!record) {
+    return null;
+  }
+
+  const normalized = {...record} as HeadlessPageElementPayload;
+  const definition = asObject(record.definition);
+  const pageElements = Array.isArray(record.pageElements)
+    ? record.pageElements
+        .map((item) => toHeadlessPageElementPayload(item))
+        .filter((item): item is HeadlessPageElementPayload => item !== null)
+    : undefined;
+  const cssClasses = toStringArray(record.cssClasses);
+
+  normalized.type = toStringOrUndefined(record.type);
+  normalized.name = toStringOrUndefined(record.name);
+  normalized.customCSS = toStringOrUndefined(record.customCSS);
+
+  if (definition) {
+    normalized.definition = definition;
+  } else {
+    delete normalized.definition;
+  }
+
+  if (cssClasses) {
+    normalized.cssClasses = cssClasses;
+  } else {
+    delete normalized.cssClasses;
+  }
+
+  if (pageElements) {
+    normalized.pageElements = pageElements;
+  } else {
+    delete normalized.pageElements;
+  }
+
+  return normalized;
+}
+
+function asObject(value: unknown): {[key: string]: unknown} | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? ({...(value as {[key: string]: unknown})} as {[key: string]: unknown})
+    : null;
+}
+
+function toStringOrUndefined(value: unknown): string | undefined {
+  if (value == null) {
+    return undefined;
+  }
+
+  const normalized = String(value).trim();
+  return normalized === '' ? undefined : normalized;
+}
+
+function toPositiveNumber(value: unknown): number | undefined {
+  if (value == null || (typeof value === 'string' && value.trim() === '')) {
+    return undefined;
+  }
+
+  const normalized = Number(value);
+  return Number.isFinite(normalized) && normalized > 0 ? normalized : undefined;
+}
+
+function toStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  return value.filter((item): item is string => typeof item === 'string');
+}


### PR DESCRIPTION
## Summary

Phase 2 of the inventory/page-layout type-debt reduction: replaces key `Record<string, unknown>` contracts with structured typed payloads and consolidates best-effort site-page fetch helpers into a shared module.

## What Changed

**Added:**
- `src/features/liferay/page-layout/liferay-site-page-shared.ts`
  - Typed payload types: `HeadlessSitePagePayload`, `HeadlessPageDefinitionPayload`, `HeadlessPageElementPayload`, `HeadlessSitePageSettingsPayload`, `HeadlessSitePageCustomFieldPayload`, `HeadlessSitePageTaxonomyCategoryBrief`
  - Tolerant normalizer: `toHeadlessSitePagePayload(raw: unknown): HeadlessSitePagePayload | null`
  - Fetch helpers (best-effort, catch  null): `fetchHeadlessSitePage`, `fetchHeadlessSitePageElement`, `fetchHeadlessSitePageMetadata`

**Modified:**
- `liferay-page-layout-export.ts`
  - `headlessSitePage` field typed as `HeadlessSitePagePayload` (was `Record<string, unknown>`)
  - Local `fetchSitePage` removed; replaced with `fetchHeadlessSitePage` from shared module
- `liferay-inventory-page-fetch-components.ts`
  - Replaced local `fetchSitePageElement` / `tryFetchSitePageMetadata` with `fetchHeadlessSitePageElement` / `fetchHeadlessSitePageMetadata` from shared module
  - Return types promoted from `Record<string, unknown> | null` to `HeadlessPageElementPayload | null` / `HeadlessSitePagePayload | null`
- `liferay-inventory-page.ts`
  - Added explicit exported types: `InventoryPageConfigurationGeneral`, `InventoryPageConfigurationDesign`, `InventoryPageConfigurationSeo`, `InventoryPageConfigurationOpenGraph`, `InventoryPageConfigurationCustomMetaTags`, `InventoryPageConfigurationTabs`, `InventoryPageRawLayout`, `InventoryPageConfigurationRaw`
  - `configurationTabs` and `configurationRaw` in `LiferayInventoryPageResult` now use these types instead of `Record<string, unknown>`
- `liferay-inventory-page-assemble.ts`
  - `collectPageElements` parameter `pageElement` typed as `HeadlessPageElementPayload | null` (was `Record<string, unknown> | null`)
- `liferay-inventory-page-fetch.ts`
  - `pageMetadata` typed as `HeadlessSitePagePayload | null` throughout
  - `buildConfigurationRawSitePage` simplified to pass-through (avoids synthetic empty strings/arrays for absent fields  regression fix)
  - `buildRegularPageConfigurationTabs` returns `InventoryPageConfigurationTabs`
  - `buildConfigurationRawLayout` returns `InventoryPageRawLayout`

## Design Decisions

**Tolerant normalizers, not strict validators**: `toHeadlessSitePagePayload` copies unknown extra fields through via spread (`{...record}`), so future API additions do not break the parser.

**Best-effort semantics preserved**: `fetchHeadlessSitePageElement` and `fetchHeadlessSitePageMetadata` both catch all errors and return `null`, matching the original `tryFetchSitePageMetadata` behavior.

**`toHeadlessPageDefinitionPayload` does not synthesize `pageElement: null`**: when the raw payload lacks `pageElement`, the key is deleted entirely, to avoid structural diffs against reference files.

## Backward Compatibility

- No changes to public CLI API.
- No changes to JSON/NDJSON output contracts.
- Error codes and handling behavior unchanged.
- Parsing remains tolerant for partial legacy payloads.

## Validation

- `npm run typecheck`  clean
- `npm run test:unit -- tests/unit/liferay-page-layout-export.test.ts tests/unit/liferay-inventory-page.test.ts tests/unit/liferay-inventory-pages.test.ts`  811/811 passed
