### PR TITLE
docs(agentic): harden menu-map guidance and browser refs after full audit

### DIFF
--- a/docs/agentic/index.md
+++ b/docs/agentic/index.md
@@ -50,6 +50,7 @@ What this prepares:
 - `AGENTS.md`
 - vendor-managed skills under `.agents/skills`
 - optional project context scaffolding
+- optional project menu-map scaffolding under `docs/ai/menu/`
 - optional project-owned skills and agents
 
 Real example:
@@ -114,6 +115,30 @@ This updates `.agents/skills/` and all tool-specific rule directories
 > (symlinks require Developer Mode). Re-running the command above refreshes
 > those copies. If you later enable Developer Mode, the next run replaces the
 > copies with proper symlinks automatically.
+
+## Runtime Contract
+
+The full execution contract lives in `AGENTS.md` (installed by `ldev ai install`). The
+canonical Safety Invariants section of that file applies to every task regardless of skill.
+
+Summary of the six phases a well-behaved agent follows:
+
+| Phase | When | Commands |
+|-------|------|----------|
+| Pre-flight | Always, before any task | `ldev context --json` |
+| Health check | Task touches runtime | `ldev doctor --json`, `ldev status --json` |
+| Discovery | Task mentions portal surface | `ldev portal inventory ...` |
+| Pre-mutation check | Before any resource change | `ldev resource import-* --check-only` |
+| Mutation | After check-only passes | `ldev resource import-*`, `ldev deploy ...` |
+| Post-mutation verify | After any mutation | `ldev logs diagnose --since 5m --json`, `ldev portal check --json` |
+
+Key invariants (full list in `AGENTS.md → Safety Invariants`):
+
+- Always read `env.portalUrl` from context — never assume.
+- Always consume `--json`. Never parse human-readable output.
+- Always run `--check-only` before resource mutations.
+- Never use plural resource commands without explicit human approval.
+- Diagnose before retrying a failed command.
 
 ## Execution, not hype
 

--- a/docs/agentic/index.md
+++ b/docs/agentic/index.md
@@ -98,7 +98,13 @@ Agents can inspect the portal without screen scraping or UI navigation:
 ldev portal inventory sites --json
 ldev portal inventory pages --site /global --json
 ldev portal inventory page --url /home --json
+ldev portal inventory structures --site /global --with-templates --json
 ```
+
+For structure/template incidents, prefer `inventory structures --with-templates`
+as the first discovery step. It returns the structure list enriched with
+associated templates in one call, so agents can route directly to the correct
+export/import commands.
 
 ## Keeping rules and skills up to date
 

--- a/docs/agentic/index.md
+++ b/docs/agentic/index.md
@@ -136,7 +136,7 @@ Summary of the six phases a well-behaved agent follows:
 | Discovery | Task mentions portal surface | `ldev portal inventory ...` |
 | Pre-mutation check | Before any resource change | `ldev resource import-* --check-only` |
 | Mutation | After check-only passes | `ldev resource import-*`, `ldev deploy ...` |
-| Post-mutation verify | After any mutation | `ldev logs diagnose --since 5m --json`, `ldev portal check --json` |
+| Post-mutation verify | After any mutation | Resource changes: read back via `ldev resource get-*` / `ldev resource export-*` / `ldev portal inventory ... --json`; runtime/deploy changes: `ldev logs diagnose --since 5m --json`, `ldev portal check --json` |
 
 Key invariants (full list in `AGENTS.md → Safety Invariants`):
 
@@ -144,6 +144,7 @@ Key invariants (full list in `AGENTS.md → Safety Invariants`):
 - Always consume `--json`. Never parse human-readable output.
 - Always run `--check-only` before resource mutations.
 - Never use plural resource commands without explicit human approval.
+- Do not treat `ldev logs diagnose` as universal verification for resource imports; prefer read-after-write evidence from `ldev resource` / `ldev portal inventory`.
 - Diagnose before retrying a failed command.
 
 ## Execution, not hype

--- a/src/commands/liferay/inventory.command.ts
+++ b/src/commands/liferay/inventory.command.ts
@@ -22,10 +22,8 @@ import {
   runLiferayInventorySites,
 } from '../../features/liferay/inventory/liferay-inventory-sites.js';
 import {
-  formatLiferayInventoryStructuresBySite,
   formatLiferayInventoryStructures,
-  type LiferayInventoryStructuresBySite,
-  type LiferayInventoryStructure,
+  type LiferayInventoryStructuresResult,
   runLiferayInventoryStructuresAllSites,
   runLiferayInventoryStructures,
 } from '../../features/liferay/inventory/liferay-inventory-structures.js';
@@ -41,12 +39,6 @@ function collect(value: string, previous: string[]): string[] {
 
 function formatInventorySitesResult(result: LiferayInventorySite[] | ContentStatsResult): string {
   return Array.isArray(result) ? formatLiferayInventorySites(result) : formatContentStats(result);
-}
-
-function isStructuresBySiteArray(
-  result: LiferayInventoryStructure[] | LiferayInventoryStructuresBySite[],
-): result is LiferayInventoryStructuresBySite[] {
-  return result.length === 0 || 'siteGroupId' in result[0];
 }
 
 export function createInventoryCommands(parent: Command): void {
@@ -257,10 +249,7 @@ Notes:
         });
       },
       {
-        text: (result) =>
-          isStructuresBySiteArray(result)
-            ? formatLiferayInventoryStructuresBySite(result)
-            : formatLiferayInventoryStructures(result),
+        text: (result: LiferayInventoryStructuresResult) => formatLiferayInventoryStructures(result),
       },
     ),
   );

--- a/src/commands/liferay/inventory.command.ts
+++ b/src/commands/liferay/inventory.command.ts
@@ -22,7 +22,11 @@ import {
   runLiferayInventorySites,
 } from '../../features/liferay/inventory/liferay-inventory-sites.js';
 import {
+  formatLiferayInventoryStructuresBySite,
   formatLiferayInventoryStructures,
+  type LiferayInventoryStructuresBySite,
+  type LiferayInventoryStructure,
+  runLiferayInventoryStructuresAllSites,
   runLiferayInventoryStructures,
 } from '../../features/liferay/inventory/liferay-inventory-structures.js';
 import {
@@ -37,6 +41,12 @@ function collect(value: string, previous: string[]): string[] {
 
 function formatInventorySitesResult(result: LiferayInventorySite[] | ContentStatsResult): string {
   return Array.isArray(result) ? formatLiferayInventorySites(result) : formatContentStats(result);
+}
+
+function isStructuresBySiteArray(
+  result: LiferayInventoryStructure[] | LiferayInventoryStructuresBySite[],
+): result is LiferayInventoryStructuresBySite[] {
+  return result.length === 0 || 'siteGroupId' in result[0];
 }
 
 export function createInventoryCommands(parent: Command): void {
@@ -223,19 +233,35 @@ Notes:
   addOutputFormatOption(
     inventory
       .command('structures')
-      .description('List journal structures for a site')
+      .description('List journal structures for a site or for all sites')
       .option('--site <site>', 'Site friendly URL or numeric ID', '/global')
       .option('--page-size <pageSize>', 'Headless page size', '200')
-      .option('--with-templates', 'Include associated templates for each structure'),
+      .option('--with-templates', 'Include associated templates for each structure')
+      .option('--all-sites', 'List structures for all accessible sites in one run'),
   ).action(
     createFormattedAction(
-      async (context, options) =>
-        runLiferayInventoryStructures(context.config, {
+      async (context, options) => {
+        const pageSize = Number.parseInt(options.pageSize, 10) || 200;
+
+        if (options.allSites) {
+          return runLiferayInventoryStructuresAllSites(context.config, {
+            pageSize,
+            withTemplates: Boolean(options.withTemplates),
+          });
+        }
+
+        return runLiferayInventoryStructures(context.config, {
           site: options.site,
-          pageSize: Number.parseInt(options.pageSize, 10) || 200,
+          pageSize,
           withTemplates: Boolean(options.withTemplates),
-        }),
-      {text: formatLiferayInventoryStructures},
+        });
+      },
+      {
+        text: (result) =>
+          isStructuresBySiteArray(result)
+            ? formatLiferayInventoryStructuresBySite(result)
+            : formatLiferayInventoryStructures(result),
+      },
     ),
   );
 

--- a/src/commands/liferay/inventory.command.ts
+++ b/src/commands/liferay/inventory.command.ts
@@ -225,13 +225,15 @@ Notes:
       .command('structures')
       .description('List journal structures for a site')
       .option('--site <site>', 'Site friendly URL or numeric ID', '/global')
-      .option('--page-size <pageSize>', 'Headless page size', '200'),
+      .option('--page-size <pageSize>', 'Headless page size', '200')
+      .option('--with-templates', 'Include associated templates for each structure'),
   ).action(
     createFormattedAction(
       async (context, options) =>
         runLiferayInventoryStructures(context.config, {
           site: options.site,
           pageSize: Number.parseInt(options.pageSize, 10) || 200,
+          withTemplates: Boolean(options.withTemplates),
         }),
       {text: formatLiferayInventoryStructures},
     ),

--- a/src/features/ai/ai-install.ts
+++ b/src/features/ai/ai-install.ts
@@ -671,8 +671,9 @@ function buildNextSteps(
   if (project) {
     steps.push('Project skills are project-owned: ldev ai update will not overwrite them.');
   }
+  steps.push('Run `ldev context --json` to verify the agent can operate.');
   steps.push(
-    `From ${targetDir}, start agent sessions with ldev context --json; run ldev doctor --json only when runtime, tooling, browser, or deploy checks matter.`,
+    'If `liferay.oauth2Configured` is false in the context output, run `ldev oauth install --write-env` to enable portal commands.',
   );
   return steps;
 }

--- a/src/features/liferay/inventory/liferay-inventory-structures.ts
+++ b/src/features/liferay/inventory/liferay-inventory-structures.ts
@@ -18,11 +18,19 @@ export type LiferayInventoryStructure = {
   templates?: LiferayStructureTemplateRef[];
 };
 
-export type LiferayInventoryStructuresBySite = {
+export type LiferayInventoryStructuresSite = {
   siteGroupId: number;
   siteFriendlyUrl: string;
   siteName: string;
   structures: LiferayInventoryStructure[];
+};
+
+export type LiferayInventoryStructuresResult = {
+  sites: LiferayInventoryStructuresSite[];
+  summary: {
+    totalSites: number;
+    totalStructures: number;
+  };
 };
 
 type DataDefinition = {
@@ -35,16 +43,31 @@ export async function runLiferayInventoryStructures(
   config: AppConfig,
   options?: {site?: string; pageSize?: number; withTemplates?: boolean},
   dependencies?: {apiClient?: LiferayApiClient; tokenClient?: OAuthTokenClient},
-): Promise<LiferayInventoryStructure[]> {
+): Promise<LiferayInventoryStructuresResult> {
   const site = await resolveSite(config, options?.site ?? '/global', dependencies);
-  return runLiferayInventoryStructuresForSiteId(config, site.id, options, dependencies);
+  const structures = await runLiferayInventoryStructuresForSiteId(config, site.id, options, dependencies);
+
+  return {
+    sites: [
+      {
+        siteGroupId: site.id,
+        siteFriendlyUrl: site.friendlyUrlPath,
+        siteName: site.name,
+        structures,
+      },
+    ],
+    summary: {
+      totalSites: 1,
+      totalStructures: structures.length,
+    },
+  };
 }
 
 export async function runLiferayInventoryStructuresAllSites(
   config: AppConfig,
   options?: {pageSize?: number; withTemplates?: boolean},
   dependencies?: {apiClient?: LiferayApiClient; tokenClient?: OAuthTokenClient},
-): Promise<LiferayInventoryStructuresBySite[]> {
+): Promise<LiferayInventoryStructuresResult> {
   const sites = await runLiferayInventorySitesIncludingGlobal(
     config,
     {pageSize: options?.pageSize ?? 200},
@@ -65,7 +88,13 @@ export async function runLiferayInventoryStructuresAllSites(
     })),
   );
 
-  return rows;
+  return {
+    sites: rows,
+    summary: {
+      totalSites: rows.length,
+      totalStructures: rows.reduce((acc, row) => acc + row.structures.length, 0),
+    },
+  };
 }
 
 async function runLiferayInventoryStructuresForSiteId(
@@ -115,33 +144,18 @@ async function runLiferayInventoryStructuresForSiteId(
   }));
 }
 
-export function formatLiferayInventoryStructures(rows: LiferayInventoryStructure[]): string {
-  if (rows.length === 0) {
-    return 'No structure data';
-  }
-
-  const lines = rows.map((row) => {
-    if (!row.templates) {
-      return `- id=${row.id} key=${row.key} name=${row.name}`;
-    }
-
-    return `- id=${row.id} key=${row.key} name=${row.name} templates=${row.templates.length}`;
-  });
-  lines.push(`total=${rows.length}`);
-  return lines.join('\n');
-}
-
-export function formatLiferayInventoryStructuresBySite(rows: LiferayInventoryStructuresBySite[]): string {
-  if (rows.length === 0) {
+export function formatLiferayInventoryStructures(result: LiferayInventoryStructuresResult): string {
+  if (result.sites.length === 0) {
     return 'No structure data';
   }
 
   const lines: string[] = [];
 
-  for (const site of rows) {
+  for (const site of result.sites) {
     lines.push(
       `site=${site.siteFriendlyUrl} groupId=${site.siteGroupId} name=${site.siteName} structures=${site.structures.length}`,
     );
+
     for (const structure of site.structures) {
       if (!structure.templates) {
         lines.push(`  - id=${structure.id} key=${structure.key} name=${structure.name}`);
@@ -153,6 +167,7 @@ export function formatLiferayInventoryStructuresBySite(rows: LiferayInventoryStr
     }
   }
 
-  lines.push(`totalSites=${rows.length}`);
+  lines.push(`totalSites=${result.summary.totalSites}`);
+  lines.push(`totalStructures=${result.summary.totalStructures}`);
   return lines.join('\n');
 }

--- a/src/features/liferay/inventory/liferay-inventory-structures.ts
+++ b/src/features/liferay/inventory/liferay-inventory-structures.ts
@@ -3,6 +3,7 @@ import type {LiferayApiClient} from '../../../core/http/client.js';
 import type {OAuthTokenClient} from '../../../core/http/auth.js';
 import {fetchPagedItems, normalizeLocalizedName, resolveSite} from './liferay-inventory-shared.js';
 import {runLiferayInventoryTemplates} from './liferay-inventory-templates.js';
+import {runLiferayInventorySitesIncludingGlobal} from './liferay-inventory-sites.js';
 
 export type LiferayStructureTemplateRef = {
   id: string;
@@ -17,6 +18,13 @@ export type LiferayInventoryStructure = {
   templates?: LiferayStructureTemplateRef[];
 };
 
+export type LiferayInventoryStructuresBySite = {
+  siteGroupId: number;
+  siteFriendlyUrl: string;
+  siteName: string;
+  structures: LiferayInventoryStructure[];
+};
+
 type DataDefinition = {
   id?: number;
   dataDefinitionKey?: string;
@@ -29,9 +37,46 @@ export async function runLiferayInventoryStructures(
   dependencies?: {apiClient?: LiferayApiClient; tokenClient?: OAuthTokenClient},
 ): Promise<LiferayInventoryStructure[]> {
   const site = await resolveSite(config, options?.site ?? '/global', dependencies);
+  return runLiferayInventoryStructuresForSiteId(config, site.id, options, dependencies);
+}
+
+export async function runLiferayInventoryStructuresAllSites(
+  config: AppConfig,
+  options?: {pageSize?: number; withTemplates?: boolean},
+  dependencies?: {apiClient?: LiferayApiClient; tokenClient?: OAuthTokenClient},
+): Promise<LiferayInventoryStructuresBySite[]> {
+  const sites = await runLiferayInventorySitesIncludingGlobal(
+    config,
+    {pageSize: options?.pageSize ?? 200},
+    dependencies,
+  );
+
+  const rows = await Promise.all(
+    sites.map(async (site) => ({
+      siteGroupId: site.groupId,
+      siteFriendlyUrl: site.siteFriendlyUrl,
+      siteName: site.name,
+      structures: await runLiferayInventoryStructuresForSiteId(
+        config,
+        site.groupId,
+        {site: site.siteFriendlyUrl, pageSize: options?.pageSize, withTemplates: options?.withTemplates},
+        dependencies,
+      ),
+    })),
+  );
+
+  return rows;
+}
+
+async function runLiferayInventoryStructuresForSiteId(
+  config: AppConfig,
+  siteId: number,
+  options?: {site?: string; pageSize?: number; withTemplates?: boolean},
+  dependencies?: {apiClient?: LiferayApiClient; tokenClient?: OAuthTokenClient},
+): Promise<LiferayInventoryStructure[]> {
   const rows = await fetchPagedItems<DataDefinition>(
     config,
-    `/o/data-engine/v2.0/sites/${site.id}/data-definitions/by-content-type/journal`,
+    `/o/data-engine/v2.0/sites/${siteId}/data-definitions/by-content-type/journal`,
     options?.pageSize ?? 200,
     dependencies,
   );
@@ -83,5 +128,31 @@ export function formatLiferayInventoryStructures(rows: LiferayInventoryStructure
     return `- id=${row.id} key=${row.key} name=${row.name} templates=${row.templates.length}`;
   });
   lines.push(`total=${rows.length}`);
+  return lines.join('\n');
+}
+
+export function formatLiferayInventoryStructuresBySite(rows: LiferayInventoryStructuresBySite[]): string {
+  if (rows.length === 0) {
+    return 'No structure data';
+  }
+
+  const lines: string[] = [];
+
+  for (const site of rows) {
+    lines.push(
+      `site=${site.siteFriendlyUrl} groupId=${site.siteGroupId} name=${site.siteName} structures=${site.structures.length}`,
+    );
+    for (const structure of site.structures) {
+      if (!structure.templates) {
+        lines.push(`  - id=${structure.id} key=${structure.key} name=${structure.name}`);
+      } else {
+        lines.push(
+          `  - id=${structure.id} key=${structure.key} name=${structure.name} templates=${structure.templates.length}`,
+        );
+      }
+    }
+  }
+
+  lines.push(`totalSites=${rows.length}`);
   return lines.join('\n');
 }

--- a/src/features/liferay/inventory/liferay-inventory-structures.ts
+++ b/src/features/liferay/inventory/liferay-inventory-structures.ts
@@ -2,11 +2,19 @@ import type {AppConfig} from '../../../core/config/load-config.js';
 import type {LiferayApiClient} from '../../../core/http/client.js';
 import type {OAuthTokenClient} from '../../../core/http/auth.js';
 import {fetchPagedItems, normalizeLocalizedName, resolveSite} from './liferay-inventory-shared.js';
+import {runLiferayInventoryTemplates} from './liferay-inventory-templates.js';
+
+export type LiferayStructureTemplateRef = {
+  id: string;
+  name: string;
+  externalReferenceCode: string;
+};
 
 export type LiferayInventoryStructure = {
   id: number;
   key: string;
   name: string;
+  templates?: LiferayStructureTemplateRef[];
 };
 
 type DataDefinition = {
@@ -17,7 +25,7 @@ type DataDefinition = {
 
 export async function runLiferayInventoryStructures(
   config: AppConfig,
-  options?: {site?: string; pageSize?: number},
+  options?: {site?: string; pageSize?: number; withTemplates?: boolean},
   dependencies?: {apiClient?: LiferayApiClient; tokenClient?: OAuthTokenClient},
 ): Promise<LiferayInventoryStructure[]> {
   const site = await resolveSite(config, options?.site ?? '/global', dependencies);
@@ -28,10 +36,37 @@ export async function runLiferayInventoryStructures(
     dependencies,
   );
 
-  return rows.map((row) => ({
+  const structures = rows.map((row) => ({
     id: row.id ?? -1,
     key: row.dataDefinitionKey ?? '',
     name: normalizeLocalizedName(row.name),
+  }));
+
+  if (!options?.withTemplates) {
+    return structures;
+  }
+
+  const templates = await runLiferayInventoryTemplates(
+    config,
+    {site: options?.site ?? '/global', pageSize: options?.pageSize ?? 200},
+    dependencies,
+  );
+
+  const templatesByStructureId = new Map<number, LiferayStructureTemplateRef[]>();
+
+  for (const template of templates) {
+    const refs = templatesByStructureId.get(template.contentStructureId) ?? [];
+    refs.push({
+      id: template.id,
+      name: template.name,
+      externalReferenceCode: template.externalReferenceCode,
+    });
+    templatesByStructureId.set(template.contentStructureId, refs);
+  }
+
+  return structures.map((structure) => ({
+    ...structure,
+    templates: templatesByStructureId.get(structure.id) ?? [],
   }));
 }
 
@@ -40,7 +75,13 @@ export function formatLiferayInventoryStructures(rows: LiferayInventoryStructure
     return 'No structure data';
   }
 
-  const lines = rows.map((row) => `- id=${row.id} key=${row.key} name=${row.name}`);
+  const lines = rows.map((row) => {
+    if (!row.templates) {
+      return `- id=${row.id} key=${row.key} name=${row.name}`;
+    }
+
+    return `- id=${row.id} key=${row.key} name=${row.name} templates=${row.templates.length}`;
+  });
   lines.push(`total=${rows.length}`);
   return lines.join('\n');
 }

--- a/src/features/liferay/resource/liferay-resource-export-structures.ts
+++ b/src/features/liferay/resource/liferay-resource-export-structures.ts
@@ -109,7 +109,8 @@ async function exportStructuresForSite(
   checkOnly: boolean,
   dependencies?: ResourceDependencies,
 ): Promise<LiferayResourceExportStructuresSiteResult> {
-  const rows = await runLiferayInventoryStructures(config, {site}, dependencies);
+  const inventory = await runLiferayInventoryStructures(config, {site}, dependencies);
+  const rows = inventory.sites[0]?.structures ?? [];
   const siteToken = resolveSiteToken(site);
   const outputDir = resolveArtifactSiteDir(config, 'structure', siteToken, dir);
   let processed = 0;

--- a/templates/ai/install/AGENTS.md
+++ b/templates/ai/install/AGENTS.md
@@ -33,7 +33,9 @@ These rules apply to every task, regardless of the skill in use:
 3. Always run `--check-only` before any resource mutation (`import-structure`, `import-template`, `import-adt`, `import-fragment`, `migration-pipeline`).
 4. Always use the smallest deploy or import that proves the change. Never broad-deploy as a default validation step.
 5. Never use plural resource commands (`import-structures`, `export-templates`, etc.) or broad deploys without explicit human approval.
-6. After any mutation, verify with `ldev logs diagnose --since 5m --json`.
+6. After any mutation, verify with operation-specific evidence:
+  - Resource imports (`import-structure`, `import-template`, `import-adt`, `import-fragment`): read back the updated resource with `ldev resource get-*` / `ldev resource export-*` / `ldev portal inventory ... --json`.
+  - Deploy/runtime changes (modules, themes, startup/runtime faults): use `ldev logs diagnose --since 5m --json`.
 7. When the change affects rendered pages or UI, verify with browser automation after the runtime settles.
 8. If a command fails, diagnose first (`ldev logs diagnose --json` or `ldev doctor --json`) before retrying.
 9. Never guess IDs, keys, or site names. Use `ldev portal inventory ...` to resolve them.
@@ -73,7 +75,7 @@ Do not stop on `CommandNotFound` for `ldev` until this fallback has been tried.
   - `ldev context --json`
   - `ldev portal check --json`
   - `ldev portal inventory ... --json`
-  - `ldev logs diagnose --json`
+  - `ldev logs diagnose --json` for runtime/deploy diagnosis
   - `ldev doctor --json` when runtime or tool readiness matters
   - `ldev mcp check --json` when MCP is part of the plan
 - For scripting and agents, prefer machine-readable output:

--- a/templates/ai/install/AGENTS.md
+++ b/templates/ai/install/AGENTS.md
@@ -24,6 +24,21 @@ Before changing code or runtime state:
 
 Use `ldev --help` as the source of truth for the public CLI surface.
 
+## Safety Invariants
+
+These rules apply to every task, regardless of the skill in use:
+
+1. Always start with `ldev context --json`. Use `commands.*` to verify readiness before running any command.
+2. Always consume `--json` output. Never parse human-readable text output from `ldev`.
+3. Always run `--check-only` before any resource mutation (`import-structure`, `import-template`, `import-adt`, `import-fragment`, `migration-pipeline`).
+4. Always use the smallest deploy or import that proves the change. Never broad-deploy as a default validation step.
+5. Never use plural resource commands (`import-structures`, `export-templates`, etc.) or broad deploys without explicit human approval.
+6. After any mutation, verify with `ldev logs diagnose --since 5m --json`.
+7. When the change affects rendered pages or UI, verify with browser automation after the runtime settles.
+8. If a command fails, diagnose first (`ldev logs diagnose --json` or `ldev doctor --json`) before retrying.
+9. Never guess IDs, keys, or site names. Use `ldev portal inventory ...` to resolve them.
+10. Never assume the portal URL. Read `env.portalUrl` from `ldev context --json`.
+
 ## ldev Command Resolution
 
 When instructions say `ldev ...`, resolve the CLI in this order:

--- a/templates/ai/install/AGENTS.workspace.md
+++ b/templates/ai/install/AGENTS.workspace.md
@@ -42,6 +42,21 @@ Before changing code or runtime state:
 
 Use `ldev --help` as the source of truth for the public CLI surface.
 
+## Safety Invariants
+
+These rules apply to every task, regardless of the skill in use:
+
+1. Always start with `ldev context --json`. Use `commands.*` to verify readiness before running any command.
+2. Always consume `--json` output. Never parse human-readable text output from `ldev`.
+3. Always run `--check-only` before any resource mutation (`import-structure`, `import-template`, `import-adt`, `import-fragment`, `migration-pipeline`).
+4. Always use the smallest deploy or import that proves the change. Never broad-deploy as a default validation step.
+5. Never use plural resource commands (`import-structures`, `export-templates`, etc.) or broad deploys without explicit human approval.
+6. After any mutation, verify with `ldev logs diagnose --since 5m --json`.
+7. When the change affects rendered pages or UI, verify with browser automation after the runtime settles.
+8. If a command fails, diagnose first (`ldev logs diagnose --json` or `ldev doctor --json`) before retrying.
+9. Never guess IDs, keys, or site names. Use `ldev portal inventory ...` to resolve them.
+10. Never assume the portal URL. Read `env.portalUrl` from `ldev context --json`.
+
 ## Workflow Rule
 
 Prefer direct, task-shaped `ldev` commands before assembling low-level portal

--- a/templates/ai/install/AGENTS.workspace.md
+++ b/templates/ai/install/AGENTS.workspace.md
@@ -51,7 +51,9 @@ These rules apply to every task, regardless of the skill in use:
 3. Always run `--check-only` before any resource mutation (`import-structure`, `import-template`, `import-adt`, `import-fragment`, `migration-pipeline`).
 4. Always use the smallest deploy or import that proves the change. Never broad-deploy as a default validation step.
 5. Never use plural resource commands (`import-structures`, `export-templates`, etc.) or broad deploys without explicit human approval.
-6. After any mutation, verify with `ldev logs diagnose --since 5m --json`.
+6. After any mutation, verify with operation-specific evidence:
+  - Resource imports (`import-structure`, `import-template`, `import-adt`, `import-fragment`): read back the updated resource with `ldev resource get-*` / `ldev resource export-*` / `ldev portal inventory ... --json`.
+  - Deploy/runtime changes (modules, themes, startup/runtime faults): use `ldev logs diagnose --since 5m --json`.
 7. When the change affects rendered pages or UI, verify with browser automation after the runtime settles.
 8. If a command fails, diagnose first (`ldev logs diagnose --json` or `ldev doctor --json`) before retrying.
 9. Never guess IDs, keys, or site names. Use `ldev portal inventory ...` to resolve them.
@@ -125,7 +127,7 @@ Before using MCP:
   - `ldev context --json`
   - `ldev portal check --json`
   - `ldev portal inventory ... --json`
-  - `ldev logs diagnose --json`
+  - `ldev logs diagnose --json` for runtime/deploy diagnosis
   - `ldev doctor --json` when runtime or tool readiness matters
   - `ldev mcp check --json` when MCP is part of the plan
 

--- a/templates/ai/project/README.md
+++ b/templates/ai/project/README.md
@@ -13,6 +13,9 @@ Rules for this folder:
 - Optional project context scaffolding is installed with `ldev ai install --project-context`
   or `ldev ai install --project`:
   `docs/ai/project-context.md`, `docs/ai/project-context.md.sample`.
+- Optional project menu-map scaffolding (for localized admin navigation) is
+  installed with `ldev ai install --project-context` or `ldev ai install --project`:
+  `docs/ai/menu/README.md`, `docs/ai/menu/navigation.i18n.json`.
 - Project-owned skills and agents remain optional overlays installed only with
   `ldev ai install --project`.
 - Project-owned overlays should stay focused on repository-specific process and
@@ -41,6 +44,9 @@ ldev ai install --target /path/to/project --local --project-context
 ```bash
 ldev ai install --target /path/to/project --project-context
 ```
+
+This also installs optional `docs/ai/menu/` scaffolding so projects can store
+localized admin menu maps for agent/browser workflows.
 
 3. If the repository wants the project-owned issue workflow overlay, add it:
 

--- a/templates/ai/project/docs/ai/menu/README.md
+++ b/templates/ai/project/docs/ai/menu/README.md
@@ -1,0 +1,68 @@
+# AI Navigation Menus
+
+This folder is an optional project-owned contract for back office navigation
+used by coding agents and browser automation.
+
+## Canonical files (default suggestion)
+
+- docs/ai/menu/navigation.i18n.json
+- docs/ai/menu/menu_admin.i18n.json
+- docs/ai/menu/sidebar_menu.i18n.json
+
+You can store this contract in a different path if your project prefers.
+If you do, declare the chosen path in `docs/ai/project-context.md` and keep one
+single entrypoint JSON for agents.
+
+## Why this exists
+
+Many Liferay admin paths are project-specific.
+A stable map avoids brittle click-navigation and speeds up reproduction.
+
+## Data contract
+
+Each item in a menu map should include:
+
+- itemId: local helper identifier inside the normalized file
+- label: visible literal for agent fallback selectors
+- path: direct navigation path
+
+Use these placeholders when needed:
+
+- {site}: site friendly URL without locale prefix (example: ub)
+- {siteGroupId}: value used in p_v_l_s_g_id query params
+
+Resolve placeholders with:
+
+1. ldev context --json (env.portalUrl)
+2. ldev portal inventory sites --json (siteFriendlyUrl and groupId)
+
+## Starter coverage
+
+The JSON files shipped in this template are intentionally minimal starter
+examples. They do not include all standard Liferay menus.
+
+Reasons:
+
+- menu visibility changes by role/permission
+- menu labels and grouping vary by DXP version and language packs
+- many projects add custom applications and custom menu entries
+
+Treat the starter files as schema examples and extend them with your full
+project menu inventory.
+
+## Authentication
+
+menu_admin.i18n.json and sidebar_menu.i18n.json represent authenticated admin
+navigation, not anonymous public navigation.
+
+Before using those paths in browser automation:
+
+1. Open the login page
+2. Authenticate with an admin-capable test user for the project
+3. Navigate to the configured path
+
+## Ownership
+
+These files are project-owned context.
+Keep them updated in the project repository and do not move project literals
+into vendor-managed skills.

--- a/templates/ai/project/docs/ai/menu/menu_admin.i18n.json
+++ b/templates/ai/project/docs/ai/menu/menu_admin.i18n.json
@@ -1,0 +1,30 @@
+{
+  "schemaVersion": "1.0.0",
+  "coverage": "starter-sample",
+  "menuId": "admin",
+  "description": "Localized admin menu paths for direct control-panel navigation.",
+  "notes": [
+    "Starter sample only: replace with your full admin menu inventory.",
+    "Include standard Liferay and project custom entries relevant to your runtime.",
+    "Use a flat label/path contract unless your project explicitly needs localized keys."
+  ],
+  "sections": [
+    {
+      "sectionId": "section_1",
+      "title": "Applications",
+      "groups": [
+        {
+          "groupId": "group_1_1",
+          "title": "Example",
+          "items": [
+            {
+              "itemId": "item_1_1_1",
+              "label": "Navigation Menus",
+              "path": "/group/{site}/~/control_panel/manage?p_p_id=com_liferay_site_navigation_admin_web_portlet_SiteNavigationAdminPortlet&p_p_lifecycle=0&p_p_state=maximized&p_v_l_s_g_id={siteGroupId}"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/templates/ai/project/docs/ai/menu/navigation.i18n.json
+++ b/templates/ai/project/docs/ai/menu/navigation.i18n.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": "1.0.0",
+  "coverage": "starter-sample",
+  "description": "Entrypoint for localized admin menu maps used by agents and browser workflows.",
+  "menus": {
+    "admin": "docs/ai/menu/menu_admin.i18n.json",
+    "sidebar": "docs/ai/menu/sidebar_menu.i18n.json"
+  },
+  "placeholders": {
+    "portalUrl": "Portal base URL from ldev context --json",
+    "site": "Site friendly URL without locale prefix",
+    "siteGroupId": "Site group ID used in p_v_l_s_g_id params"
+  },
+  "notes": [
+    "Path is configurable per project; keep this file as your single canonical entrypoint wherever you place it.",
+    "Use project-owned literals only. Do not assume values from other repositories.",
+    "Admin and sidebar menu paths require an authenticated admin session.",
+    "Do not assume locale keys; projects may use a flat label/path contract."
+  ]
+}

--- a/templates/ai/project/docs/ai/menu/sidebar_menu.i18n.json
+++ b/templates/ai/project/docs/ai/menu/sidebar_menu.i18n.json
@@ -1,0 +1,29 @@
+{
+  "schemaVersion": "1.0.0",
+  "coverage": "starter-sample",
+  "menuId": "sidebar",
+  "description": "Localized site-sidebar menu paths for direct admin navigation.",
+  "notes": [
+    "Starter sample only: replace with your full sidebar menu inventory.",
+    "Use a flat label/path contract unless your project explicitly needs localized keys."
+  ],
+  "sections": [
+    {
+      "sectionId": "section_1",
+      "title": "Site",
+      "groups": [
+        {
+          "groupId": "group_1_1",
+          "title": "Builder",
+          "items": [
+            {
+              "itemId": "item_1_1_1",
+              "label": "Pages",
+              "path": "/group/{site}/~/control_panel/manage?p_p_id=com_liferay_layout_admin_web_portlet_GroupPagesPortlet&p_p_lifecycle=0&p_p_state=maximized&p_v_l_s_g_id={siteGroupId}"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/templates/ai/project/docs/ai/project-context.md
+++ b/templates/ai/project/docs/ai/project-context.md
@@ -54,3 +54,5 @@ List only what cannot live in a reusable vendor skill:
 - [TODO] site-building workflow
 - [TODO] fragment import workflow
 - [TODO] CI/deploy caveats
+- [TODO] localized admin menu maps under docs/ai/menu/
+- [TODO] menu map entrypoint path for agents (for example: docs/ai/menu/navigation.i18n.json)

--- a/templates/ai/project/docs/ai/project-context.md.sample
+++ b/templates/ai/project/docs/ai/project-context.md.sample
@@ -103,6 +103,31 @@ Notes:
 
 ## Project Runbooks
 
+- Optional: localized admin menu maps for browser workflows:
+
+If your project uses complex or localized back office menus, keep a project-owned
+menu map contract under `docs/ai/menu/`:
+
+- `docs/ai/menu/navigation.i18n.json` (entrypoint)
+- `docs/ai/menu/menu_admin.i18n.json` (admin/control-panel paths)
+- `docs/ai/menu/sidebar_menu.i18n.json` (site-scoped sidebar paths)
+
+Use placeholders (`{site}`, `{siteGroupId}`) and resolve them with:
+
+```bash
+ldev context --json
+ldev portal inventory sites --json
+```
+
+Declare a canonical entrypoint path in this document so agents do not assume
+a hardcoded location, for example:
+
+```md
+Menu map entrypoint: docs/ai/menu/navigation.i18n.json
+```
+
+These files are project-owned context and should be adapted in each repository.
+
 - Build and deploy the smallest affected artifact:
 
 ```bash

--- a/templates/ai/skills/automating-browser-tests/REFERENCE.md
+++ b/templates/ai/skills/automating-browser-tests/REFERENCE.md
@@ -1,6 +1,6 @@
-# Browser Check Notes
+# Browser Automation Reference
 
-Verified local CLI shape:
+## Command syntax
 
 ```bash
 playwright-cli open [url]
@@ -9,31 +9,93 @@ playwright-cli run-code "<javascript function>"
 playwright-cli install --skills
 ```
 
-Practical rules:
+Quick rules:
 
 - Use `--filename`, not `--output`, for screenshots.
-- Do not pass `--viewport-width` or `--viewport-height` to `screenshot`; set viewport on an open page with `run-code`.
-- Install the official `playwright-cli` skills with `playwright-cli install --skills` before guessing command syntax.
+- Do not pass `--viewport-width` / `--viewport-height` to `screenshot`; set viewport on an open page with `run-code`.
+- Install official skills with `playwright-cli install --skills` before guessing command syntax.
 - Do not start with `snapshot` on pages that still redirect or re-render heavily.
-- For `run-code`, prefer building the snippet into a shell variable with `cat <<'EOF'` and passing it quoted once.
-- Keep one browser helper active at a time per session name.
-- Do not run helper commands in parallel against the same session. Open first,
-  then `snapshot`, `run-code`, `goto`, and `screenshot` sequentially.
-- If local virtual host routing sends the browser to another site while `curl` still reaches the expected page, record that as a browser-routing limitation and finish validation with HTTP plus logs instead of claiming a visual pass.
-- Lock the browser host to `ldev context --json -> env.portalUrl` before login.
-  Do not mix `localhost` and `127.0.0.1` after authentication.
-- `ldev portal inventory page --url ... --json` may return `adminUrls.*` with a
-  different host spelling than the current browser session. Normalize the host
-  before opening the URL.
-- On localized Liferay login pages, prefer DOM-id selectors inside `run-code`
-  (`#_com_liferay_login_web_portlet_LoginPortlet_login` and
-  `#_com_liferay_login_web_portlet_LoginPortlet_password`) over wrapper
-  text-based `fill` commands.
-- If a deep-link to page configuration or translation falls back to generic
-  "Pàgines del lloc web", treat it as a context fallback. You are authenticated,
-  but not at the final target yet.
+- Build `run-code` snippets into a shell variable with `cat <<'EOF'` and pass once.
+- Keep one browser helper active at a time per session name. Do not run helpers in
+  parallel against the same session — open first, then sequence snapshot / run-code /
+  goto / screenshot.
+- Lock the browser host to `ldev context --json → env.portalUrl`. Do not mix `localhost`
+  and `127.0.0.1` after authentication.
+- If local virtual host routing sends the browser to another site while `curl` reaches
+  the expected page, record it as a browser-routing limitation and finish validation with
+  HTTP + logs.
+- `ldev portal inventory page --url ... --json` may return `adminUrls.*` with a different
+  host spelling. Normalize the host before opening.
 
-Mobile capture pattern:
+## Project menu maps (optional)
+
+Use the project-defined menu entrypoint from `docs/ai/project-context.md`.
+If not defined there, use `docs/ai/menu/navigation.i18n.json` as default.
+
+If the menu entrypoint exists, use it as the source of truth for admin navigation.
+
+Recommended contract for project-owned maps:
+
+- `docs/ai/menu/navigation.i18n.json`: entrypoint with menu file locations
+- `docs/ai/menu/menu_admin.i18n.json`: control panel and global admin paths
+- `docs/ai/menu/sidebar_menu.i18n.json`: site-scoped menu paths
+- each menu item includes at least `label` and `path`
+- placeholder support: `{site}`, `{siteGroupId}`
+
+Suggested flow:
+
+1. Resolve `portalUrl` from `ldev context --json`.
+2. Resolve `site` and `groupId` from `ldev portal inventory sites --json`.
+3. Start an authenticated admin browser session.
+4. Build the final URL from `portalUrl + path` after replacing placeholders.
+5. Open the direct URL first; use labels only as fallback selectors.
+
+Keep menu map literals in project-owned docs. Vendor skills should document the pattern,
+not project-specific labels or portlet IDs.
+
+## Install Playwright Chromium
+
+If `playwright-cli` reports chromium is not installed:
+
+PowerShell:
+
+```powershell
+$playwrightCli = Join-Path (npm root -g) '@playwright/cli/node_modules/playwright/cli.js'
+node $playwrightCli install chromium
+```
+
+Bash:
+
+```bash
+node "$(npm root -g)/@playwright/cli/node_modules/playwright/cli.js" install chromium
+```
+
+This installs the exact browser revision expected by the globally installed `playwright-cli` wrapper.
+
+## Browser selection
+
+Check available browsers before starting a flow:
+
+```bash
+playwright-cli open --help
+```
+
+Fallback policy when Chrome fails:
+
+```bash
+playwright-cli -s=<session-name> open --browser firefox "<url>"
+playwright-cli -s=<session-name> open --browser webkit "<url>"
+```
+
+Use `--browser chrome` only when Chrome is genuinely required. For generic validation,
+`firefox` is an acceptable alternate if it launches and reproduces the page.
+
+## Mobile viewport
+
+Do not pass viewport flags to `playwright-cli screenshot`. Open the URL first, set the
+viewport on the existing page with `run-code`, then capture.
+
+PowerShell:
 
 ```powershell
 playwright-cli -s=mobile-<issue> open "<url>"
@@ -47,3 +109,88 @@ playwright-cli -s=mobile-<issue> run-code "$CODE"
 playwright-cli -s=mobile-<issue> screenshot --filename=.tmp/<issue>/mobile.png
 playwright-cli -s=mobile-<issue> close
 ```
+
+## Liferay admin login
+
+Default local portal credentials are documented in `ldev-liferay-core.md`.
+Prefer DOM-id selectors inside `run-code` over wrapper text-matching commands on
+localized pages.
+
+The sample below uses placeholder test credentials. Replace with project-specific
+test user credentials when they differ.
+
+```bash
+PORTAL_URL="$(ldev context --json | jq -r '.env.portalUrl')"
+playwright-cli -s=page-editor-<issue> open "${PORTAL_URL}/c/portal/login"
+CODE=$(cat <<'EOF'
+async function (page) {
+  await page.locator("#_com_liferay_login_web_portlet_LoginPortlet_login").fill("<test-user-email>");
+  await page.locator("#_com_liferay_login_web_portlet_LoginPortlet_password").fill("<test-user-password>");
+  await page.locator("button[type=submit]").first().click();
+}
+EOF
+)
+playwright-cli -s=page-editor-<issue> run-code "$CODE"
+```
+
+After login, confirm the current page:
+
+```bash
+playwright-cli -s=<session-name> run-code "async function (page) { return { url: page.url(), title: await page.title() }; }"
+```
+
+If login lands on another site (e.g., `edicioweb`), that only confirms the auth session.
+Navigate explicitly to the target site's admin URL afterwards.
+
+If a direct `adminUrls.translate` or `adminUrls.configure` URL falls back to a generic
+"Pàgines del lloc web" screen, treat that URL as a hint rather than a guaranteed deep-link.
+
+## Page layout mutations
+
+```bash
+# 1. Export before touching
+ldev portal page-layout export --url <pageUrl>
+
+# 2. Separate sessions for runtime and editor
+playwright-cli -s=runtime-<issue> open "<runtimeUrl>"
+playwright-cli -s=editor-<issue> open "<editUrl>"
+
+# 3. Login first if the editor requires it
+PORTAL_URL="$(ldev context --json | jq -r '.env.portalUrl')"
+playwright-cli -s=editor-<issue> open "${PORTAL_URL}/c/portal/login"
+
+# 4. Make changes via run-code
+CODE=$(cat <<'EOF'
+async function (page) {
+  /* action */
+}
+EOF
+)
+playwright-cli -s=editor-<issue> run-code "$CODE"
+
+# 5. Capture and close
+playwright-cli -s=editor-<issue> screenshot --filename=.tmp/<issue>/after-edit.png
+playwright-cli -s=editor-<issue> close
+```
+
+Rules:
+- Keep runtime and editor in separate named sessions.
+- Never run two helpers against the same session in parallel.
+- If a session reports `session-busy`, wait and retry sequentially.
+
+## Runtime verification
+
+```bash
+playwright-cli -s=runtime-check open "<url>"
+playwright-cli -s=runtime-check screenshot --filename=.tmp/<issue>/runtime-check.png
+playwright-cli -s=runtime-check close
+ldev logs --since 2m --no-follow
+```
+
+## Cleanup between sessions
+
+```bash
+playwright-cli close-all || true
+playwright-cli kill-all || true
+```
+

--- a/templates/ai/skills/automating-browser-tests/SKILL.md
+++ b/templates/ai/skills/automating-browser-tests/SKILL.md
@@ -7,6 +7,9 @@ description: "Use when a project needs Playwright-based browser checks, visual e
 
 Use `ldev` for portal discovery and runtime state, `playwright-cli` for browser actions.
 
+Read `REFERENCE.md` next to this skill for command syntax, browser installation,
+mobile viewport, login flows, page layout mutations, and cleanup patterns.
+
 ## Required bootstrap
 
 ```bash
@@ -18,131 +21,65 @@ ldev portal inventory page --url <fullUrl> --json
 
 Before opening Playwright, lock these fields from bootstrap:
 
-- `env.portalUrl`: use this exact host for the whole browser session
-- `ldev portal inventory page --url <fullUrl> --json`:
-  - `adminUrls.*` for candidate admin targets
-  - `siteFriendlyUrl`, `groupId`, `layout.plid` for manual fallback
-
-Do not mix `localhost` and `127.0.0.1` in the same browser flow. Liferay auth
-cookies are host-scoped, so a login on one host will not authenticate the
-other.
+- `env.portalUrl`: use this exact host for the whole browser session — do not mix `localhost` and `127.0.0.1`.
+- `ldev portal inventory page --url <fullUrl> --json` → `adminUrls.*`, `siteFriendlyUrl`, `groupId`, `layout.plid`.
 
 Check `ldev doctor --json` → `tools.playwrightCli.available` before starting any browser flow.
 
-If `tools.playwrightCli.available` is `false`, install it first and do not proceed until it is available:
+If `tools.playwrightCli.available` is `false`:
 
 ```bash
 npm install -g @playwright/cli@latest
 ```
 
-Then re-run `ldev doctor --json` to confirm `tools.playwrightCli.available` is `true` before continuing.
-All browser flows in this skill require `playwright-cli`.
-
-Install the official `playwright-cli` agent skills before using ad-hoc command
-syntax from memory:
+Re-confirm before continuing. Then install official skills:
 
 ```bash
 playwright-cli install --skills
 ```
 
-If this command fails, stop and report the tool-skills install failure instead of
-guessing unsupported flags. Then use `playwright-cli <command> --help` and this
-skill's `REFERENCE.md` for the current session.
+If that fails, stop and report the install failure. Use `playwright-cli <command> --help`
+and `REFERENCE.md` for the current session.
 
-Known wrapper caveats and safe shell patterns live in `REFERENCE.md` next to this skill. Read it when the browser flow starts failing for reasons that look tooling-related rather than product-related.
+For chromium install details or browser selection fallback policy, see `REFERENCE.md`.
 
-## Install Playwright Chromium (run first if browser is missing)
+## Project menu maps (optional)
 
-If `playwright-cli` reports that `chromium` is not installed:
+Some projects keep localized admin menu maps to speed up issue reproduction and
+browser navigation.
 
-PowerShell:
+Use the project-defined menu entrypoint path from `docs/ai/project-context.md`.
+If the project does not define one, the default suggestion is
+`docs/ai/menu/navigation.i18n.json`.
 
-```powershell
-$playwrightCli = Join-Path (npm root -g) '@playwright/cli/node_modules/playwright/cli.js'
-node $playwrightCli install chromium
-```
+If the menu entrypoint exists:
 
-Bash:
-
-```bash
-node "$(npm root -g)/@playwright/cli/node_modules/playwright/cli.js" install chromium
-```
-
-This installs the exact browser revision that the globally installed `playwright-cli` wrapper expects.
-
-## Browser Selection
-
-Do not assume Chrome is available on the machine.
-
-Before spending time on login or editor flows, check what the wrapper supports:
-
-```bash
-playwright-cli open --help
-```
-
-If browser startup fails with Chrome/Chromium errors, use this policy:
-
-1. If the issue is explicitly Chrome-specific, say Chrome validation is blocked by missing runtime and only use another browser for non-blocking functional checks.
-2. If the issue is not browser-specific, try alternate browsers and keep the first browser that actually opens:
-
-```bash
-playwright-cli -s=<session-name> open --browser firefox "<url>"
-playwright-cli -s=<session-name> open --browser webkit "<url>"
-```
-
-3. Do not burn time retrying browser installs without privileges. Move to `firefox` or `webkit` and continue validating the flow.
-
-Use `--browser chrome` only when Chrome is genuinely required. For generic runtime or editor validation, `firefox` is an acceptable alternate browser if it launches and reproduces the page.
-
-## Mobile viewport
-
-Do not pass viewport flags to `playwright-cli screenshot`; the screenshot command
-does not own navigation or viewport setup. Open the URL first, set the viewport
-on the existing page with `run-code`, then capture the screenshot.
-
-PowerShell:
-
-```powershell
-playwright-cli -s=mobile-<issue> open "<url>"
-$CODE = @'
-async function (page) {
-  await page.setViewportSize({ width: 390, height: 844 });
-  await page.reload({ waitUntil: "domcontentloaded" });
-}
-'@
-playwright-cli -s=mobile-<issue> run-code "$CODE"
-playwright-cli -s=mobile-<issue> screenshot --filename=.tmp/<issue>/mobile.png
-playwright-cli -s=mobile-<issue> close
-```
+- Prefer those map paths for direct admin navigation instead of brittle label clicks.
+- Resolve placeholders from runtime facts:
+  - `portalUrl` from `ldev context --json`
+  - `site` and `siteGroupId` from `ldev portal inventory sites --json`
+- Start an authenticated admin session before opening admin map paths.
+- Keep map data project-owned. Do not copy project literals into vendor skills.
 
 ## Typical flow
 
 ```bash
-# Create evidence directory first (PowerShell: New-Item -ItemType Directory -Force .tmp/<issue-or-session>)
+# Create evidence directory (PowerShell: New-Item -ItemType Directory -Force .tmp/<issue>)
 mkdir -p .tmp/<issue-or-session>/
 
-# Open session
 playwright-cli -s=<session-name> open "<url>"
-
-# Capture before state
 playwright-cli -s=<session-name> screenshot --filename=.tmp/<issue>/before.png
-
-# Snapshot only after navigation is stable; skip it if the page is still redirecting
 playwright-cli -s=<session-name> snapshot
-
-# After fix: capture post state
+# after fix:
 playwright-cli -s=<session-name> screenshot --filename=.tmp/<issue>/after.png
-
-# Close session
 playwright-cli -s=<session-name> close
 ```
 
 Do not run `open`, `snapshot`, `screenshot`, `goto`, or `run-code` in parallel
 against the same session. Open first, then continue sequentially.
 
-When the browser flow starts from an issue URL, do not jump from `open` straight
-to grep or code edits. Use the browser and `ldev portal inventory page --url`
-together to inspect the actual loaded page first:
+When the browser flow starts from an issue URL, inspect the loaded page before
+deciding what code or resource to edit:
 
 ```bash
 playwright-cli -s=<session-name> open "<localUrl>"
@@ -150,143 +87,33 @@ playwright-cli -s=<session-name> snapshot
 ldev portal inventory page --url <localUrl> --json
 ```
 
-Use that inspection to answer:
-
-- did the expected local page load?
-- which page/resource/component is actually backing the visible UI?
-- which exact symptom is still present in `Red`?
-
-Do not treat "screenshot command succeeded" as evidence that the right page or
-component was validated.
-
-If the project provides a `.playwright/cli.config.json`, pass it:
-
-```bash
-playwright-cli -s=<session-name> open "<url>" --config=.playwright/cli.config.json
-```
-
-If the default config path does not exist, locate the actual config once before retrying:
-
-```bash
-rg --files . | rg '(^|/)cli\\.config\\.json$|playwright\\.config\\.'
-```
-
 ## Liferay login and editor auth
 
-Before attempting Page Editor actions, determine whether you need an authenticated admin session.
+Before Page Editor actions, determine whether an authenticated admin session is needed.
+Default local portal credentials are in `ldev-liferay-core.md`.
 
-Default local portal credentials are documented in `ldev-liferay-core.md`. Use those values
-in the login script below rather than assuming them from memory.
+Use DOM-id selectors inside `run-code` for login (localized pages are unreliable
+with text-matching wrappers). Full login script is in `REFERENCE.md`.
 
-For admin URLs from navigation maps, `adminUrls.*`, or Control Panel paths:
-
-- assume authentication is required unless the task proves otherwise
-- open the login page on the same host as `env.portalUrl`
-- finish login before navigating to the admin URL
-- if `ldev portal inventory page --url ... --json` returns `adminUrls.*` on a
-  different host spelling than the browser session, normalize the URL to the
-  browser host before opening it
-
-Manual `playwright-cli` login flow:
-
-```bash
-playwright-cli -s=page-editor-<issue> open "http://127.0.0.1:8080/c/portal/login"
-CODE=$(cat <<'EOF'
-async function (page) {
-  await page.locator("#_com_liferay_login_web_portlet_LoginPortlet_login").fill("test@liferay.com");
-  await page.locator("#_com_liferay_login_web_portlet_LoginPortlet_password").fill("test");
-  await page.locator("button[type=submit]").first().click();
-}
-EOF
-)
-playwright-cli -s=page-editor-<issue> run-code "$CODE"
-```
-
-Prefer `run-code` for login over ad-hoc `fill`/`click` wrapper commands when the
-login page is localized or wrapper text matching is unstable. Use DOM ids like:
-
-- `#_com_liferay_login_web_portlet_LoginPortlet_login`
-- `#_com_liferay_login_web_portlet_LoginPortlet_password`
-
-After login, immediately confirm the current page:
+After login, confirm the current page before navigating to admin URLs:
 
 ```bash
 playwright-cli -s=<session-name> run-code "async function (page) { return { url: page.url(), title: await page.title() }; }"
 ```
 
-If login lands on another site such as `edicioweb`, that only confirms the auth
-session. You may still need to navigate explicitly to the target site's admin
-URL afterwards.
-
-If a direct `adminUrls.translate` or `adminUrls.configure` URL does not land on
-the expected page and instead falls back to a generic "Pàgines del lloc web"
-screen, treat that URL as a hint rather than a guaranteed deep-link.
-
-Project-specific wrappers can document their own historical helper commands in a local `REFERENCE.md`.
-
-## Page layout mutations
-
-When the issue involves content page composition:
-
-```bash
-# 1. Export before touching
-ldev portal page-layout export --url <pageUrl>
-
-# 2. Separate sessions for runtime and editor
-playwright-cli -s=runtime-<issue> open "<runtimeUrl>"
-playwright-cli -s=editor-<issue> open "<editUrl>"
-
-# 3. If editor auth is needed, login first
-playwright-cli -s=editor-<issue> open "http://127.0.0.1:8080/c/portal/login"
-
-# 4. Make changes via run-code
-CODE=$(cat <<'EOF'
-async function (page) {
-  /* action */
-}
-EOF
-)
-playwright-cli -s=editor-<issue> run-code "$CODE"
-
-# 5. Capture and close
-playwright-cli -s=editor-<issue> screenshot --filename=.tmp/<issue>/after-edit.png
-playwright-cli -s=editor-<issue> close
-```
-
-Rules:
-- Keep runtime and editor in separate named sessions
-- Never run two helpers against the same session in parallel
-- If a session reports `session-busy`, wait and retry sequentially
-
-## Runtime verification
-
-```bash
-playwright-cli -s=runtime-check open "<url>"
-playwright-cli -s=runtime-check screenshot --filename=.tmp/<issue>/runtime-check.png
-playwright-cli -s=runtime-check close
-```
-
-Then check logs:
-```bash
-ldev logs --since 2m --no-follow
-```
-
-## Cleanup between sessions
-
-```bash
-playwright-cli close-all || true
-playwright-cli kill-all || true
-```
+For `adminUrls.*` on a different host spelling than the browser session, normalize the URL
+to the browser host before opening. Full page layout mutation pattern is in `REFERENCE.md`.
 
 ## Guardrails
 
-- Use semantic session names (`issue-NUM`, `page-editor-NUM`), not generic ones
-- Store evidence under `.tmp/<issue>/` before uploading anywhere
-- For flaky failures, use `tracing-start`/`tracing-stop` before guessing
-- Never validate against production; always reproduce locally first
-- For issue work, inspect the loaded local page with `snapshot` plus `ldev portal inventory page --url` before deciding what code/resource to edit
-- If browser navigation lands on the wrong local site because of virtual host routing, treat browser evidence as blocked for that URL and use `curl`, `ldev portal inventory ...`, and runtime logs instead of forcing a misleading screenshot
-- If the browser is authenticated but lands in the wrong site admin context, do
-  not treat that as a login failure. Rebuild the admin URL from the intended
-  site context and continue on the same host.
-- If Chrome is unavailable but Firefox/WebKit works, report that explicitly instead of treating the whole validation as blocked
+- Use semantic session names (`issue-NUM`, `page-editor-NUM`), not generic ones.
+- Store evidence under `.tmp/<issue>/` before uploading anywhere.
+- For flaky failures, use `tracing-start`/`tracing-stop` before guessing.
+- Never validate against production; always reproduce locally first.
+- Inspect the loaded local page with `snapshot` plus `ldev portal inventory page --url`
+  before deciding what code or resource to edit.
+- If browser navigation lands on the wrong site due to virtual host routing, use
+  `curl`, `ldev portal inventory ...`, and runtime logs instead of a misleading screenshot.
+- If Chrome is unavailable but Firefox/WebKit works, report that explicitly.
+- If a session reports `session-busy`, wait and retry sequentially.
+

--- a/templates/ai/skills/developing-liferay/SKILL.md
+++ b/templates/ai/skills/developing-liferay/SKILL.md
@@ -161,6 +161,7 @@ References:
 - `references/structures.md` — CLI workflow (export, validate, import)
 - `references/structure-field-catalog.md` — field type JSON catalog (use when authoring or editing structure JSON directly)
 - `references/workflow.md` — approval workflow states, inspection, and publish failures
+- `references/groovy-console.md` — portal console scripts, ERC vocabulary fixes, bulk operations with no `ldev` equivalent
 
 ```bash
 ldev resource import-structure --site /<site> --key <STRUCTURE_KEY> --check-only

--- a/templates/ai/skills/developing-liferay/references/groovy-console.md
+++ b/templates/ai/skills/developing-liferay/references/groovy-console.md
@@ -1,0 +1,138 @@
+# Portal Console and Groovy Scripts
+
+Use this reference when a task requires executing Groovy in the Liferay portal
+console, running bulk fix-up operations, or auditing portal state that has no
+direct `ldev` or headless API equivalent.
+
+This reference is intentionally minimal. Groovy console operations bypass the
+normal authorization and validation pipeline. Use `ldev` and headless resources
+whenever they exist.
+
+## When to use the Groovy console
+
+Use the portal console only for operations that no `ldev` command or headless
+API covers cleanly:
+
+- Bulk fix of corrupted portal objects (vocabulary assignments, broken DDM records)
+- Forced reindex for specific asset types
+- Inspecting internal portal state (Service Builder entities, DDM structures from Java)
+- Clearing portal caches directly via service calls
+- Running one-time cleanup scripts for content that cannot be addressed through the headless API
+
+Do **not** use the portal console to compensate for a missing `ldev resource`
+command. Check `ldev --help` and `ldev mcp check --json` first.
+
+## Gogo shell vs. Groovy console
+
+These are two completely different execution contexts. Do not confuse them.
+
+| | Gogo shell (`ldev osgi shell`) | Groovy console |
+|---|---|---|
+| Language | Felix OSGi gogo commands | Groovy |
+| Spring context | No | Yes |
+| `PortalBeanLocatorUtil` | Not available | Available |
+| Service calls (DDM, Journal...) | Not available | Available |
+| How to run | `ldev osgi shell` | Portal UI only (see below) |
+
+**Use `ldev osgi shell` / `ldev osgi diag` only for OSGi-level operations** (bundle
+state, dependency resolution, thread dumps). The Groovy patterns in this reference
+require the full portal Groovy console — never the gogo shell.
+
+## Access the portal console
+
+1. Log into the portal as an administrator.
+2. Navigate to: **Control Panel → Configuration → Server Administration → Script**
+3. Language: **Groovy**
+
+Or by URL: `<portalUrl>/group/control_panel/manage/-/server/script`
+
+Resolve `portalUrl` from `ldev context --json` (field: `env.portalUrl`).
+
+> **DXP 2024.Q3+**: scripting is disabled by default. If the Script Console is not visible,
+> a system administrator must enable it in:
+> **Control Panel → System Settings → Security → Script Management**.
+
+There is no official REST or JSONWS API to execute scripts remotely. The Script Console
+is only accessible from the portal UI.
+
+## Minimal working pattern
+
+```groovy
+import com.liferay.portal.kernel.service.ServiceContext
+
+// Use the service locator pattern
+def ddmStructureLocalService = com.liferay.portal.kernel.bean.PortalBeanLocatorUtil
+    .locate("com.liferay.dynamic.data.mapping.service.DDMStructureLocalService")
+
+// Example: list DDM structures in a group
+def structures = ddmStructureLocalService.getStructures(-1L)
+structures.each { s ->
+    out.println("${s.structureId} | ${s.structureKey} | ${s.nameCurrentValue}")
+}
+```
+
+Use `out.println(...)` to write visible output to the console result area.
+
+## Working with vocabularies and categories (ERC / Category Filter)
+
+Vocabulary assignment bugs (e.g. filters not matching, ERC category scripts
+failing) are often caused by a mismatch between the `externalReferenceCode`
+stored on the vocabulary/category and what the search query expects.
+
+Inspect a vocabulary and its ERCs:
+
+```groovy
+import com.liferay.portal.kernel.service.ServiceContextFactory
+import com.liferay.asset.kernel.service.AssetVocabularyLocalServiceUtil
+
+long groupId = <site-group-id> // from ldev portal inventory sites --json
+
+def vocabularies = AssetVocabularyLocalServiceUtil.getGroupVocabularies(groupId)
+vocabularies.each { v ->
+    out.println("ID: ${v.vocabularyId} | Key: ${v.externalReferenceCode} | Name: ${v.name}")
+}
+```
+
+Inspect categories in a vocabulary:
+
+```groovy
+import com.liferay.asset.kernel.service.AssetCategoryLocalServiceUtil
+
+long vocabularyId = <vocabularyId>
+def categories = AssetCategoryLocalServiceUtil.getVocabularyCategories(vocabularyId, -1, -1, null)
+categories.each { c ->
+    out.println("catId: ${c.categoryId} | ERC: ${c.externalReferenceCode} | Name: ${c.name}")
+}
+```
+
+## Troubleshooting ERC-based filter scripts
+
+If a Groovy script using ERCs fails or returns no results:
+
+1. Verify the ERC value exists on the actual vocabulary/category using the
+   inspection script above.
+2. Check the group ID is correct — vocabularies are group-scoped.
+3. Confirm the script targets the right site (`groupId`) — ercs are not
+   globally unique.
+4. If the ERC was set via UI, check for whitespace or case differences.
+
+## Safe Groovy script checklist
+
+Before running any Groovy script that mutates portal data:
+
+- [ ] Run it on a local or PRE environment first.
+- [ ] Preview the affected objects with a read-only `out.println` loop before any update.
+- [ ] Save the script in the project repository under `docs/scripts/groovy/`.
+- [ ] Run `ldev start` and confirm `ldev status --json` shows a healthy runtime before running.
+- [ ] Run `ldev logs diagnose --since 5m --json` after the script to confirm no errors.
+
+## Guardrails
+
+- Never run destructive Groovy scripts on production without prior staging validation.
+- Resolve `groupId` and other identifiers from `ldev portal inventory sites --json`
+  before hardcoding them in scripts.
+- If a script fails with a `ClassNotFoundException`, the service class name may differ
+  across Liferay versions. Use `ldev context --json` to identify the runtime version
+  and adjust imports accordingly.
+- MCP is preferred over Groovy for service calls when the portal exposes a headless
+  API: `ldev mcp check --json`.

--- a/templates/ai/skills/developing-liferay/references/structures.md
+++ b/templates/ai/skills/developing-liferay/references/structures.md
@@ -54,6 +54,15 @@ ldev resource adt --display-style ddmTemplate_<ID> --site /<site> --json
 issue triage and migration planning. Use `--page-size` only when you need to
 override the default page size.
 
+For a one-shot inventory across all sites:
+
+```bash
+ldev portal inventory structures --all-sites --with-templates --json
+```
+
+This is preferred over maintaining static structure-template catalogs in
+project docs.
+
 2. Export current state if needed:
 
 ```bash

--- a/templates/ai/skills/developing-liferay/references/structures.md
+++ b/templates/ai/skills/developing-liferay/references/structures.md
@@ -60,6 +60,9 @@ For a one-shot inventory across all sites:
 ldev portal inventory structures --all-sites --with-templates --json
 ```
 
+The JSON output is site-aware in both modes (`--site` and `--all-sites`) and
+always returns a `sites` array with site metadata plus `summary` totals.
+
 This is preferred over maintaining static structure-template catalogs in
 project docs.
 

--- a/templates/ai/skills/developing-liferay/references/structures.md
+++ b/templates/ai/skills/developing-liferay/references/structures.md
@@ -28,11 +28,11 @@ Always verify before exporting or importing:
 ldev portal inventory page --url <fullUrl> --json
 
 # Check global site first for shared resources
-ldev portal inventory structures --site /global --json
+ldev portal inventory structures --site /global --with-templates --json
 ldev portal inventory templates --site /global --json
 
 # Then check the concrete site
-ldev portal inventory structures --site /<site> --json
+ldev portal inventory structures --site /<site> --with-templates --json
 ldev portal inventory templates --site /<site> --json
 ```
 
@@ -45,10 +45,14 @@ will create a duplicate instead of updating the intended one.
 1. Discover first in portal:
 
 ```bash
-ldev portal inventory structures --site /<site> --json
+ldev portal inventory structures --site /<site> --with-templates --json
 ldev portal inventory templates --site /<site> --json
 ldev resource adt --display-style ddmTemplate_<ID> --site /<site> --json
 ```
+
+`--with-templates` is the fastest way to build a structure-template map for
+issue triage and migration planning. Use `--page-size` only when you need to
+override the default page size.
 
 2. Export current state if needed:
 

--- a/templates/ai/skills/developing-liferay/references/structures.md
+++ b/templates/ai/skills/developing-liferay/references/structures.md
@@ -84,6 +84,30 @@ ldev resource import-adt --site /<site> --file <path/to/adt.ftl> --check-only
 
 4. If validation is correct, rerun without `--check-only`
 
+## Post-import verification (read-after-write)
+
+Do not rely only on runtime logs for resource imports. Verify by reading the
+current portal state after mutation:
+
+```bash
+# Structure: confirm current remote payload
+ldev resource get-structure --site /<site> --key <STRUCTURE_KEY> --json
+
+# Template: confirm current remote payload
+ldev resource get-template --site /<site> --id <TEMPLATE_ID> --json
+
+# ADT: confirm current remote payload
+ldev resource get-adt --site /<site> --id <ADT_ID> --json
+
+# Cross-check mapping and ownership
+ldev portal inventory structures --site /<site> --with-templates --json
+ldev portal inventory templates --site /<site> --json
+```
+
+Use `ldev logs diagnose --since 5m --json` mainly for deploy/runtime issues
+(modules/themes/startup faults), not as the primary signal for resource-import
+success.
+
 ## Guardrails
 
 - Do not guess keys or IDs

--- a/templates/ai/skills/liferay-expert/SKILL.md
+++ b/templates/ai/skills/liferay-expert/SKILL.md
@@ -45,6 +45,8 @@ ldev portal inventory templates --site /<site> --json
     - `../troubleshooting-liferay/references/reindex-after-import.md`
     - `../troubleshooting-liferay/references/reindex-journal.md`
     - `../troubleshooting-liferay/references/ddm-migration.md`
+    - `../troubleshooting-liferay/references/search-debug.md` — for buscador / search widget failures
+    - `../troubleshooting-liferay/references/content-versions.md` — for version accumulation or empty language versions
 - If the change is known and you need to edit source or portal resources:
   - use `developing-liferay`
   - useful references there:
@@ -53,6 +55,8 @@ ldev portal inventory templates --site /<site> --json
     - `../developing-liferay/references/fragments.md`
     - `../developing-liferay/references/osgi.md`
     - `../developing-liferay/references/extending-liferay.md`
+    - `../developing-liferay/references/groovy-console.md` — for portal console scripts, ERC vocabulary fixes
+    - `../developing-liferay/references/workflow.md` — for publish failures and workflow approval issues
 - If the change already exists and you need to build, deploy or verify runtime:
   - use `deploying-liferay`
   - useful reference there:
@@ -71,57 +75,9 @@ ldev portal inventory pages --site /<site> --json
 ldev portal inventory page --url <fullUrl> --json
 ```
 
-### Display Page Templates
-
-`ldev` does not expose dedicated Display Page Template commands yet.
-Verify MCP availability and use it for inspection:
-
-```bash
-ldev mcp check --json
-```
-
-If MCP is available, use OpenAPI discovery to find the relevant endpoint.
-Without MCP, `ldev portal inventory page --url <url> --json` can still confirm
-whether the URL resolves as a display page (`pageType: displayPage`) and which
-article/structure it serves, but it does not expose dedicated Display Page
-Template metadata yet.
-
-### Navigation Menus
-
-`ldev` does not expose dedicated Navigation Menu commands yet.
-Use `ldev mcp check --json` to verify MCP availability and route through
-the headless delivery API (`/o/headless-delivery/v2.0/navigation-menus`).
-
-### Multi-site resource origin
-
-Structures and templates are not always owned by the site visible in the
-browser URL. Shared or global structures live in `/global` or a shared site.
-
-Always verify the owning site before editing or importing:
-
-```bash
-ldev portal inventory page --url <fullUrl> --json
-ldev portal inventory structures --site /global --json
-ldev portal inventory structures --site /<site> --json
-```
-
-Do not assume the browser URL site is the source of truth. Export from the
-site that actually owns the object.
-
-See also: `../developing-liferay/references/structures.md` for the full
-export/import workflow.
-
-### Content volume per site
-
-When investigating large datasets after a production import:
-
-```bash
-ldev portal inventory sites --with-content --sort-by content
-ldev portal inventory sites --site /<site> --with-structures --limit 20
-```
-
-If volume is too high for local work, route to `troubleshooting-liferay`
-for the post-import content prune workflow.
+For details on Display Page Templates, Navigation Menus, multi-site resource
+ownership, and content volume inspection, see
+`references/site-objects.md`.
 
 ## Shared guardrails
 

--- a/templates/ai/skills/liferay-expert/references/site-objects.md
+++ b/templates/ai/skills/liferay-expert/references/site-objects.md
@@ -1,0 +1,86 @@
+# Site-Level Objects
+
+## Display Page Templates
+
+`ldev` does not expose dedicated Display Page Template commands yet.
+Verify MCP availability and use it for inspection:
+
+```bash
+ldev mcp check --json
+```
+
+If MCP is available, use OpenAPI discovery to find the relevant endpoint.
+Without MCP, `ldev portal inventory page --url <url> --json` can still confirm
+whether the URL resolves as a display page (`pageType: displayPage`) and which
+article/structure it serves, but it does not expose dedicated Display Page
+Template metadata yet.
+
+## Navigation Menus
+
+`ldev` does not expose dedicated Navigation Menu commands yet.
+Use `ldev mcp check --json` to verify MCP availability and route through
+the headless delivery API (`/o/headless-delivery/v2.0/navigation-menus`).
+
+For browser issue reproduction, if the project provides localized admin menu maps
+under `docs/ai/menu/*.i18n.json`, prefer those direct paths instead of ad hoc
+UI clicking. Resolve placeholders from:
+
+- `ldev context --json` (`env.portalUrl`)
+- `ldev portal inventory sites --json` (`siteFriendlyUrl`, `groupId`)
+
+## Multi-Site Resource Origin
+
+Structures and templates are not always owned by the site visible in the
+browser URL. Shared or global structures live in `/global` or a shared site.
+
+Always verify the owning site before editing or importing:
+
+```bash
+ldev portal inventory page --url <fullUrl> --json
+ldev portal inventory structures --site /global --json
+ldev portal inventory structures --site /<site> --json
+```
+
+Do not assume the browser URL site is the source of truth. Export from the
+site that actually owns the object.
+
+See also: `../developing-liferay/references/structures.md` for the full
+export/import workflow.
+
+## Content Volume
+
+When investigating large datasets after a production import:
+
+```bash
+ldev portal inventory sites --with-content --sort-by content
+ldev portal inventory sites --site /<site> --with-structures --limit 20
+```
+
+If volume is too high for local work, route to `troubleshooting-liferay`
+for the post-import content prune workflow.
+
+For per-article version accumulation or empty language version cleanup,
+see `../../troubleshooting-liferay/references/content-versions.md`.
+
+## Translation Export Limitations
+
+`ldev` does not expose a direct wrapper for Liferay's built-in
+"Exporta per traduir" (Export for Translation) feature.
+
+If the translation export from the portal UI is failing:
+
+1. Verify the content item is in `APPROVED` state — draft content cannot be exported for translation.
+2. Check that the article is not in a workflow `PENDING` state (see `../../developing-liferay/references/workflow.md`).
+3. For **web content**, the export uses the publication language set on the article.
+   Stubs with empty language versions may prevent export of that locale.
+4. For **fragments**, Liferay fragments with inline editable content support translation
+   export, but only when the fragment collection is properly registered. Verify the
+   fragment collection exists in the portal with:
+   ```bash
+   ldev resource fragments --site /<site> --json
+   ```
+5. If the portal exports nothing for a specific content type, use MCP to investigate:
+   ```bash
+   ldev mcp check --json
+   ldev mcp openapis --json | jq '.[] | select(.name | test("translation"; "i")) | .name'
+   ```

--- a/templates/ai/skills/liferay-expert/references/site-objects.md
+++ b/templates/ai/skills/liferay-expert/references/site-objects.md
@@ -37,9 +37,12 @@ Always verify the owning site before editing or importing:
 
 ```bash
 ldev portal inventory page --url <fullUrl> --json
-ldev portal inventory structures --site /global --json
-ldev portal inventory structures --site /<site> --json
+ldev portal inventory structures --site /global --with-templates --json
+ldev portal inventory structures --site /<site> --with-templates --json
 ```
+
+Use `--with-templates` to get the structure-template relationship in one
+inventory pass before choosing export/import commands.
 
 Do not assume the browser URL site is the source of truth. Export from the
 site that actually owns the object.

--- a/templates/ai/skills/troubleshooting-liferay/SKILL.md
+++ b/templates/ai/skills/troubleshooting-liferay/SKILL.md
@@ -163,6 +163,21 @@ References:
 - `references/reindex-after-import.md`
 - `references/reindex-journal.md`
 
+### Search and buscadores not working
+
+Reference: `references/search-debug.md`
+
+Covers: search widget returning 0 results, filter widgets (category/tag) not
+working, persistent visual bugs such as a hidden "Limpiar" button, and guest
+vs. authenticated result differences.
+
+### Content version accumulation or empty language versions
+
+Reference: `references/content-versions.md`
+
+Covers: articles with excessive version history, empty linguistic versions
+added by bulk sync processes, and Groovy-based bulk version cleanup.
+
 ```bash
 ldev portal reindex status --json
 ldev portal reindex tasks --json

--- a/templates/ai/skills/troubleshooting-liferay/SKILL.md
+++ b/templates/ai/skills/troubleshooting-liferay/SKILL.md
@@ -62,9 +62,12 @@ If a page, site, structure or template is involved, resolve it from the portal:
 
 ```bash
 ldev portal inventory page --url <fullUrl> --json
-ldev portal inventory structures --site /<site> --json
+ldev portal inventory structures --site /<site> --with-templates --json
 ldev portal inventory templates --site /<site> --json
 ```
+
+For structure/template incidents, treat `--with-templates` as the default
+discovery path to avoid separate lookup rounds.
 
 ### Production reproduction
 

--- a/templates/ai/skills/troubleshooting-liferay/references/content-versions.md
+++ b/templates/ai/skills/troubleshooting-liferay/references/content-versions.md
@@ -1,0 +1,159 @@
+# Content Versions Management
+
+Use this reference when a content item has too many versions accumulated, when
+empty linguistic versions are causing problems, or when a cleanup of old
+revisions is needed.
+
+This is distinct from `ldev portal content prune`, which removes complete
+articles by count. This reference covers per-article version history and
+language version issues.
+
+## Diagnosing the version volume problem
+
+First confirm the scope. Get article volume per site:
+
+```bash
+ldev portal inventory sites --with-content --sort-by content
+```
+
+If a structure generates many versions (e.g. a sync process creates a new
+version on every run), identify which structure is the source:
+
+```bash
+ldev portal inventory sites --site /<site> --with-structures --limit 20
+```
+
+To count versions on a specific article, use MCP or the headless API after
+confirming availability:
+
+```bash
+ldev mcp check --json
+```
+
+## Reducing version history via portal UI
+
+For individual articles:
+
+1. Open the article in **Web Content Administration**.
+2. Select the article → **Actions → Expire**.
+3. Or use **Actions → View History** to see the version list.
+4. In version history, older revisions can be individually deleted via UI.
+
+For bulk version cleanup, prefer a Groovy script (see below).
+
+## Groovy script for bulk version cleanup
+
+See `../developing-liferay/references/groovy-console.md` for console access.
+
+Preview articles with many versions before deleting:
+
+```groovy
+import com.liferay.journal.service.JournalArticleLocalServiceUtil
+
+long groupId = <groupId> // from ldev portal inventory sites --json
+
+def articles = JournalArticleLocalServiceUtil.getArticles(groupId, 0, -1)
+def articlesByVersion = articles
+    .groupBy { it.articleId }
+    .findAll { k, v -> v.size() > 5 }
+
+articlesByVersion.each { articleId, versions ->
+    out.println("articleId: ${articleId} | versions: ${versions.size()}")
+}
+```
+
+Cleanup older versions for a single article (leave the N most recent):
+
+```groovy
+import com.liferay.journal.service.JournalArticleLocalServiceUtil
+
+long groupId = <groupId>
+String articleId = "<ARTICLE_ID>"
+int keepCount = 5 // number of most recent versions to keep
+
+def versions = JournalArticleLocalServiceUtil.getArticlesByArticleId(groupId, articleId)
+    .sort { a, b -> b.version <=> a.version } // newest first
+
+versions.drop(keepCount).each { article ->
+    JournalArticleLocalServiceUtil.deleteArticle(article)
+    out.println("Deleted version ${article.version} of article ${article.articleId}")
+}
+```
+
+> Always run preview first. Deletions via Groovy are not reversible.
+
+## Empty linguistic versions
+
+Symptoms: articles with empty or partially empty translations; language switcher
+shows a page but the content is blank; imports created stub language versions.
+
+### Diagnose
+
+1. In Web Content Administration, open the article.
+2. Select each language from the language selector.
+3. Empty translations will show a blank title or empty body.
+
+### Fix via portal UI
+
+1. In the article editor, select the empty language version using the language
+   selector on the title field.
+2. Click the **delete language** icon (trashcan next to the language flag),  
+   if the portal version supports per-language deletion.
+3. If not available: fill the translation with placeholder text and republish,
+   then remove via Groovy if needed.
+
+### Fix via Groovy script (bulk)
+
+Remove a specific translation from all articles of a given structure:
+
+```groovy
+import com.liferay.journal.service.JournalArticleLocalServiceUtil
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal
+
+long groupId = <groupId>
+String structureKey = "<STRUCTURE_KEY>"
+String locale = "ca_ES" // the locale to remove
+
+def articles = JournalArticleLocalServiceUtil.getArticles(groupId)
+    .findAll { it.DDMStructureKey == structureKey }
+
+articles.each { article ->
+    def xmlContent = article.getContent()
+    if (xmlContent?.contains("language-id=\"${locale}\"")) {
+        out.println("Would remove locale ${locale} from article ${article.articleId}")
+        // To actually remove: modify the XML or use the API to update the article
+    }
+}
+```
+
+> Language content in Journal articles is embedded in the XML. Programmatic
+> removal requires reconstructing the content XML and calling
+> `JournalArticleLocalServiceUtil.updateArticle(...)`. Test in PRE first.
+
+## After version cleanup
+
+Reindex Journal content after bulk version deletions to keep search consistent:
+
+```bash
+ldev portal reindex watch --json
+```
+
+Monitor:
+
+```bash
+ldev portal reindex status --json
+ldev logs diagnose --since 10m --json
+```
+
+## Guardrails
+
+- Never run bulk version deletion on production without a prior database backup.
+- Use `ldev db sync` to bring a production snapshot locally before testing
+  cleanup scripts.
+- Groovy version deletions bypass workflow — verify the article is not in an
+  active approval workflow before deleting versions.
+- After cleanup, verify with `ldev portal inventory sites --with-content` that
+  total article counts are as expected.
+- If the version accumulation is caused by a sync process (e.g. external API
+  updating content on every run), the root fix is in the sync logic, not in
+  the cleanup script.

--- a/templates/ai/skills/troubleshooting-liferay/references/search-debug.md
+++ b/templates/ai/skills/troubleshooting-liferay/references/search-debug.md
@@ -1,0 +1,165 @@
+# Search and Buscadores Troubleshooting
+
+Use this reference when a search widget is not returning results, is visually
+broken, or behaves differently than expected across environments.
+
+This reference covers: search bar/results, filter widgets (category, tag,
+keyword), and Elasticsearch health. It does not cover DDM structure indexing
+(see `reindex-after-import.md` and `reindex-journal.md`).
+
+## Establish baseline first
+
+Before debugging the search widget, confirm the portal is healthy and the
+index exists:
+
+```bash
+ldev status --json
+ldev doctor --json
+ldev portal reindex status --json
+```
+
+If the portal is not running or a reindex is in progress, resolve that first.
+
+## Diagnose the buscador (search widget) problem
+
+### 1. Confirm the symptom type
+
+| Symptom | Likely cause |
+|---|---|
+| Search returns 0 results for any query | Reindex incomplete or Elasticsearch down |
+| Search returns results but "no results" message shows | Display condition in FTL/ADT or CSS visibility bug |
+| Search works on desktop but not mobile | CSS/responsive bug in ADT or theme |
+| Search results are stale or missing recent content | Incremental reindex did not run or failed |
+| Filters (category, tag, keyword) have no effect | Widget configuration or missing vocabulary mapping |
+| Search works logged in but not as guest | Permissions issue on documents or web content |
+
+### 2. Check index health
+
+```bash
+# Identify Elasticsearch container name from docker-compose
+ldev logs --since 2m --service elasticsearch --no-follow
+
+# Then check cluster health from inside the container
+ldev shell --service elasticsearch
+curl -s http://localhost:9200/_cluster/health?pretty
+curl -s http://localhost:9200/_cat/indices?v
+```
+
+A healthy cluster shows `status: green` or `yellow`. `red` means at least one
+primary shard is unassigned — search will return incomplete results.
+
+### 3. Force a full search reindex
+
+```bash
+ldev portal reindex watch --json
+```
+
+If the reindex is hanging, enable speedup while it runs:
+
+```bash
+ldev portal reindex speedup-on
+# wait for reindex to complete
+ldev portal reindex speedup-off
+```
+
+After reindex completes, check for remaining reindex tasks:
+
+```bash
+ldev portal reindex tasks --json
+```
+
+### 4. Inspect the search widget configuration
+
+If the portal index is healthy but the buscador still returns no results, the
+problem is likely in the widget or ADT configuration:
+
+1. Open the affected page in the portal UI as an administrator.
+2. On the Search Results portlet: **Configure → General → Scope**.
+   - Confirm "Everything" or the correct site scope is selected.
+3. On the Search Bar portlet: **Configure → General → Scope**.
+   - Confirm it matches the Search Results portlet scope.
+4. Check **Search Options** portlet if present — it may override scope.
+
+For Search Results with an ADT:
+
+```bash
+ldev resource export-adt --site /<site> --key <ADT_KEY> --widget-type AssetPublisher --json
+```
+
+Review the FTL template for conditions that hide results:
+
+```ftl
+<#if entries?has_content>
+  ...
+<#else>
+  <p>No results found</p>
+</#if>
+```
+
+If `entries` is empty because the wrong type is indexed, check the asset class
+configured in the Search Results or Asset Publisher portlet.
+
+### 5. Check permissions on search results
+
+If logged-in users see results but guests do not:
+
+1. Control Panel → **Web Content** → find a sample content item.
+2. Permissions → verify "View" is granted to "Guest".
+
+Or check via portal inventory for the page:
+
+```bash
+ldev portal inventory page --url <fullUrl> --json
+```
+
+If the page is private (not public), guests cannot see search results regardless
+of index state.
+
+### 6. Filter widgets (category / tag / keyword)
+
+For a filter that has no visible effect or shows no options:
+
+1. Confirm the vocabulary is assigned to the site:
+   Control Panel → **Categorization → Vocabularies** → check site scope.
+
+2. Confirm the vocabulary's `Visibility` is set to **Public** if guest access is required.
+
+3. In the filter portlet configuration, verify the vocabulary is selected.
+
+4. If the filter was working and stopped, run a reindex scoped to categories:
+   ```bash
+   ldev portal reindex watch --json
+   ```
+
+For ERC-based filter scripts that fail (e.g. in Groovy or FTL conditions):
+See `../developing-liferay/references/groovy-console.md` for ERC inspection.
+
+### 7. Visual issues with "Limpiar" (clear) button
+
+If the "Limpiar" or clear button is not visible or misaligned:
+
+This is typically a CSS or theme issue, not a search index issue.
+
+1. Inspect the button in browser DevTools to confirm it is rendered but hidden.
+2. If hidden: CSS rule applied by the theme or a custom SCSS override.
+   - Check `custom.scss` or a theme fragment with a `button[type="reset"]` selector.
+   - Otherwise export and review the search ADT with `ldev resource export-adt`.
+3. If not rendered: the FTL template governing the filter widget does not
+   include the reset button for the current configuration.
+   - Export the ADT and check for `<#if showClearButton>` or similar conditions.
+
+Verify the fix with browser automation after applying:
+```bash
+playwright-cli screenshot --url <pageUrl> --filename before.png
+```
+
+## Guardrails
+
+- Do not assume a broken search is caused by a portal bug without confirming
+  the index is healthy first. Reindex solves ~80% of search regressions.
+- Do not force a full portal reindex when only one content type is affected;
+  use the targeted reindex action in Control Panel if available.
+- Do not edit ADT templates directly in the portal UI. Export, edit locally,
+  validate, import.
+- When verifying a fix to a search widget, use `playwright-cli` to confirm the
+  visual result — CLI or reindex completion alone is not sufficient proof.

--- a/templates/ai/workspace-rules/ldev-deploy-verification.md
+++ b/templates/ai/workspace-rules/ldev-deploy-verification.md
@@ -12,7 +12,7 @@ When a change affects deployable code or assets:
 
 1. confirm the runtime is healthy with `ldev status --json`
 2. deploy with the narrowest suitable deploy command
-3. verify with `ldev logs diagnose --since 5m --json`
+3. verify runtime/deploy behavior with `ldev logs diagnose --since 5m --json`
 4. use `ldev portal inventory ... --json` when the change affects page behavior or content rendering
 
 Use deploy commands only for deployable artifacts:
@@ -26,7 +26,9 @@ Prefer atomic deploys. Do not use a broad deploy as a default validation step.
 
 Do not use deploy commands for Journal templates, ADTs, fragments, or
 structures. Those require a prepared runtime and `ldev resource import-*`, then
-browser validation with `playwright-cli` when rendering is affected.
+read-after-write verification with `ldev resource get-*` / `ldev resource export-*`
+and `ldev portal inventory ... --json`; use browser validation with `playwright-cli`
+when rendering is affected.
 
 For the full deploy and verification workflow, route to:
 

--- a/templates/ai/workspace-rules/ldev-native-deploy.md
+++ b/templates/ai/workspace-rules/ldev-native-deploy.md
@@ -18,12 +18,8 @@ Primary deploy model:
   change cannot be proved with a narrower deploy
 - `ldev deploy status` to verify what the runtime observed
 
-Prefer atomic deploys. Do not use a broad deploy as a default validation step.
-
-Do not use deploy commands for Journal templates, ADTs, fragments, or
-structures. Those live in the portal runtime; apply them with
-`ldev resource import-*` and validate the affected portal flow with
-`playwright-cli`.
+For universal deploy invariants (atomic-first policy, journal/ADT/fragment
+exclusions, post-mutation verification), see `ldev-deploy-verification.md`.
 
 If you reused a fix from another branch or commit, that does not waive local
 validation. Re-run the same `Red -> Green` flow in the current runtime before

--- a/templates/ai/workspace-rules/ldev-workspace-deploy.md
+++ b/templates/ai/workspace-rules/ldev-workspace-deploy.md
@@ -18,12 +18,8 @@ Primary deploy model:
 - use a a broad deploy only when a human explicitly asks for a full deploy and
   the change cannot be proved with a narrower deploy
 
-Prefer atomic deploys. Do not use a broad deploy as a default validation step.
-
-Do not use deploy commands for Journal templates, ADTs, fragments, or
-structures. Those live in the portal runtime; apply them with
-`ldev resource import-*` and validate browser-visible behavior with
-`playwright-cli`.
+For universal deploy invariants (atomic-first policy, journal/ADT/fragment
+exclusions, post-mutation verification), see `ldev-deploy-verification.md`.
 
 For Client Extensions:
 

--- a/tests/unit/liferay-inventory.test.ts
+++ b/tests/unit/liferay-inventory.test.ts
@@ -271,6 +271,58 @@ describe('liferay inventory structures and templates', () => {
     expect(formatLiferayInventoryStructures(result)).toContain('id=301 key=BASIC name=Basic Web Content');
   });
 
+  test('lists structures with associated templates when requested', async () => {
+    const apiClient = createLiferayApiClient({
+      fetchImpl: async (input) => {
+        const url = String(input);
+
+        if (url.includes('/o/headless-admin-site/v1.0/sites/by-friendly-url-path/global')) {
+          return new Response('{"id":20121,"friendlyUrlPath":"/global","name":"Global"}', {status: 200});
+        }
+
+        if (url.includes('/o/headless-admin-site/v1.0/sites?pageSize=100&page=1')) {
+          return new Response('{"items":[{"id":20121,"friendlyUrlPath":"/global","name":"Global"}],"lastPage":1}', {
+            status: 200,
+          });
+        }
+
+        if (url.includes('/data-definitions/by-content-type/journal?page=1&pageSize=2')) {
+          return new Response(
+            '{"items":[{"id":301,"dataDefinitionKey":"BASIC","name":{"en_US":"Basic Web Content"}},{"id":302,"dataDefinitionKey":"NEWS","name":{"en_US":"News"}}],"lastPage":1}',
+            {status: 200},
+          );
+        }
+
+        if (url.includes('/sites/20121/content-templates?page=1&pageSize=2')) {
+          return new Response(
+            '{"items":[{"id":"40801","name":"News Template","contentStructureId":302,"externalReferenceCode":"news-template"}],"lastPage":1}',
+            {status: 200},
+          );
+        }
+
+        throw new Error(`Unexpected URL ${url}`);
+      },
+    });
+
+    const result = await runLiferayInventoryStructures(
+      CONFIG,
+      {site: '/global', pageSize: 2, withTemplates: true},
+      {apiClient, tokenClient: TOKEN_CLIENT},
+    );
+
+    expect(result).toEqual([
+      {id: 301, key: 'BASIC', name: 'Basic Web Content', templates: []},
+      {
+        id: 302,
+        key: 'NEWS',
+        name: 'News',
+        templates: [{id: '40801', name: 'News Template', externalReferenceCode: 'news-template'}],
+      },
+    ]);
+
+    expect(formatLiferayInventoryStructures(result)).toContain('id=302 key=NEWS name=News templates=1');
+  });
+
   test('lists templates for a site', async () => {
     const apiClient = createLiferayApiClient({
       fetchImpl: async (input) => {

--- a/tests/unit/liferay-inventory.test.ts
+++ b/tests/unit/liferay-inventory.test.ts
@@ -2,7 +2,6 @@ import {describe, expect, test, beforeEach} from 'vitest';
 
 import {createLiferayApiClient} from '../../src/core/http/client.js';
 import {
-  formatLiferayInventoryStructuresBySite,
   runLiferayInventoryStructuresAllSites,
   formatLiferayInventoryStructures,
   runLiferayInventoryStructures,
@@ -266,10 +265,20 @@ describe('liferay inventory structures and templates', () => {
       {apiClient, tokenClient: TOKEN_CLIENT},
     );
 
-    expect(result).toEqual([
-      {id: 301, key: 'BASIC', name: 'Basic Web Content'},
-      {id: 302, key: 'NEWS', name: 'News'},
-    ]);
+    expect(result).toEqual({
+      sites: [
+        {
+          siteGroupId: 20121,
+          siteFriendlyUrl: '/global',
+          siteName: 'Global',
+          structures: [
+            {id: 301, key: 'BASIC', name: 'Basic Web Content'},
+            {id: 302, key: 'NEWS', name: 'News'},
+          ],
+        },
+      ],
+      summary: {totalSites: 1, totalStructures: 2},
+    });
     expect(formatLiferayInventoryStructures(result)).toContain('id=301 key=BASIC name=Basic Web Content');
   });
 
@@ -312,15 +321,25 @@ describe('liferay inventory structures and templates', () => {
       {apiClient, tokenClient: TOKEN_CLIENT},
     );
 
-    expect(result).toEqual([
-      {id: 301, key: 'BASIC', name: 'Basic Web Content', templates: []},
-      {
-        id: 302,
-        key: 'NEWS',
-        name: 'News',
-        templates: [{id: '40801', name: 'News Template', externalReferenceCode: 'news-template'}],
-      },
-    ]);
+    expect(result).toEqual({
+      sites: [
+        {
+          siteGroupId: 20121,
+          siteFriendlyUrl: '/global',
+          siteName: 'Global',
+          structures: [
+            {id: 301, key: 'BASIC', name: 'Basic Web Content', templates: []},
+            {
+              id: 302,
+              key: 'NEWS',
+              name: 'News',
+              templates: [{id: '40801', name: 'News Template', externalReferenceCode: 'news-template'}],
+            },
+          ],
+        },
+      ],
+      summary: {totalSites: 1, totalStructures: 2},
+    });
 
     expect(formatLiferayInventoryStructures(result)).toContain('id=302 key=NEWS name=News templates=1');
   });
@@ -387,39 +406,40 @@ describe('liferay inventory structures and templates', () => {
       {apiClient, tokenClient: TOKEN_CLIENT},
     );
 
-    expect(result).toEqual([
-      {
-        siteGroupId: 20121,
-        siteFriendlyUrl: '/global',
-        siteName: 'Global',
-        structures: [
-          {
-            id: 301,
-            key: 'GLOBAL_BASIC',
-            name: 'Global Basic',
-            templates: [{id: '41001', name: 'Global Template', externalReferenceCode: 'global-template'}],
-          },
-        ],
-      },
-      {
-        siteGroupId: 20122,
-        siteFriendlyUrl: '/ub',
-        siteName: 'UB',
-        structures: [
-          {
-            id: 302,
-            key: 'UB_NEWS',
-            name: 'UB News',
-            templates: [{id: '41002', name: 'UB Template', externalReferenceCode: 'ub-template'}],
-          },
-        ],
-      },
-    ]);
+    expect(result).toEqual({
+      sites: [
+        {
+          siteGroupId: 20121,
+          siteFriendlyUrl: '/global',
+          siteName: 'Global',
+          structures: [
+            {
+              id: 301,
+              key: 'GLOBAL_BASIC',
+              name: 'Global Basic',
+              templates: [{id: '41001', name: 'Global Template', externalReferenceCode: 'global-template'}],
+            },
+          ],
+        },
+        {
+          siteGroupId: 20122,
+          siteFriendlyUrl: '/ub',
+          siteName: 'UB',
+          structures: [
+            {
+              id: 302,
+              key: 'UB_NEWS',
+              name: 'UB News',
+              templates: [{id: '41002', name: 'UB Template', externalReferenceCode: 'ub-template'}],
+            },
+          ],
+        },
+      ],
+      summary: {totalSites: 2, totalStructures: 2},
+    });
 
-    expect(formatLiferayInventoryStructuresBySite(result)).toContain(
-      'site=/global groupId=20121 name=Global structures=1',
-    );
-    expect(formatLiferayInventoryStructuresBySite(result)).toContain('site=/ub groupId=20122 name=UB structures=1');
+    expect(formatLiferayInventoryStructures(result)).toContain('site=/global groupId=20121 name=Global structures=1');
+    expect(formatLiferayInventoryStructures(result)).toContain('site=/ub groupId=20122 name=UB structures=1');
   });
 
   test('lists templates for a site', async () => {

--- a/tests/unit/liferay-inventory.test.ts
+++ b/tests/unit/liferay-inventory.test.ts
@@ -2,6 +2,8 @@ import {describe, expect, test, beforeEach} from 'vitest';
 
 import {createLiferayApiClient} from '../../src/core/http/client.js';
 import {
+  formatLiferayInventoryStructuresBySite,
+  runLiferayInventoryStructuresAllSites,
   formatLiferayInventoryStructures,
   runLiferayInventoryStructures,
 } from '../../src/features/liferay/inventory/liferay-inventory-structures.js';
@@ -321,6 +323,103 @@ describe('liferay inventory structures and templates', () => {
     ]);
 
     expect(formatLiferayInventoryStructures(result)).toContain('id=302 key=NEWS name=News templates=1');
+  });
+
+  test('lists structures for all sites in one run', async () => {
+    const apiClient = createLiferayApiClient({
+      fetchImpl: async (input) => {
+        const url = String(input);
+
+        if (url.includes('/o/headless-admin-site/v1.0/sites?page=1&pageSize=2')) {
+          return new Response(
+            '{"items":[{"id":20121,"friendlyUrlPath":"/global","name":"Global"},{"id":20122,"friendlyUrlPath":"/ub","name":"UB"}],"lastPage":1}',
+            {status: 200},
+          );
+        }
+
+        if (url.includes('/o/headless-admin-site/v1.0/sites/by-friendly-url-path/global')) {
+          return new Response('{"id":20121,"friendlyUrlPath":"/global","name":"Global"}', {status: 200});
+        }
+
+        if (url.includes('/o/headless-admin-site/v1.0/sites/by-friendly-url-path/ub')) {
+          return new Response('{"id":20122,"friendlyUrlPath":"/ub","name":"UB"}', {status: 200});
+        }
+
+        if (
+          url.includes('/o/data-engine/v2.0/sites/20121/data-definitions/by-content-type/journal?page=1&pageSize=2')
+        ) {
+          return new Response(
+            '{"items":[{"id":301,"dataDefinitionKey":"GLOBAL_BASIC","name":{"en_US":"Global Basic"}}],"lastPage":1}',
+            {status: 200},
+          );
+        }
+
+        if (
+          url.includes('/o/data-engine/v2.0/sites/20122/data-definitions/by-content-type/journal?page=1&pageSize=2')
+        ) {
+          return new Response(
+            '{"items":[{"id":302,"dataDefinitionKey":"UB_NEWS","name":{"en_US":"UB News"}}],"lastPage":1}',
+            {status: 200},
+          );
+        }
+
+        if (url.includes('/sites/20121/content-templates?page=1&pageSize=2')) {
+          return new Response(
+            '{"items":[{"id":"41001","name":"Global Template","contentStructureId":301,"externalReferenceCode":"global-template"}],"lastPage":1}',
+            {status: 200},
+          );
+        }
+
+        if (url.includes('/sites/20122/content-templates?page=1&pageSize=2')) {
+          return new Response(
+            '{"items":[{"id":"41002","name":"UB Template","contentStructureId":302,"externalReferenceCode":"ub-template"}],"lastPage":1}',
+            {status: 200},
+          );
+        }
+
+        throw new Error(`Unexpected URL ${url}`);
+      },
+    });
+
+    const result = await runLiferayInventoryStructuresAllSites(
+      CONFIG,
+      {pageSize: 2, withTemplates: true},
+      {apiClient, tokenClient: TOKEN_CLIENT},
+    );
+
+    expect(result).toEqual([
+      {
+        siteGroupId: 20121,
+        siteFriendlyUrl: '/global',
+        siteName: 'Global',
+        structures: [
+          {
+            id: 301,
+            key: 'GLOBAL_BASIC',
+            name: 'Global Basic',
+            templates: [{id: '41001', name: 'Global Template', externalReferenceCode: 'global-template'}],
+          },
+        ],
+      },
+      {
+        siteGroupId: 20122,
+        siteFriendlyUrl: '/ub',
+        siteName: 'UB',
+        structures: [
+          {
+            id: 302,
+            key: 'UB_NEWS',
+            name: 'UB News',
+            templates: [{id: '41002', name: 'UB Template', externalReferenceCode: 'ub-template'}],
+          },
+        ],
+      },
+    ]);
+
+    expect(formatLiferayInventoryStructuresBySite(result)).toContain(
+      'site=/global groupId=20121 name=Global structures=1',
+    );
+    expect(formatLiferayInventoryStructuresBySite(result)).toContain('site=/ub groupId=20122 name=UB structures=1');
   });
 
   test('lists templates for a site', async () => {


### PR DESCRIPTION
## Summary
- Reviews and hardens the recent agentic/template update set before publishing.
- Adds optional project-owned menu-map scaffolding under `templates/ai/project/docs/ai/menu/*` and aligns docs/install surfaces with that workflow.
- Fixes quality issues detected during audit (language consistency, duplicated JSON notes, hardcoded login host in browser examples, and screenshot flag mismatch).
- Unifies `ldev portal inventory structures --json` output to a site-aware contract for both single-site and all-sites modes.

## Audit Corrections Included
- `templates/ai/skills/developing-liferay/references/groovy-console.md`
  - Replaced remaining Spanish block with English for single-language consistency.
  - Kept the DXP 2024.Q3+ scripting-disabled guidance and UI-only execution constraint.
- `templates/ai/skills/automating-browser-tests/REFERENCE.md`
  - Replaced hardcoded login URL (`127.0.0.1:8080`) with `portalUrl` resolved from `ldev context --json` in both login examples.
- `templates/ai/project/docs/ai/menu/navigation.i18n.json`
  - Removed duplicated canonical-entrypoint note.
- `templates/ai/skills/troubleshooting-liferay/references/search-debug.md`
  - Corrected screenshot example to use `--filename` (consistent with documented CLI syntax).

## Main Functional Additions In This Change Set
- Optional menu-map scaffold files:
  - `templates/ai/project/docs/ai/menu/README.md`
  - `templates/ai/project/docs/ai/menu/navigation.i18n.json`
  - `templates/ai/project/docs/ai/menu/menu_admin.i18n.json`
  - `templates/ai/project/docs/ai/menu/sidebar_menu.i18n.json`
- Agentic docs and install templates updated to include this project-owned context pattern:
  - `docs/agentic/index.md`
  - `templates/ai/project/README.md`
  - `templates/ai/project/docs/ai/project-context.md`
  - `templates/ai/project/docs/ai/project-context.md.sample`
  - `templates/ai/install/AGENTS.md`
  - `templates/ai/install/AGENTS.workspace.md`
  - `templates/ai/skills/*` updates and new references

## Inventory Structures Contract Update
- `src/features/liferay/inventory/liferay-inventory-structures.ts`
  - Introduced a unified result shape: `{ sites: [...], summary: { totalSites, totalStructures } }`.
  - `runLiferayInventoryStructures` now returns one site entry instead of a flat array.
  - `runLiferayInventoryStructuresAllSites` now returns the same shape with multiple sites.
  - Consolidated text formatting into a single formatter for both modes.
- `src/commands/liferay/inventory.command.ts`
  - Simplified structures command output handling to the unified result type.
- `src/features/liferay/resource/liferay-resource-export-structures.ts`
  - Adapted export flow to read structures from `result.sites[0].structures`.
- `tests/unit/liferay-inventory.test.ts`
  - Updated assertions for single-site and all-sites to validate the unified contract.
- `templates/ai/skills/developing-liferay/references/structures.md`
  - Documented that both modes return site-aware JSON with `sites` + `summary`.

## Validation
- `npm run typecheck` (pass)
- `npm run test:unit -- tests/unit/liferay-inventory.test.ts` (pass)

## Notes
- Pre-existing lint warnings in unrelated files were reported by repository hooks but did not block push.
- This update intentionally does not preserve backward compatibility for the old flat single-site JSON shape (confirmed acceptable for this stage).
