### PR TITLE
refactor: deliver P1-P5 (tests + oauth/env decomposition + process error helper)

### DIFF
--- a/src/core/platform/process.ts
+++ b/src/core/platform/process.ts
@@ -76,6 +76,10 @@ export function resolveSpawnCommand(command: string, env?: NodeJS.ProcessEnv): s
   return command;
 }
 
+export function formatProcessError(result: RunProcessResult, fallback: string): string {
+  return result.stderr.trim() || result.stdout.trim() || fallback;
+}
+
 export async function runProcess(
   command: string,
   args: string[] = [],

--- a/src/features/agent/agent-context.ts
+++ b/src/features/agent/agent-context.ts
@@ -1,4 +1,4 @@
-import type {AppConfig} from '../../core/config/load-config.js';
+﻿import type {AppConfig} from '../../core/config/load-config.js';
 import type {ProjectContext} from '../../core/config/project-context.js';
 import {resolveProjectContext} from '../../core/config/project-context.js';
 import type {PlatformCapabilities} from '../../core/platform/capabilities.js';
@@ -6,7 +6,7 @@ import {detectCapabilities} from '../../core/platform/capabilities.js';
 import {getCurrentBranchName, getGitCommonDir, isWorktree} from '../../core/platform/git.js';
 import {runProcess} from '../../core/platform/process.js';
 import {collectEnvStatus} from '../env/env-health.js';
-import {resolveEnvContext} from '../env/env-files.js';
+import {resolveEnvContext} from '../env/env-shared.js';
 import {runAiStatus} from '../ai/ai-status.js';
 import {runAgentCapabilities, type AgentCapabilitiesReport} from './agent-capabilities.js';
 

--- a/src/features/db/db-download.ts
+++ b/src/features/db/db-download.ts
@@ -1,4 +1,4 @@
-import fs from 'fs-extra';
+﻿import fs from 'fs-extra';
 import path from 'node:path';
 
 import {CliError} from '../../core/errors.js';
@@ -6,7 +6,7 @@ import type {AppConfig} from '../../core/config/load-config.js';
 import {readEnvFile} from '../../core/config/env-file.js';
 import type {Printer} from '../../core/output/printer.js';
 import {withProgress} from '../../core/output/printer.js';
-import {runProcess} from '../../core/platform/process.js';
+import {formatProcessError, runProcess} from '../../core/platform/process.js';
 
 export type DbDownloadResult = {
   ok: true;
@@ -145,7 +145,7 @@ async function ensureDatabaseBackup(
       {reject: false},
     );
     if (!result.ok) {
-      throw new CliError(result.stderr.trim() || result.stdout.trim() || 'lcp backup download --database', {
+      throw new CliError(formatProcessError(result, 'lcp backup download --database'), {
         code: 'DB_LCP_BACKUP_DOWNLOAD_FAILED',
       });
     }

--- a/src/features/db/db-files-download.ts
+++ b/src/features/db/db-files-download.ts
@@ -1,4 +1,4 @@
-import fs from 'fs-extra';
+﻿import fs from 'fs-extra';
 import path from 'node:path';
 import {spawn} from 'node:child_process';
 
@@ -9,7 +9,7 @@ import type {AppConfig} from '../../core/config/load-config.js';
 import {readEnvFile, upsertEnvFileValues} from '../../core/config/env-file.js';
 import type {Printer} from '../../core/output/printer.js';
 import {runStep} from '../../core/output/run-step.js';
-import {normalizeProcessEnv, runProcess} from '../../core/platform/process.js';
+import {formatProcessError, normalizeProcessEnv, runProcess} from '../../core/platform/process.js';
 
 export type DbFilesDownloadResult = {
   ok: true;
@@ -165,7 +165,7 @@ async function ensureDoclibBackup(options: {
       {reject: false},
     );
     if (!result.ok) {
-      throw new CliError(result.stderr.trim() || result.stdout.trim() || 'lcp backup download --doclib', {
+      throw new CliError(formatProcessError(result, 'lcp backup download --doclib'), {
         code: 'DB_LCP_DOCLIB_DOWNLOAD_FAILED',
       });
     }

--- a/src/features/db/db-files-mount.ts
+++ b/src/features/db/db-files-mount.ts
@@ -1,4 +1,4 @@
-import fs from 'fs-extra';
+﻿import fs from 'fs-extra';
 import path from 'node:path';
 
 import {CliError} from '../../core/errors.js';
@@ -6,7 +6,8 @@ import type {AppConfig} from '../../core/config/load-config.js';
 import {readEnvFile, upsertEnvFileValues} from '../../core/config/env-file.js';
 import type {Printer} from '../../core/output/printer.js';
 import {runDocker} from '../../core/platform/docker.js';
-import {resolveEnvContext, resolveDataRoot} from '../env/env-files.js';
+import {formatProcessError} from '../../core/platform/process.js';
+import {resolveEnvContext, resolveDataRoot} from '../env/env-shared.js';
 
 export type DbFilesMountResult = {
   ok: true;
@@ -145,7 +146,7 @@ async function createLocalBindVolume(volume: string, localPath: string): Promise
     {reject: false},
   );
   if (!result.ok) {
-    throw new CliError(result.stderr.trim() || result.stdout.trim() || `Could not create volume ${volume}`, {
+    throw new CliError(formatProcessError(result, `Could not create volume ${volume}`), {
       code: 'DB_DOCLIB_VOLUME_ERROR',
     });
   }
@@ -178,7 +179,7 @@ async function createNasVolume(
     {reject: false},
   );
   if (!result.ok) {
-    throw new CliError(result.stderr.trim() || result.stdout.trim() || `Could not create CIFS volume ${volume}`, {
+    throw new CliError(formatProcessError(result, `Could not create CIFS volume ${volume}`), {
       code: 'DB_DOCLIB_VOLUME_ERROR',
     });
   }

--- a/src/features/db/db-import.ts
+++ b/src/features/db/db-import.ts
@@ -1,4 +1,4 @@
-import fs from 'fs-extra';
+﻿import fs from 'fs-extra';
 import path from 'node:path';
 import {createGunzip} from 'node:zlib';
 import {pipeline} from 'node:stream/promises';
@@ -13,8 +13,8 @@ import {runStep} from '../../core/output/run-step.js';
 import {detectCapabilities} from '../../core/platform/capabilities.js';
 import {runDocker, runDockerCompose, runDockerComposeOrThrow} from '../../core/platform/docker.js';
 import {removePathRobust} from '../../core/platform/fs.js';
-import {normalizeProcessEnv} from '../../core/platform/process.js';
-import {buildComposeEnv, ensureEnvDataLayout, resolveEnvContext, resolvePostgresStorage} from '../env/env-files.js';
+import {formatProcessError, normalizeProcessEnv} from '../../core/platform/process.js';
+import {buildComposeEnv, ensureEnvDataLayout, resolveEnvContext, resolvePostgresStorage} from '../env/env-shared.js';
 
 export type DbImportResult = {
   ok: true;
@@ -129,7 +129,7 @@ async function resolvePostImportFiles(dockerDir: string): Promise<string[]> {
     .sort((left, right) => path.basename(left).localeCompare(path.basename(right)));
 }
 
-async function resolveBackupFile(dockerDir: string, explicitFile?: string): Promise<string> {
+export async function resolveBackupFile(dockerDir: string, explicitFile?: string): Promise<string> {
   if (explicitFile && explicitFile.trim() !== '') {
     const candidate = path.resolve(explicitFile);
     if (!(await fs.pathExists(candidate))) {
@@ -150,7 +150,7 @@ async function resolveBackupFile(dockerDir: string, explicitFile?: string): Prom
   return candidates[0].file;
 }
 
-async function findBackupFiles(root: string): Promise<Array<{file: string; mtimeMs: number}>> {
+export async function findBackupFiles(root: string): Promise<Array<{file: string; mtimeMs: number}>> {
   if (!(await fs.pathExists(root))) {
     return [];
   }
@@ -215,7 +215,7 @@ async function hasDirectoryContents(directory: string, processEnv?: NodeJS.Proce
   );
 
   if (!result.ok) {
-    throw new CliError(result.stderr.trim() || result.stdout.trim() || `Could not inspect ${directory}`, {
+    throw new CliError(formatProcessError(result, `Could not inspect ${directory}`), {
       code: 'DB_IMPORT_POSTGRES_CHECK_FAILED',
     });
   }
@@ -263,16 +263,17 @@ async function waitForPostgresReady(
   }
 }
 
-async function streamSqlIntoPostgres(
+export async function streamSqlIntoPostgres(
   dockerDir: string,
   sqlFile: string,
   envValues: Record<string, string>,
   processEnv?: NodeJS.ProcessEnv,
+  spawnFn: typeof spawn = spawn,
 ): Promise<void> {
   const user = envValues.POSTGRES_USER || 'liferay';
   const db = envValues.POSTGRES_DB || 'liferay';
   const normalizedEnv = normalizeProcessEnv(processEnv);
-  const child = spawn('docker', ['compose', 'exec', '-T', 'postgres', 'psql', '-U', user, '-d', db], {
+  const child = spawnFn('docker', ['compose', 'exec', '-T', 'postgres', 'psql', '-U', user, '-d', db], {
     cwd: dockerDir,
     env: normalizedEnv,
     shell: process.platform === 'win32',
@@ -301,7 +302,7 @@ async function streamSqlIntoPostgres(
   } catch (error) {
     // EPIPE / ERR_STREAM_PREMATURE_CLOSE: the child closed its stdin before we
     // finished writing (e.g. fake docker in tests or a quick psql exit).
-    // This is expected — wait for the actual exit code rather than aborting.
+    // This is expected â€” wait for the actual exit code rather than aborting.
     const errorCode = error instanceof Error ? (error as NodeJS.ErrnoException).code : undefined;
     const isExpected = errorCode === 'EPIPE' || errorCode === 'ERR_STREAM_PREMATURE_CLOSE';
     if (!isExpected) {

--- a/src/features/db/db-query.ts
+++ b/src/features/db/db-query.ts
@@ -1,10 +1,10 @@
-import fs from 'fs-extra';
+﻿import fs from 'fs-extra';
 
 import {CliError} from '../../core/errors.js';
 import type {AppConfig} from '../../core/config/load-config.js';
 import {runDockerComposeOrThrow} from '../../core/platform/docker.js';
 
-import {resolveEnvContext} from '../env/env-files.js';
+import {resolveEnvContext} from '../env/env-shared.js';
 
 export type DbQueryResult = {
   ok: true;

--- a/src/features/deploy/deploy-cache.ts
+++ b/src/features/deploy/deploy-cache.ts
@@ -1,11 +1,12 @@
-import path from 'node:path';
+﻿import path from 'node:path';
 
 import fs from 'fs-extra';
 
 import {CliError} from '../../core/errors.js';
 import type {AppConfig} from '../../core/config/load-config.js';
 import {runDocker} from '../../core/platform/docker.js';
-import {resolveEnvContext, resolveRuntimeStorage, type RuntimeStorage} from '../env/env-files.js';
+import {formatProcessError} from '../../core/platform/process.js';
+import {resolveEnvContext, resolveRuntimeStorage, type RuntimeStorage} from '../env/env-shared.js';
 import {listDeployArtifacts, syncArtifactsToDirectory, escapeSingleQuotes} from './deploy-artifacts.js';
 import {writePrepareCommit, readPrepareCommit, currentArtifactCommit, type DeployContext} from './deploy-gradle.js';
 
@@ -128,7 +129,7 @@ async function syncCachedArtifactsToBuildDeploy(
     {reject: false},
   );
   if (!result.ok) {
-    throw new CliError(result.stderr.trim() || result.stdout.trim() || 'Could not restore deploy cache artifacts.', {
+    throw new CliError(formatProcessError(result, 'Could not restore deploy cache artifacts.'), {
       code: 'DEPLOY_ARTIFACTS_NOT_FOUND',
     });
   }
@@ -157,7 +158,7 @@ async function syncBuildArtifactsToCachedStorage(
     {reject: false},
   );
   if (!result.ok) {
-    throw new CliError(result.stderr.trim() || result.stdout.trim() || 'Could not update deploy cache.', {
+    throw new CliError(formatProcessError(result, 'Could not update deploy cache.'), {
       code: 'DEPLOY_ARTIFACTS_NOT_FOUND',
     });
   }
@@ -210,7 +211,7 @@ async function writeCachedPrepareCommit(storage: RuntimeStorage, commit: string)
     {reject: false},
   );
   if (!result.ok) {
-    throw new CliError(result.stderr.trim() || result.stdout.trim() || 'Could not write deploy cache commit.', {
+    throw new CliError(formatProcessError(result, 'Could not write deploy cache commit.'), {
       code: 'DEPLOY_ARTIFACTS_NOT_FOUND',
     });
   }
@@ -240,7 +241,7 @@ async function clearCachedDeployArtifacts(storage: RuntimeStorage): Promise<void
     {reject: false},
   );
   if (!result.ok) {
-    throw new CliError(result.stderr.trim() || result.stdout.trim() || 'Could not clear deploy cache.', {
+    throw new CliError(formatProcessError(result, 'Could not clear deploy cache.'), {
       code: 'DEPLOY_ARTIFACTS_NOT_FOUND',
     });
   }
@@ -253,12 +254,9 @@ async function ensureStorageVolume(storage: RuntimeStorage): Promise<void> {
 
   const result = await runDocker(['volume', 'create', storage.volumeName], {reject: false});
   if (!result.ok) {
-    throw new CliError(
-      result.stderr.trim() || result.stdout.trim() || `Could not create volume ${storage.volumeName}`,
-      {
-        code: 'DEPLOY_ARTIFACTS_NOT_FOUND',
-      },
-    );
+    throw new CliError(formatProcessError(result, `Could not create volume ${storage.volumeName}`), {
+      code: 'DEPLOY_ARTIFACTS_NOT_FOUND',
+    });
   }
 }
 

--- a/src/features/deploy/deploy-gradle.ts
+++ b/src/features/deploy/deploy-gradle.ts
@@ -1,4 +1,4 @@
-import path from 'node:path';
+﻿import path from 'node:path';
 
 import fs from 'fs-extra';
 
@@ -6,7 +6,7 @@ import {CliError} from '../../core/errors.js';
 import type {AppConfig} from '../../core/config/load-config.js';
 import type {Printer} from '../../core/output/printer.js';
 import {withProgress} from '../../core/output/printer.js';
-import {runProcess} from '../../core/platform/process.js';
+import {formatProcessError, runProcess} from '../../core/platform/process.js';
 
 export type DeployContext = {
   repoRoot: string;
@@ -56,7 +56,7 @@ export async function runDeployStep<T>(printer: Printer | undefined, label: stri
 export async function runGradleTask(context: DeployContext, args: string[]): Promise<void> {
   const result = await runProcess(context.gradlewPath, ['--console=plain', ...args], {cwd: context.liferayDir});
   if (!result.ok) {
-    throw new CliError(result.stderr.trim() || result.stdout.trim() || `${context.gradlewPath} ${args.join(' ')}`, {
+    throw new CliError(formatProcessError(result, `${context.gradlewPath} ${args.join(' ')}`), {
       code: 'DEPLOY_GRADLE_ERROR',
     });
   }
@@ -65,7 +65,7 @@ export async function runGradleTask(context: DeployContext, args: string[]): Pro
 export async function resolveHeadCommit(repoRoot: string): Promise<string> {
   const result = await runProcess('git', ['rev-parse', 'HEAD'], {cwd: repoRoot});
   if (!result.ok) {
-    throw new CliError(result.stderr.trim() || result.stdout.trim() || 'git rev-parse HEAD', {
+    throw new CliError(formatProcessError(result, 'git rev-parse HEAD'), {
       code: 'GIT_ERROR',
     });
   }

--- a/src/features/deploy/deploy-hot.ts
+++ b/src/features/deploy/deploy-hot.ts
@@ -1,8 +1,9 @@
-import path from 'node:path';
+﻿import path from 'node:path';
 
 import type {AppConfig} from '../../core/config/load-config.js';
 import {runDocker, runDockerCompose} from '../../core/platform/docker.js';
-import {buildComposeEnv, resolveEnvContext} from '../env/env-files.js';
+import {formatProcessError} from '../../core/platform/process.js';
+import {buildComposeEnv, resolveEnvContext} from '../env/env-shared.js';
 import {escapeShellArg, uniquePaths} from './deploy-artifacts.js';
 
 const DEPLOY_TARGET_DIR = '/opt/liferay/deploy';
@@ -44,7 +45,7 @@ export async function hotDeployArtifactsToRunningLiferay(
     if (result.ok) {
       copied += 1;
     } else {
-      failures.push(result.stderr.trim() || result.stdout.trim() || `could not copy ${fileName}`);
+      failures.push(formatProcessError(result, `could not copy ${fileName}`));
     }
   }
 

--- a/src/features/deploy/deploy-prepare.ts
+++ b/src/features/deploy/deploy-prepare.ts
@@ -1,8 +1,8 @@
-import {CliError} from '../../core/errors.js';
+﻿import {CliError} from '../../core/errors.js';
 import type {AppConfig} from '../../core/config/load-config.js';
 import type {Printer} from '../../core/output/printer.js';
 import {collectEnvStatus} from '../env/env-health.js';
-import {resolveEnvContext} from '../env/env-files.js';
+import {resolveEnvContext} from '../env/env-shared.js';
 import {
   ensureGradleWrapper,
   resolveDeployContext,

--- a/src/features/env/env-restore.ts
+++ b/src/features/env/env-restore.ts
@@ -1,4 +1,4 @@
-import path from 'node:path';
+﻿import path from 'node:path';
 
 import fs from 'fs-extra';
 
@@ -8,7 +8,7 @@ import type {Printer} from '../../core/output/printer.js';
 import {withProgress} from '../../core/output/printer.js';
 import {runDocker, runDockerCompose} from '../../core/platform/docker.js';
 import {removePathRobust} from '../../core/platform/fs.js';
-import {runProcess} from '../../core/platform/process.js';
+import {formatProcessError, runProcess} from '../../core/platform/process.js';
 import {resolveDeployContext, restoreArtifactsFromDeployCache} from '../deploy/deploy-shared.js';
 import {buildComposeEnv, resolvePostgresStorage} from './env-files.js';
 import {resolveBtrfsConfig} from '../worktree/worktree-state.js';
@@ -153,7 +153,7 @@ async function restoreDataSubdir(sourceDir: string, targetDir: string, processEn
     {env: processEnv, reject: false},
   );
   if (!result.ok) {
-    throw new Error(result.stderr.trim() || result.stdout.trim() || `Could not restore ${sourceDir}`);
+    throw new Error(formatProcessError(result, `Could not restore ${sourceDir}`));
   }
 }
 
@@ -207,7 +207,7 @@ async function restorePostgresStorage(
     {env: processEnv, reject: false},
   );
   if (!result.ok) {
-    throw new Error(result.stderr.trim() || result.stdout.trim() || 'Could not restore PostgreSQL storage');
+    throw new Error(formatProcessError(result, 'Could not restore PostgreSQL storage'));
   }
 
   return true;

--- a/src/features/env/env-shared.ts
+++ b/src/features/env/env-shared.ts
@@ -1,0 +1,17 @@
+export {
+  buildComposeEnv,
+  buildComposeFilesEnv,
+  ensureDoclibVolume,
+  ensureEnvDataLayout,
+  ensureEnvFile,
+  resolveDataRoot,
+  resolveEnvContext,
+  resolveManagedStorages,
+  resolvePostgresStorage,
+  resolveRuntimeStorage,
+  seedBuildDockerConfigs,
+  type EnvContext,
+  type PostgresStorage,
+  type RuntimeStorage,
+  type RuntimeStorageKey,
+} from './env-files.js';

--- a/src/features/health/health.ts
+++ b/src/features/health/health.ts
@@ -1,11 +1,11 @@
-import os from 'node:os';
+﻿import os from 'node:os';
 
 import type {AppConfig} from '../../core/config/load-config.js';
 import {measureHttpLatency} from '../../core/http/latency.js';
 import {runProcess} from '../../core/platform/process.js';
 import {parseLines} from '../../core/utils/text.js';
 import {collectEnvStatus} from '../env/env-health.js';
-import {resolveEnvContext} from '../env/env-files.js';
+import {resolveEnvContext} from '../env/env-shared.js';
 
 export type HealthResult = {
   ok: true;

--- a/src/features/oauth/oauth-install-bundle.ts
+++ b/src/features/oauth/oauth-install-bundle.ts
@@ -1,0 +1,165 @@
+import {fileURLToPath} from 'node:url';
+import path from 'node:path';
+
+import fs from 'fs-extra';
+
+import {CliError} from '../../core/errors.js';
+import type {AppConfig} from '../../core/config/load-config.js';
+import type {Printer} from '../../core/output/printer.js';
+import {withProgress} from '../../core/output/printer.js';
+import {resolveEnvContext} from '../env/env-files.js';
+
+const BUNDLE_FILE_NAME = 'dev.mordonez.ldev.oauth2.app-1.0.0.jar';
+
+export async function deployBundledOAuthInstallerJar(config: AppConfig, printer?: Printer): Promise<string> {
+  const bundleSourceFile = resolveBundledOAuthInstallerJar();
+  const bundleTargetFiles = resolveOAuthBundleDeployFiles(config);
+
+  for (const bundleTargetFile of bundleTargetFiles) {
+    await deployBundledOAuthInstaller(bundleSourceFile, bundleTargetFile, printer);
+  }
+
+  return bundleTargetFiles[0];
+}
+
+export function buildOAuthInstallerConfig(options: {
+  enabled: boolean;
+  externalReferenceCode: string;
+  appName: string;
+  clientId: string;
+  clientSecret: string;
+  rotateClientSecret: boolean;
+  scopeAliases: string[];
+  companyId?: number;
+  userId?: number;
+}): string {
+  const lines = [
+    `enabled=B"${String(options.enabled)}"`,
+    `externalReferenceCode=${quoteOsgiConfigValue(options.externalReferenceCode)}`,
+    `appName=${quoteOsgiConfigValue(options.appName)}`,
+    `clientId=${quoteOsgiConfigValue(options.clientId)}`,
+    `clientSecret=${quoteOsgiConfigValue(options.clientSecret)}`,
+    `rotateClientSecret=B"${String(options.rotateClientSecret)}"`,
+    `scopeAliases=${quoteOsgiConfigStringArray(options.scopeAliases)}`,
+  ];
+
+  if (options.companyId && options.companyId > 0) {
+    lines.push(`companyId=L"${options.companyId}"`);
+  }
+
+  if (options.userId && options.userId > 0) {
+    lines.push(`userId=L"${options.userId}"`);
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+export async function writeOAuthInstallerOsgiConfig(
+  config: AppConfig,
+  options: {
+    enabled: boolean;
+    externalReferenceCode: string;
+    appName: string;
+    clientId: string;
+    clientSecret: string;
+    rotateClientSecret: boolean;
+    scopeAliases: string[];
+    companyId?: number;
+    userId?: number;
+  },
+): Promise<void> {
+  const fileName = 'dev.mordonez.ldev.oauth2.app.configuration.LdevOAuth2AppConfiguration.config';
+  const content = buildOAuthInstallerConfig(options);
+
+  for (const targetFile of resolveOAuthInstallerConfigFiles(config, fileName)) {
+    await fs.ensureDir(path.dirname(targetFile));
+    await fs.writeFile(targetFile, content, 'utf8');
+  }
+}
+
+async function deployBundledOAuthInstaller(sourceFile: string, targetFile: string, printer?: Printer): Promise<void> {
+  const deploy = async () => {
+    await fs.ensureDir(path.dirname(targetFile));
+    await fs.copy(sourceFile, targetFile, {overwrite: true});
+  };
+
+  if (printer) {
+    await withProgress(printer, 'Deploying bundled OAuth installer', deploy);
+    return;
+  }
+
+  await deploy();
+}
+
+function resolveOAuthBundleDeployFiles(config: AppConfig): string[] {
+  if (config.dockerDir && config.liferayDir && config.repoRoot) {
+    const envContext = resolveEnvContext(config);
+    return [path.join(envContext.repoRoot, 'liferay', 'build', 'docker', 'deploy', BUNDLE_FILE_NAME)];
+  }
+
+  if (config.repoRoot) {
+    return [
+      path.join(config.repoRoot, 'bundles', 'deploy', BUNDLE_FILE_NAME),
+      path.join(config.repoRoot, 'configs', 'local', 'deploy', BUNDLE_FILE_NAME),
+    ];
+  }
+
+  throw new CliError('Could not resolve the deploy directory for the OAuth installer bundle.', {
+    code: 'OAUTH_INSTALL_DEPLOY_DIR_NOT_FOUND',
+  });
+}
+
+function resolveOAuthInstallerConfigFiles(config: AppConfig, fileName: string): string[] {
+  if (config.dockerDir && config.liferayDir && config.repoRoot) {
+    return [
+      path.join(config.liferayDir, 'configs', 'dockerenv', 'osgi', 'configs', fileName),
+      path.join(config.liferayDir, 'build', 'docker', 'configs', 'dockerenv', 'osgi', 'configs', fileName),
+    ];
+  }
+
+  if (config.repoRoot) {
+    return [
+      path.join(config.repoRoot, 'configs', 'local', 'osgi', 'configs', fileName),
+      path.join(config.repoRoot, 'bundles', 'osgi', 'configs', fileName),
+    ];
+  }
+
+  return [];
+}
+
+function resolveBundledOAuthInstallerJar(): string {
+  const packageRoot = findPackageRoot(fileURLToPath(import.meta.url));
+  const filePath = path.join(packageRoot, 'templates', 'bundles', BUNDLE_FILE_NAME);
+
+  if (!fs.existsSync(filePath)) {
+    throw new CliError(`Bundled OAuth installer not found: ${filePath}`, {
+      code: 'OAUTH_INSTALL_BUNDLE_NOT_FOUND',
+    });
+  }
+
+  return filePath;
+}
+
+function findPackageRoot(fromFile: string): string {
+  let current = path.dirname(fromFile);
+
+  while (true) {
+    if (fs.existsSync(path.join(current, 'package.json')) && fs.existsSync(path.join(current, 'templates'))) {
+      return current;
+    }
+
+    const parent = path.dirname(current);
+    if (parent === current) {
+      throw new Error(`Could not resolve the ldev package root from ${fromFile}`);
+    }
+    current = parent;
+  }
+}
+
+function quoteOsgiConfigValue(value: string): string {
+  return `"${value.replaceAll('\\', '\\\\').replaceAll('"', '\\"')}"`;
+}
+
+function quoteOsgiConfigStringArray(values: string[]): string {
+  return `[${values.map(quoteOsgiConfigValue).join(',')}]`;
+}

--- a/src/features/oauth/oauth-install-gogo.ts
+++ b/src/features/oauth/oauth-install-gogo.ts
@@ -1,0 +1,88 @@
+import {setTimeout as delay} from 'node:timers/promises';
+
+import {CliError} from '../../core/errors.js';
+import type {AppConfig} from '../../core/config/load-config.js';
+import {runGogoCommand} from '../osgi/osgi-shared.js';
+
+export async function executeOAuthInstallerCommand(
+  config: AppConfig,
+  command: string,
+  successPredicate: (output: string) => boolean,
+): Promise<string> {
+  let lastOutput = '';
+
+  for (let attempt = 1; attempt <= 12; attempt++) {
+    const output = await runGogoCommand(config, command, process.env);
+    lastOutput = output;
+
+    if (output.includes('CommandNotFoundException')) {
+      await delay(2000);
+      continue;
+    }
+
+    if (output.includes('Unrecognized client authentication method')) {
+      throw new CliError(
+        'OAuth installer bundle is deployed, but the portal rejected the client authentication method.',
+        {
+          code: 'OAUTH_INSTALL_CLIENT_AUTH_METHOD',
+        },
+      );
+    }
+
+    if (output.includes('PortalException:')) {
+      throw new CliError(output.trim(), {
+        code: 'OAUTH_INSTALL_FAILED',
+      });
+    }
+
+    if (successPredicate(output)) {
+      return output;
+    }
+
+    await delay(2000);
+  }
+
+  throw new CliError(lastOutput.trim() || 'OAuth installer command did not become available in Gogo.', {
+    code: 'OAUTH_INSTALL_GOGO_UNAVAILABLE',
+  });
+}
+
+export function buildOAuthInstallGogoCommand(companyId?: number, userId?: number): string {
+  return buildGogoCommand(companyId, userId);
+}
+
+export function parseKeyValueOutput(output: string): Record<string, string> {
+  const values: Record<string, string> = {};
+
+  for (const rawLine of output.split(/\r?\n/)) {
+    const trimmedLine = rawLine.trim();
+    if (
+      !trimmedLine.includes('=') ||
+      trimmedLine.startsWith('Trying ') ||
+      trimmedLine.startsWith('Connected') ||
+      trimmedLine.startsWith('Escape character')
+    ) {
+      continue;
+    }
+
+    const line = trimmedLine.startsWith('g! ') ? trimmedLine.slice(3).trim() : trimmedLine;
+    const separatorIndex = line.indexOf('=');
+    const key = line.slice(0, separatorIndex).trim();
+    const value = line.slice(separatorIndex + 1).trim();
+    values[key] = value;
+  }
+
+  return values;
+}
+
+function buildGogoCommand(companyId?: number, userId?: number): string {
+  if (companyId && userId) {
+    return `ldev:oauthInstall ${companyId} ${userId}`;
+  }
+
+  if (companyId) {
+    return `ldev:oauthInstall ${companyId}`;
+  }
+
+  return 'ldev:oauthInstall';
+}

--- a/src/features/oauth/oauth-install-verify.ts
+++ b/src/features/oauth/oauth-install-verify.ts
@@ -1,0 +1,74 @@
+import {createOAuthTokenClient} from '../../core/http/auth.js';
+import type {AppConfig} from '../../core/config/load-config.js';
+import type {OAuthInstallResult} from './oauth-install.js';
+
+export async function verifyProvisionedOAuthInstall(
+  config: AppConfig,
+  credentials: {
+    clientId: string;
+    clientSecret: string;
+  },
+): Promise<OAuthInstallResult['verification']> {
+  if (!config.liferay.url || config.liferay.url.trim() === '') {
+    return {
+      attempted: false,
+      verified: false,
+      sanitized: false,
+      tokenType: null,
+      expiresIn: null,
+      error: null,
+    };
+  }
+
+  try {
+    const tokenClient = createOAuthTokenClient({
+      invalidClientRetryDelayMs: 3000,
+      invalidClientMaxWaitMs: 30000,
+    });
+    const token = await tokenClient.fetchClientCredentialsToken({
+      ...config.liferay,
+      oauth2ClientId: credentials.clientId,
+      oauth2ClientSecret: credentials.clientSecret,
+    });
+
+    return {
+      attempted: true,
+      verified: true,
+      sanitized: false,
+      tokenType: token.tokenType,
+      expiresIn: token.expiresIn,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      attempted: true,
+      verified: false,
+      sanitized: false,
+      tokenType: null,
+      expiresIn: null,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+export function shouldSanitizeProvisionedOAuthConfig(verification: OAuthInstallResult['verification']): boolean {
+  if (verification.verified) {
+    return true;
+  }
+
+  if (!verification.attempted || !verification.error) {
+    return false;
+  }
+
+  const normalized = verification.error.toLowerCase();
+
+  return normalized.includes('token request failed (');
+}
+
+export function shouldPersistProvisionedOAuthCredentials(verification: OAuthInstallResult['verification']): boolean {
+  if (verification.verified || !verification.attempted) {
+    return true;
+  }
+
+  return Boolean(verification.error) && !shouldSanitizeProvisionedOAuthConfig(verification);
+}

--- a/src/features/oauth/oauth-install.ts
+++ b/src/features/oauth/oauth-install.ts
@@ -1,27 +1,24 @@
-import {randomUUID} from 'node:crypto';
-import {fileURLToPath} from 'node:url';
+﻿import {randomUUID} from 'node:crypto';
 import path from 'node:path';
-import {setTimeout as delay} from 'node:timers/promises';
-
-import fs from 'fs-extra';
 
 import {CliError} from '../../core/errors.js';
 import type {AppConfig} from '../../core/config/load-config.js';
 import {LIFERAY_LOCAL_PROFILE_FILE} from '../../core/config/liferay-profile.js';
 import {resolveProjectContext} from '../../core/config/project-context.js';
 import type {Printer} from '../../core/output/printer.js';
-import {withProgress} from '../../core/output/printer.js';
-import {createOAuthTokenClient} from '../../core/http/auth.js';
-import {resolveEnvContext} from '../env/env-files.js';
-import {runGogoCommand} from '../osgi/osgi-shared.js';
-import {writeCredentialsToLocalProfile} from './oauth-env.js';
 import {
   resolveManagedOAuthScopeAliases,
   resolveOAuthScopeProfileAliases,
   type OAuthScopeProfileName,
 } from './oauth-scope-aliases.js';
-
-const BUNDLE_FILE_NAME = 'dev.mordonez.ldev.oauth2.app-1.0.0.jar';
+import {writeCredentialsToLocalProfile} from './oauth-env.js';
+import {deployBundledOAuthInstallerJar, writeOAuthInstallerOsgiConfig} from './oauth-install-bundle.js';
+import {executeOAuthInstallerCommand, buildOAuthInstallGogoCommand, parseKeyValueOutput} from './oauth-install-gogo.js';
+import {
+  verifyProvisionedOAuthInstall,
+  shouldSanitizeProvisionedOAuthConfig,
+  shouldPersistProvisionedOAuthCredentials,
+} from './oauth-install-verify.js';
 
 export type OAuthInstallResult = {
   ok: true;
@@ -68,6 +65,13 @@ export type OAuthAdminUnblockResult = {
   rawOutput: string;
 };
 
+export {deployBundledOAuthInstallerJar} from './oauth-install-bundle.js';
+export {executeOAuthInstallerCommand, buildOAuthInstallGogoCommand, parseKeyValueOutput} from './oauth-install-gogo.js';
+export {
+  shouldSanitizeProvisionedOAuthConfig,
+  shouldPersistProvisionedOAuthCredentials,
+} from './oauth-install-verify.js';
+
 export async function runOAuthInstall(
   config: AppConfig,
   options?: {
@@ -103,7 +107,7 @@ export async function runOAuthInstall(
 
   const bundleTargetFile = await deployBundledOAuthInstallerJar(config, options?.printer);
 
-  const command = buildGogoCommand(options?.companyId, options?.userId);
+  const command = buildOAuthInstallGogoCommand(options?.companyId, options?.userId);
   const rawOutput = await executeOAuthInstallCommand(config, command);
   const parsed = parseOAuthInstallOutput(rawOutput);
 
@@ -270,280 +274,8 @@ async function provisionOAuthViaOsgiConfig(
   };
 }
 
-async function deployBundledOAuthInstaller(sourceFile: string, targetFile: string, printer?: Printer): Promise<void> {
-  const deploy = async () => {
-    await fs.ensureDir(path.dirname(targetFile));
-    await fs.copy(sourceFile, targetFile, {overwrite: true});
-  };
-
-  if (printer) {
-    await withProgress(printer, 'Deploying bundled OAuth installer', deploy);
-    return;
-  }
-
-  await deploy();
-}
-
-export async function deployBundledOAuthInstallerJar(config: AppConfig, printer?: Printer): Promise<string> {
-  const bundleSourceFile = resolveBundledOAuthInstallerJar();
-  const bundleTargetFiles = resolveOAuthBundleDeployFiles(config);
-
-  for (const bundleTargetFile of bundleTargetFiles) {
-    await deployBundledOAuthInstaller(bundleSourceFile, bundleTargetFile, printer);
-  }
-
-  return bundleTargetFiles[0];
-}
-
-function resolveOAuthBundleDeployFiles(config: AppConfig): string[] {
-  if (config.dockerDir && config.liferayDir && config.repoRoot) {
-    const envContext = resolveEnvContext(config);
-    return [path.join(envContext.repoRoot, 'liferay', 'build', 'docker', 'deploy', BUNDLE_FILE_NAME)];
-  }
-
-  if (config.repoRoot) {
-    return [
-      path.join(config.repoRoot, 'bundles', 'deploy', BUNDLE_FILE_NAME),
-      path.join(config.repoRoot, 'configs', 'local', 'deploy', BUNDLE_FILE_NAME),
-    ];
-  }
-
-  throw new CliError('Could not resolve the deploy directory for the OAuth installer bundle.', {
-    code: 'OAUTH_INSTALL_DEPLOY_DIR_NOT_FOUND',
-  });
-}
-
-function resolveOAuthLocalProfileFile(config: AppConfig): string | null {
-  if (config.files.liferayLocalProfile) {
-    return config.files.liferayLocalProfile;
-  }
-
-  if (config.repoRoot) {
-    return path.join(config.repoRoot, LIFERAY_LOCAL_PROFILE_FILE);
-  }
-
-  return null;
-}
-
-async function writeOAuthInstallerOsgiConfig(
-  config: AppConfig,
-  options: {
-    enabled: boolean;
-    externalReferenceCode: string;
-    appName: string;
-    clientId: string;
-    clientSecret: string;
-    rotateClientSecret: boolean;
-    scopeAliases: string[];
-    companyId?: number;
-    userId?: number;
-  },
-): Promise<void> {
-  const fileName = 'dev.mordonez.ldev.oauth2.app.configuration.LdevOAuth2AppConfiguration.config';
-  const content = buildOAuthInstallerConfig(options);
-
-  for (const targetFile of resolveOAuthInstallerConfigFiles(config, fileName)) {
-    await fs.ensureDir(path.dirname(targetFile));
-    await fs.writeFile(targetFile, content, 'utf8');
-  }
-}
-
-function resolveOAuthInstallerConfigFiles(config: AppConfig, fileName: string): string[] {
-  if (config.dockerDir && config.liferayDir && config.repoRoot) {
-    return [
-      path.join(config.liferayDir, 'configs', 'dockerenv', 'osgi', 'configs', fileName),
-      path.join(config.liferayDir, 'build', 'docker', 'configs', 'dockerenv', 'osgi', 'configs', fileName),
-    ];
-  }
-
-  if (config.repoRoot) {
-    return [
-      path.join(config.repoRoot, 'configs', 'local', 'osgi', 'configs', fileName),
-      path.join(config.repoRoot, 'bundles', 'osgi', 'configs', fileName),
-    ];
-  }
-
-  return [];
-}
-
-function buildOAuthInstallerConfig(options: {
-  enabled: boolean;
-  externalReferenceCode: string;
-  appName: string;
-  clientId: string;
-  clientSecret: string;
-  rotateClientSecret: boolean;
-  scopeAliases: string[];
-  companyId?: number;
-  userId?: number;
-}): string {
-  const lines = [
-    `enabled=B"${String(options.enabled)}"`,
-    `externalReferenceCode=${quoteOsgiConfigValue(options.externalReferenceCode)}`,
-    `appName=${quoteOsgiConfigValue(options.appName)}`,
-    `clientId=${quoteOsgiConfigValue(options.clientId)}`,
-    `clientSecret=${quoteOsgiConfigValue(options.clientSecret)}`,
-    `rotateClientSecret=B"${String(options.rotateClientSecret)}"`,
-    `scopeAliases=${quoteOsgiConfigStringArray(options.scopeAliases)}`,
-  ];
-
-  if (options.companyId && options.companyId > 0) {
-    lines.push(`companyId=L"${options.companyId}"`);
-  }
-
-  if (options.userId && options.userId > 0) {
-    lines.push(`userId=L"${options.userId}"`);
-  }
-
-  return `${lines.join('\n')}\n`;
-}
-
-function quoteOsgiConfigValue(value: string): string {
-  return `"${value.replaceAll('\\', '\\\\').replaceAll('"', '\\"')}"`;
-}
-
-function quoteOsgiConfigStringArray(values: string[]): string {
-  return `[${values.map(quoteOsgiConfigValue).join(',')}]`;
-}
-
-function resolveConfiguredOAuthScopeAliases(
-  config: AppConfig,
-  extraScopeAliases?: string[],
-  extraScopeProfiles?: OAuthScopeProfileName[],
-): string[] {
-  return resolveManagedOAuthScopeAliases([
-    ...config.liferay.scopeAliases.split(','),
-    ...resolveOAuthScopeProfileAliases(extraScopeProfiles ?? []),
-    ...(extraScopeAliases ?? []),
-  ]);
-}
-
-function shouldProvisionOAuthViaOsgiConfig(config: AppConfig): boolean {
-  if (!config.repoRoot) {
-    return false;
-  }
-
-  return resolveProjectContext({cwd: config.cwd}).projectType === 'blade-workspace';
-}
-
-function buildGeneratedClientId(prefix: string): string {
-  return `${prefix}-${randomUUID().replaceAll('-', '').slice(0, 12)}`;
-}
-
-function buildGeneratedClientSecret(): string {
-  return `secret-${randomUUID()}`;
-}
-
-async function verifyProvisionedOAuthInstall(
-  config: AppConfig,
-  credentials: {
-    clientId: string;
-    clientSecret: string;
-  },
-): Promise<OAuthInstallResult['verification']> {
-  if (!config.liferay.url || config.liferay.url.trim() === '') {
-    return {
-      attempted: false,
-      verified: false,
-      sanitized: false,
-      tokenType: null,
-      expiresIn: null,
-      error: null,
-    };
-  }
-
-  try {
-    const tokenClient = createOAuthTokenClient({
-      invalidClientRetryDelayMs: 3000,
-      invalidClientMaxWaitMs: 30000,
-    });
-    const token = await tokenClient.fetchClientCredentialsToken({
-      ...config.liferay,
-      oauth2ClientId: credentials.clientId,
-      oauth2ClientSecret: credentials.clientSecret,
-    });
-
-    return {
-      attempted: true,
-      verified: true,
-      sanitized: false,
-      tokenType: token.tokenType,
-      expiresIn: token.expiresIn,
-      error: null,
-    };
-  } catch (error) {
-    return {
-      attempted: true,
-      verified: false,
-      sanitized: false,
-      tokenType: null,
-      expiresIn: null,
-      error: error instanceof Error ? error.message : String(error),
-    };
-  }
-}
-
 async function executeOAuthInstallCommand(config: AppConfig, command: string): Promise<string> {
   return executeOAuthInstallerCommand(config, command, (output) => output.includes('LIFERAY_CLI_OAUTH2_CLIENT_ID='));
-}
-
-export async function executeOAuthInstallerCommand(
-  config: AppConfig,
-  command: string,
-  successPredicate: (output: string) => boolean,
-): Promise<string> {
-  let lastOutput = '';
-
-  for (let attempt = 1; attempt <= 12; attempt++) {
-    const output = await runGogoCommand(config, command, process.env);
-    lastOutput = output;
-
-    if (output.includes('CommandNotFoundException')) {
-      await delay(2000);
-      continue;
-    }
-
-    if (output.includes('Unrecognized client authentication method')) {
-      throw new CliError(
-        'OAuth installer bundle is deployed, but the portal rejected the client authentication method.',
-        {
-          code: 'OAUTH_INSTALL_CLIENT_AUTH_METHOD',
-        },
-      );
-    }
-
-    if (output.includes('PortalException:')) {
-      throw new CliError(output.trim(), {
-        code: 'OAUTH_INSTALL_FAILED',
-      });
-    }
-
-    if (successPredicate(output)) {
-      return output;
-    }
-
-    await delay(2000);
-  }
-
-  throw new CliError(lastOutput.trim() || 'OAuth installer command did not become available in Gogo.', {
-    code: 'OAUTH_INSTALL_GOGO_UNAVAILABLE',
-  });
-}
-
-function buildGogoCommand(companyId?: number, userId?: number): string {
-  if (companyId && userId) {
-    return `ldev:oauthInstall ${companyId} ${userId}`;
-  }
-
-  if (companyId) {
-    return `ldev:oauthInstall ${companyId}`;
-  }
-
-  return 'ldev:oauthInstall';
-}
-
-export function buildOAuthInstallGogoCommand(companyId?: number, userId?: number): string {
-  return buildGogoCommand(companyId, userId);
 }
 
 function parseOAuthInstallOutput(output: string): {
@@ -561,25 +293,7 @@ function parseOAuthInstallOutput(output: string): {
     clientSecret: string;
   } | null;
 } {
-  const values: Record<string, string> = {};
-
-  for (const rawLine of output.split(/\r?\n/)) {
-    const trimmedLine = rawLine.trim();
-    if (
-      !trimmedLine.includes('=') ||
-      trimmedLine.startsWith('Trying ') ||
-      trimmedLine.startsWith('Connected') ||
-      trimmedLine.startsWith('Escape character')
-    ) {
-      continue;
-    }
-
-    const line = trimmedLine.startsWith('g! ') ? trimmedLine.slice(3).trim() : trimmedLine;
-    const separatorIndex = line.indexOf('=');
-    const key = line.slice(0, separatorIndex).trim();
-    const value = line.slice(separatorIndex + 1).trim();
-    values[key] = value;
-  }
+  const values = parseKeyValueOutput(output);
 
   const requiredKeys = [
     'companyId',
@@ -619,77 +333,42 @@ function parseOAuthInstallOutput(output: string): {
   };
 }
 
-function resolveBundledOAuthInstallerJar(): string {
-  const packageRoot = findPackageRoot(fileURLToPath(import.meta.url));
-  const filePath = path.join(packageRoot, 'templates', 'bundles', BUNDLE_FILE_NAME);
-
-  if (!fs.existsSync(filePath)) {
-    throw new CliError(`Bundled OAuth installer not found: ${filePath}`, {
-      code: 'OAUTH_INSTALL_BUNDLE_NOT_FOUND',
-    });
+function resolveOAuthLocalProfileFile(config: AppConfig): string | null {
+  if (config.files.liferayLocalProfile) {
+    return config.files.liferayLocalProfile;
   }
 
-  return filePath;
+  if (config.repoRoot) {
+    return path.join(config.repoRoot, LIFERAY_LOCAL_PROFILE_FILE);
+  }
+
+  return null;
 }
 
-export function parseKeyValueOutput(output: string): Record<string, string> {
-  const values: Record<string, string> = {};
-
-  for (const rawLine of output.split(/\r?\n/)) {
-    const trimmedLine = rawLine.trim();
-    if (
-      !trimmedLine.includes('=') ||
-      trimmedLine.startsWith('Trying ') ||
-      trimmedLine.startsWith('Connected') ||
-      trimmedLine.startsWith('Escape character')
-    ) {
-      continue;
-    }
-
-    const line = trimmedLine.startsWith('g! ') ? trimmedLine.slice(3).trim() : trimmedLine;
-    const separatorIndex = line.indexOf('=');
-    const key = line.slice(0, separatorIndex).trim();
-    const value = line.slice(separatorIndex + 1).trim();
-    values[key] = value;
-  }
-
-  return values;
+function resolveConfiguredOAuthScopeAliases(
+  config: AppConfig,
+  extraScopeAliases?: string[],
+  extraScopeProfiles?: OAuthScopeProfileName[],
+): string[] {
+  return resolveManagedOAuthScopeAliases([
+    ...config.liferay.scopeAliases.split(','),
+    ...resolveOAuthScopeProfileAliases(extraScopeProfiles ?? []),
+    ...(extraScopeAliases ?? []),
+  ]);
 }
 
-export function shouldSanitizeProvisionedOAuthConfig(verification: OAuthInstallResult['verification']): boolean {
-  if (verification.verified) {
-    return true;
-  }
-
-  if (!verification.attempted || !verification.error) {
+function shouldProvisionOAuthViaOsgiConfig(config: AppConfig): boolean {
+  if (!config.repoRoot) {
     return false;
   }
 
-  const normalized = verification.error.toLowerCase();
-
-  return normalized.includes('token request failed (');
+  return resolveProjectContext({cwd: config.cwd}).projectType === 'blade-workspace';
 }
 
-export function shouldPersistProvisionedOAuthCredentials(verification: OAuthInstallResult['verification']): boolean {
-  if (verification.verified || !verification.attempted) {
-    return true;
-  }
-
-  return Boolean(verification.error) && !shouldSanitizeProvisionedOAuthConfig(verification);
+function buildGeneratedClientId(prefix: string): string {
+  return `${prefix}-${randomUUID().replaceAll('-', '').slice(0, 12)}`;
 }
 
-function findPackageRoot(fromFile: string): string {
-  let current = path.dirname(fromFile);
-
-  while (true) {
-    if (fs.existsSync(path.join(current, 'package.json')) && fs.existsSync(path.join(current, 'templates'))) {
-      return current;
-    }
-
-    const parent = path.dirname(current);
-    if (parent === current) {
-      throw new Error(`Could not resolve the ldev package root from ${fromFile}`);
-    }
-    current = parent;
-  }
+function buildGeneratedClientSecret(): string {
+  return `secret-${randomUUID()}`;
 }

--- a/src/features/osgi/osgi-shared.ts
+++ b/src/features/osgi/osgi-shared.ts
@@ -1,11 +1,11 @@
-import net from 'node:net';
+﻿import net from 'node:net';
 import {setTimeout as delay} from 'node:timers/promises';
 
 import {CliError} from '../../core/errors.js';
 import type {AppConfig} from '../../core/config/load-config.js';
 import {runDockerCompose, runDockerComposeOrThrow} from '../../core/platform/docker.js';
 import {runProcess} from '../../core/platform/process.js';
-import {resolveEnvContext} from '../env/env-files.js';
+import {resolveEnvContext} from '../env/env-shared.js';
 
 export function resolveOsgiContext(config: AppConfig) {
   const envContext = resolveEnvContext(config);

--- a/src/features/perf/perf.ts
+++ b/src/features/perf/perf.ts
@@ -1,4 +1,4 @@
-import path from 'node:path';
+﻿import path from 'node:path';
 
 import fs from 'fs-extra';
 
@@ -7,7 +7,7 @@ import type {AppConfig} from '../../core/config/load-config.js';
 import {measureHttpLatency} from '../../core/http/latency.js';
 import {resolveEsUrl} from '../reindex/reindex-shared.js';
 
-import {resolveEnvContext} from '../env/env-files.js';
+import {resolveEnvContext} from '../env/env-shared.js';
 
 export type PerfSnapshot = {
   capturedAt: string;

--- a/src/features/reindex/reindex-shared.ts
+++ b/src/features/reindex/reindex-shared.ts
@@ -1,9 +1,10 @@
-import path from 'node:path';
+﻿import path from 'node:path';
 
 import {CliError} from '../../core/errors.js';
 import type {AppConfig} from '../../core/config/load-config.js';
 import {runDockerCompose} from '../../core/platform/docker.js';
-import {resolveEnvContext} from '../env/env-files.js';
+import {formatProcessError} from '../../core/platform/process.js';
+import {resolveEnvContext} from '../env/env-shared.js';
 
 export type ReindexIndexRow = {
   health: string;
@@ -109,7 +110,7 @@ export async function queryReindexTasks(config: AppConfig, processEnv?: NodeJS.P
   );
 
   if (!result.ok) {
-    throw new CliError(result.stderr.trim() || result.stdout.trim() || 'No se pudieron consultar tareas de reindex.', {
+    throw new CliError(formatProcessError(result, 'No se pudieron consultar tareas de reindex.'), {
       code: 'REINDEX_TASKS_FAILED',
     });
   }

--- a/src/features/snapshot/snapshot.ts
+++ b/src/features/snapshot/snapshot.ts
@@ -1,4 +1,4 @@
-import fs from 'fs-extra';
+﻿import fs from 'fs-extra';
 import path from 'node:path';
 import {spawn} from 'node:child_process';
 import os from 'node:os';
@@ -12,7 +12,7 @@ import type {Printer} from '../../core/output/printer.js';
 import {runStep} from '../../core/output/run-step.js';
 import {runDockerComposeOrThrow} from '../../core/platform/docker.js';
 import {normalizeProcessEnv} from '../../core/platform/process.js';
-import {buildComposeEnv, resolveEnvContext} from '../env/env-files.js';
+import {buildComposeEnv, resolveEnvContext} from '../env/env-shared.js';
 import {
   resolveAdtsBaseDir,
   resolveFragmentsBaseDir,
@@ -104,7 +104,7 @@ export function formatSnapshot(result: SnapshotResult): string {
   ].join('\n');
 }
 
-function resolveSnapshotDir(config: AppConfig, explicitOutput?: string): string {
+export function resolveSnapshotDir(config: AppConfig, explicitOutput?: string): string {
   if (explicitOutput?.trim()) {
     return path.resolve(explicitOutput);
   }
@@ -116,7 +116,7 @@ function resolveSnapshotDir(config: AppConfig, explicitOutput?: string): string 
   return path.join(config.repoRoot, '.ldev', 'snapshots', stamp);
 }
 
-async function collectSnapshotPaths(config: AppConfig): Promise<string[]> {
+export async function collectSnapshotPaths(config: AppConfig): Promise<string[]> {
   if (!config.liferayDir) {
     throw new CliError('snapshot requires liferayDir.', {code: 'SNAPSHOT_REPO_REQUIRED'});
   }
@@ -130,15 +130,16 @@ async function collectSnapshotPaths(config: AppConfig): Promise<string[]> {
   ];
 }
 
-async function writePostgresDump(
+export async function writePostgresDump(
   envContext: ReturnType<typeof resolveEnvContext>,
   outputFile: string,
   processEnv?: NodeJS.ProcessEnv,
+  spawnFn: typeof spawn = spawn,
 ): Promise<void> {
   const user = envContext.envValues.POSTGRES_USER || 'liferay';
   const db = envContext.envValues.POSTGRES_DB || 'liferay';
   const normalizedEnv = normalizeProcessEnv(processEnv);
-  const child = spawn('docker', ['compose', 'exec', '-T', 'postgres', 'pg_dump', '-U', user, '-d', db], {
+  const child = spawnFn('docker', ['compose', 'exec', '-T', 'postgres', 'pg_dump', '-U', user, '-d', db], {
     cwd: envContext.dockerDir,
     env: normalizedEnv,
     shell: process.platform === 'win32',

--- a/src/features/worktree/worktree-btrfs-refresh-base.ts
+++ b/src/features/worktree/worktree-btrfs-refresh-base.ts
@@ -1,8 +1,8 @@
-import {CliError} from '../../core/errors.js';
+﻿import {CliError} from '../../core/errors.js';
 import {loadConfig} from '../../core/config/load-config.js';
 import type {Printer} from '../../core/output/printer.js';
 import {withProgress} from '../../core/output/printer.js';
-import {resolveEnvContext} from '../env/env-files.js';
+import {resolveEnvContext} from '../env/env-shared.js';
 import {resolveWorktreeContext} from './worktree-paths.js';
 import {refreshBtrfsBaseFromMain, resolveBtrfsConfig} from './worktree-state.js';
 

--- a/src/features/worktree/worktree-clean.ts
+++ b/src/features/worktree/worktree-clean.ts
@@ -1,4 +1,4 @@
-import path from 'node:path';
+﻿import path from 'node:path';
 
 import fs from 'fs-extra';
 
@@ -16,7 +16,7 @@ import {
 import type {Printer} from '../../core/output/printer.js';
 import {withProgress} from '../../core/output/printer.js';
 import {runDocker, runDockerCompose} from '../../core/platform/docker.js';
-import {buildComposeEnv, resolveManagedStorages, type RuntimeStorageKey} from '../env/env-files.js';
+import {buildComposeEnv, resolveManagedStorages, type RuntimeStorageKey} from '../env/env-shared.js';
 import {resolveBtrfsConfig} from './worktree-state.js';
 import {resolveWorktreeContext, resolveWorktreeTarget} from './worktree-paths.js';
 
@@ -116,7 +116,7 @@ export async function runWorktreeClean(options: {
   const doclibVolumesRemoved: string[] = [];
 
   const cleanTask = async () => {
-    // === Docker cleanup first: containers → volumes → images ===
+    // === Docker cleanup first: containers â†’ volumes â†’ images ===
     // Must run before any filesystem operations so that Docker resources are
     // always freed even if a later git/file removal throws EBUSY.
     if (await fs.pathExists(target.dockerDir)) {
@@ -139,7 +139,7 @@ export async function runWorktreeClean(options: {
     // === Filesystem cleanup ===
     if (isRegistered) {
       // Remove the directory first (with EBUSY retries), then let git prune the
-      // stale reference — avoids git's own rmdir attempt racing with Docker handle release.
+      // stale reference â€” avoids git's own rmdir attempt racing with Docker handle release.
       if (await fs.pathExists(target.worktreeDir)) {
         await removePathRobust(target.worktreeDir, {processEnv: options.processEnv}).catch(async () => {
           // Fallback: let git try its own force-remove

--- a/src/features/worktree/worktree-env.ts
+++ b/src/features/worktree/worktree-env.ts
@@ -1,4 +1,4 @@
-import path from 'node:path';
+﻿import path from 'node:path';
 
 import fs from 'fs-extra';
 
@@ -7,7 +7,7 @@ import {CliError} from '../../core/errors.js';
 import {loadConfig} from '../../core/config/load-config.js';
 import {readEnvFile, upsertEnvFileValues} from '../../core/config/env-file.js';
 import type {Printer} from '../../core/output/printer.js';
-import {resolveManagedStorages} from '../env/env-files.js';
+import {resolveManagedStorages} from '../env/env-shared.js';
 import {resolveWorktreeContext, resolveWorktreeTarget, resolvePortSet, type WorktreeTarget} from './worktree-paths.js';
 import {syncWorktreeLocalArtifacts} from './worktree-local-artifacts.js';
 import {cloneInitialWorktreeState, resolveBtrfsConfig, worktreeEnvHasState} from './worktree-state.js';

--- a/src/features/worktree/worktree-setup.ts
+++ b/src/features/worktree/worktree-setup.ts
@@ -1,10 +1,10 @@
-import fs from 'fs-extra';
+﻿import fs from 'fs-extra';
 
 import {CliError} from '../../core/errors.js';
 import {loadConfig} from '../../core/config/load-config.js';
 import {detectCapabilities} from '../../core/platform/capabilities.js';
 import {readEnvFile} from '../../core/config/env-file.js';
-import {resolveEnvContext} from '../env/env-files.js';
+import {resolveEnvContext} from '../env/env-shared.js';
 import {addGitWorktree, isGitRepository, listGitWorktrees} from '../../core/platform/git.js';
 import type {Printer} from '../../core/output/printer.js';
 import {withProgress} from '../../core/output/printer.js';

--- a/src/features/worktree/worktree-state.ts
+++ b/src/features/worktree/worktree-state.ts
@@ -1,4 +1,4 @@
-import path from 'node:path';
+﻿import path from 'node:path';
 
 import fs from 'fs-extra';
 
@@ -6,9 +6,9 @@ import {CliError} from '../../core/errors.js';
 import {runDockerCompose} from '../../core/platform/docker.js';
 import {removePathRobust} from '../../core/platform/fs.js';
 import {runDocker} from '../../core/platform/docker.js';
-import {runProcess} from '../../core/platform/process.js';
-import type {EnvContext} from '../env/env-files.js';
-import {resolveManagedStorages, resolveRuntimeStorage, type RuntimeStorageKey} from '../env/env-files.js';
+import {formatProcessError, runProcess} from '../../core/platform/process.js';
+import type {EnvContext} from '../env/env-shared.js';
+import {resolveManagedStorages, resolveRuntimeStorage, type RuntimeStorageKey} from '../env/env-shared.js';
 
 export const WORKTREE_STATE_SUBDIRS = [
   'postgres-data',
@@ -264,7 +264,7 @@ async function emptyDirRobust(targetDir: string, processEnv?: NodeJS.ProcessEnv)
   );
 
   if (!result.ok) {
-    throw new CliError(result.stderr.trim() || result.stdout.trim() || `Could not empty ${targetDir}`, {
+    throw new CliError(formatProcessError(result, `Could not empty ${targetDir}`), {
       code: 'WORKTREE_STATE_CLEAR_FAILED',
     });
   }
@@ -300,7 +300,7 @@ async function copyDirContents(sourceDir: string, targetDir: string, processEnv?
   );
 
   if (!result.ok) {
-    throw new CliError(result.stderr.trim() || result.stdout.trim() || `Could not clone ${sourceDir}`, {
+    throw new CliError(formatProcessError(result, `Could not clone ${sourceDir}`), {
       code: 'WORKTREE_CLONE_FAILED',
     });
   }
@@ -368,7 +368,7 @@ async function cloneManagedRuntimeStorage(
   );
 
   if (!result.ok) {
-    throw new CliError(result.stderr.trim() || result.stdout.trim() || `Could not clone ${key} storage`, {
+    throw new CliError(formatProcessError(result, `Could not clone ${key} storage`), {
       code: 'WORKTREE_CLONE_FAILED',
     });
   }

--- a/tests/unit/db-import.test.ts
+++ b/tests/unit/db-import.test.ts
@@ -1,0 +1,214 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import {PassThrough, Writable} from 'node:stream';
+import {EventEmitter} from 'node:events';
+import type {ChildProcess} from 'node:child_process';
+import type {spawn as nodeSpawn} from 'node:child_process';
+
+import {describe, expect, test} from 'vitest';
+
+import {CliError} from '../../src/core/errors.js';
+import {findBackupFiles, resolveBackupFile, streamSqlIntoPostgres} from '../../src/features/db/db-import.js';
+import {createTempDir} from '../../src/testing/temp-repo.js';
+
+describe('db-import helpers', () => {
+  describe('findBackupFiles', () => {
+    test('returns empty list when root does not exist', async () => {
+      const root = path.join(createTempDir('db-import-missing-root-'), 'missing');
+
+      await expect(findBackupFiles(root)).resolves.toEqual([]);
+    });
+
+    test('returns empty list when no backup files match', async () => {
+      const root = createTempDir('db-import-no-matches-');
+      fs.writeFileSync(path.join(root, 'README.md'), 'not a backup\n');
+      fs.mkdirSync(path.join(root, 'nested'), {recursive: true});
+      fs.writeFileSync(path.join(root, 'nested', 'image.png'), 'x');
+
+      await expect(findBackupFiles(root)).resolves.toEqual([]);
+    });
+
+    test('returns .gz, .sql, and .dump files from nested directories', async () => {
+      const root = createTempDir('db-import-backups-');
+      const nested = path.join(root, 'nested');
+      fs.mkdirSync(nested, {recursive: true});
+
+      const files = [path.join(root, 'a.sql'), path.join(root, 'b.dump'), path.join(nested, 'c.gz')];
+
+      for (const file of files) {
+        fs.writeFileSync(file, 'backup\n');
+      }
+
+      const result = await findBackupFiles(root);
+      const resolved = result.map((entry) => path.normalize(entry.file)).sort();
+
+      expect(resolved).toEqual(files.map((file) => path.normalize(file)).sort());
+      for (const entry of result) {
+        expect(typeof entry.mtimeMs).toBe('number');
+        expect(Number.isFinite(entry.mtimeMs)).toBe(true);
+      }
+    });
+
+    test('skips doclib directory entirely', async () => {
+      const root = createTempDir('db-import-doclib-');
+      const doclib = path.join(root, 'doclib');
+      const nested = path.join(root, 'nested');
+      fs.mkdirSync(doclib, {recursive: true});
+      fs.mkdirSync(nested, {recursive: true});
+
+      fs.writeFileSync(path.join(doclib, 'should-not-be-found.sql'), 'backup\n');
+      const validFile = path.join(nested, 'should-be-found.sql');
+      fs.writeFileSync(validFile, 'backup\n');
+
+      const result = await findBackupFiles(root);
+      expect(result.map((entry) => path.normalize(entry.file))).toEqual([path.normalize(validFile)]);
+    });
+  });
+
+  describe('resolveBackupFile', () => {
+    test('throws DB_BACKUP_NOT_FOUND when explicit file does not exist', async () => {
+      const dockerDir = createTempDir('db-import-explicit-missing-');
+      const missing = path.join(dockerDir, 'backup.sql');
+
+      await expect(resolveBackupFile(dockerDir, missing)).rejects.toMatchObject({
+        code: 'DB_BACKUP_NOT_FOUND',
+      });
+    });
+
+    test('returns explicit file when it exists', async () => {
+      const dockerDir = createTempDir('db-import-explicit-ok-');
+      const explicit = path.join(dockerDir, 'backup.sql');
+      fs.writeFileSync(explicit, 'select 1;\n');
+
+      await expect(resolveBackupFile(dockerDir, explicit)).resolves.toBe(path.resolve(explicit));
+    });
+
+    test('throws DB_BACKUP_NOT_FOUND when docker/backups is empty', async () => {
+      const dockerDir = createTempDir('db-import-empty-backups-');
+      fs.mkdirSync(path.join(dockerDir, 'backups'), {recursive: true});
+
+      await expect(resolveBackupFile(dockerDir)).rejects.toMatchObject({
+        code: 'DB_BACKUP_NOT_FOUND',
+      });
+    });
+
+    test('returns newest backup by mtime when no explicit file is given', async () => {
+      const dockerDir = createTempDir('db-import-newest-backup-');
+      const backupsDir = path.join(dockerDir, 'backups');
+      fs.mkdirSync(backupsDir, {recursive: true});
+
+      const older = path.join(backupsDir, 'older.sql');
+      const newer = path.join(backupsDir, 'newer.sql');
+      fs.writeFileSync(older, 'old\n');
+      fs.writeFileSync(newer, 'new\n');
+
+      const olderTime = new Date('2025-01-01T00:00:00.000Z');
+      const newerTime = new Date('2026-01-01T00:00:00.000Z');
+      fs.utimesSync(older, olderTime, olderTime);
+      fs.utimesSync(newer, newerTime, newerTime);
+
+      await expect(resolveBackupFile(dockerDir)).resolves.toBe(newer);
+    });
+  });
+
+  describe('streamSqlIntoPostgres', () => {
+    test('resolves when child exits with code 0', async () => {
+      const sqlFile = writeSqlFile('db-import-stream-ok-');
+      const spawnMock = createSpawnMock({exitCode: 0});
+
+      await expect(streamSqlIntoPostgres('C:/tmp', sqlFile, {}, undefined, spawnMock)).resolves.toBeUndefined();
+    });
+
+    test('throws DB_IMPORT_ERROR with stderr when child exits non-zero', async () => {
+      const sqlFile = writeSqlFile('db-import-stream-stderr-');
+      const spawnMock = createSpawnMock({exitCode: 1, stderr: 'psql failed'});
+
+      await expect(streamSqlIntoPostgres('C:/tmp', sqlFile, {}, undefined, spawnMock)).rejects.toMatchObject({
+        code: 'DB_IMPORT_ERROR',
+        message: 'psql failed',
+      });
+    });
+
+    test('falls back to stdout when stderr is empty', async () => {
+      const sqlFile = writeSqlFile('db-import-stream-stdout-');
+      const spawnMock = createSpawnMock({exitCode: 1, stdout: 'stdout only failure'});
+
+      await expect(streamSqlIntoPostgres('C:/tmp', sqlFile, {}, undefined, spawnMock)).rejects.toMatchObject({
+        code: 'DB_IMPORT_ERROR',
+        message: 'stdout only failure',
+      });
+    });
+
+    test('uses fallback message when stderr and stdout are empty', async () => {
+      const sqlFile = writeSqlFile('db-import-stream-fallback-');
+      const spawnMock = createSpawnMock({exitCode: 1});
+
+      await expect(streamSqlIntoPostgres('C:/tmp', sqlFile, {}, undefined, spawnMock)).rejects.toMatchObject({
+        code: 'DB_IMPORT_ERROR',
+      });
+
+      await streamSqlIntoPostgres('C:/tmp', sqlFile, {}, undefined, createSpawnMock({exitCode: 1})).catch((error) => {
+        expect(error).toBeInstanceOf(CliError);
+        expect((error as CliError).message).toContain(`Could not import ${sqlFile}`);
+      });
+    });
+
+    test('ignores expected EPIPE pipeline failure and still resolves on exit code 0', async () => {
+      const sqlFile = writeSqlFile('db-import-stream-epipe-');
+      const spawnMock = createSpawnMock({exitCode: 0, stdin: createEpipeWritable()});
+
+      await expect(streamSqlIntoPostgres('C:/tmp', sqlFile, {}, undefined, spawnMock)).resolves.toBeUndefined();
+    });
+  });
+});
+
+function writeSqlFile(prefix: string): string {
+  const root = createTempDir(prefix);
+  const sqlFile = path.join(root, 'input.sql');
+  fs.writeFileSync(sqlFile, 'SELECT 1;\n');
+  return sqlFile;
+}
+
+function createSpawnMock(options: {
+  exitCode: number;
+  stderr?: string;
+  stdout?: string;
+  stdin?: NodeJS.WritableStream;
+}): typeof nodeSpawn {
+  return ((..._args: unknown[]) => {
+    const child = new EventEmitter() as EventEmitter & {
+      stdin: NodeJS.WritableStream;
+      stdout: PassThrough;
+      stderr: PassThrough;
+      kill: (signal?: NodeJS.Signals | number) => boolean;
+    };
+
+    child.stdin = options.stdin ?? new PassThrough();
+    child.stdout = new PassThrough();
+    child.stderr = new PassThrough();
+    child.kill = () => true;
+
+    if (options.stdout) {
+      child.stdout.write(options.stdout);
+    }
+    if (options.stderr) {
+      child.stderr.write(options.stderr);
+    }
+
+    setImmediate(() => {
+      child.emit('close', options.exitCode);
+    });
+
+    return child as unknown as ChildProcess;
+  }) as unknown as typeof nodeSpawn;
+}
+
+function createEpipeWritable(): Writable {
+  return new Writable({
+    write(_chunk, _encoding, callback) {
+      const error = new Error('simulated EPIPE') as NodeJS.ErrnoException;
+      error.code = 'EPIPE';
+      callback(error);
+    },
+  });
+}

--- a/tests/unit/snapshot.test.ts
+++ b/tests/unit/snapshot.test.ts
@@ -1,0 +1,200 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import {EventEmitter} from 'node:events';
+import {PassThrough} from 'node:stream';
+import type {ChildProcess} from 'node:child_process';
+import type {spawn as nodeSpawn} from 'node:child_process';
+
+import {describe, expect, test} from 'vitest';
+
+import type {AppConfig} from '../../src/core/config/load-config.js';
+import {loadConfig} from '../../src/core/config/load-config.js';
+import {resolveEnvContext} from '../../src/features/env/env-files.js';
+import {collectSnapshotPaths, resolveSnapshotDir, writePostgresDump} from '../../src/features/snapshot/snapshot.js';
+import {createTempDir} from '../../src/testing/temp-repo.js';
+
+describe('snapshot helpers', () => {
+  describe('resolveSnapshotDir', () => {
+    test('throws SNAPSHOT_REPO_REQUIRED when repoRoot is not available and no explicit output is provided', () => {
+      const config = {
+        repoRoot: null,
+      } as AppConfig;
+
+      expect(() => resolveSnapshotDir(config)).toThrowError(expect.objectContaining({code: 'SNAPSHOT_REPO_REQUIRED'}));
+    });
+
+    test('returns path.resolve when explicit output is provided', () => {
+      const config = {
+        repoRoot: null,
+      } as AppConfig;
+
+      const explicit = path.join('tmp', 'snapshot-folder');
+      expect(resolveSnapshotDir(config, explicit)).toBe(path.resolve(explicit));
+    });
+
+    test('returns path under .ldev/snapshots with sanitized timestamp', () => {
+      const repoRoot = createTempDir('snapshot-dir-');
+      const config = {
+        repoRoot,
+      } as AppConfig;
+
+      const resolved = resolveSnapshotDir(config);
+      const expectedPrefix = path.join(repoRoot, '.ldev', 'snapshots');
+
+      expect(resolved.startsWith(expectedPrefix)).toBe(true);
+      const stamp = path.basename(resolved);
+      expect(stamp).not.toContain(':');
+      expect(stamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}\.\d{3}Z$/);
+    });
+  });
+
+  describe('collectSnapshotPaths', () => {
+    test('throws SNAPSHOT_REPO_REQUIRED when liferayDir is missing', async () => {
+      const config = {
+        liferayDir: null,
+      } as AppConfig;
+
+      await expect(collectSnapshotPaths(config)).rejects.toMatchObject({code: 'SNAPSHOT_REPO_REQUIRED'});
+    });
+
+    test('returns paths for configs, structures, templates, adts, and fragments', async () => {
+      const repoRoot = createSnapshotFixture();
+      const config = loadConfig({cwd: repoRoot, env: process.env});
+
+      const paths = await collectSnapshotPaths(config);
+
+      expect(paths).toEqual(
+        expect.arrayContaining([
+          path.join(repoRoot, 'liferay', 'configs'),
+          path.join(repoRoot, 'liferay', 'resources', 'journal', 'structures'),
+          path.join(repoRoot, 'liferay', 'resources', 'journal', 'templates'),
+          path.join(repoRoot, 'liferay', 'resources', 'templates', 'application_display'),
+          path.join(repoRoot, 'liferay', 'fragments'),
+        ]),
+      );
+    });
+  });
+
+  describe('writePostgresDump', () => {
+    test('resolves on exit code 0 and runs pg_dump with configured user/db', async () => {
+      const repoRoot = createSnapshotFixture();
+      const envContext = resolveEnvContext(loadConfig({cwd: repoRoot, env: process.env}));
+      envContext.envValues.POSTGRES_USER = 'custom-user';
+      envContext.envValues.POSTGRES_DB = 'custom-db';
+
+      const outputFile = path.join(repoRoot, '.ldev', 'snapshots', 'dump.sql');
+      let capturedArgs: string[] = [];
+
+      const spawnMock = ((command: string, args: string[]) => {
+        capturedArgs = [command, ...args];
+        return createChildProcessMock({exitCode: 0, stdout: 'SELECT 1;\n'});
+      }) as unknown as typeof nodeSpawn;
+
+      await expect(writePostgresDump(envContext, outputFile, process.env, spawnMock)).resolves.toBeUndefined();
+      expect(capturedArgs).toEqual([
+        'docker',
+        'compose',
+        'exec',
+        '-T',
+        'postgres',
+        'pg_dump',
+        '-U',
+        'custom-user',
+        '-d',
+        'custom-db',
+      ]);
+      expect(fs.existsSync(outputFile)).toBe(true);
+    });
+
+    test('falls back to liferay defaults when POSTGRES_USER and POSTGRES_DB are absent', async () => {
+      const repoRoot = createSnapshotFixture();
+      const envContext = resolveEnvContext(loadConfig({cwd: repoRoot, env: process.env}));
+      delete envContext.envValues.POSTGRES_USER;
+      delete envContext.envValues.POSTGRES_DB;
+
+      const outputFile = path.join(repoRoot, '.ldev', 'snapshots', 'dump-defaults.sql');
+      let capturedArgs: string[] = [];
+
+      const spawnMock = ((command: string, args: string[]) => {
+        capturedArgs = [command, ...args];
+        return createChildProcessMock({exitCode: 0, stdout: 'SELECT 1;\n'});
+      }) as unknown as typeof nodeSpawn;
+
+      await writePostgresDump(envContext, outputFile, process.env, spawnMock);
+
+      expect(capturedArgs).toEqual([
+        'docker',
+        'compose',
+        'exec',
+        '-T',
+        'postgres',
+        'pg_dump',
+        '-U',
+        'liferay',
+        '-d',
+        'liferay',
+      ]);
+    });
+
+    test('throws SNAPSHOT_DB_DUMP_FAILED and surfaces stderr when pg_dump exits non-zero', async () => {
+      const repoRoot = createSnapshotFixture();
+      const envContext = resolveEnvContext(loadConfig({cwd: repoRoot, env: process.env}));
+      const outputFile = path.join(repoRoot, '.ldev', 'snapshots', 'dump-failed.sql');
+
+      const spawnMock = (() =>
+        createChildProcessMock({exitCode: 2, stderr: 'permission denied'})) as unknown as typeof nodeSpawn;
+
+      await expect(writePostgresDump(envContext, outputFile, process.env, spawnMock)).rejects.toMatchObject({
+        code: 'SNAPSHOT_DB_DUMP_FAILED',
+        message: 'permission denied',
+      });
+    });
+  });
+});
+
+function createSnapshotFixture(): string {
+  const repoRoot = createTempDir('snapshot-unit-');
+
+  fs.mkdirSync(path.join(repoRoot, 'docker', 'data', 'default'), {recursive: true});
+  fs.mkdirSync(path.join(repoRoot, 'liferay', 'configs', 'dockerenv'), {recursive: true});
+  fs.mkdirSync(path.join(repoRoot, 'liferay', 'resources', 'journal', 'structures', 'global'), {recursive: true});
+  fs.mkdirSync(path.join(repoRoot, 'liferay', 'resources', 'journal', 'templates', 'global'), {recursive: true});
+  fs.mkdirSync(path.join(repoRoot, 'liferay', 'resources', 'templates', 'application_display'), {recursive: true});
+  fs.mkdirSync(path.join(repoRoot, 'liferay', 'fragments'), {recursive: true});
+
+  fs.writeFileSync(path.join(repoRoot, 'docker', 'docker-compose.yml'), 'services:\n  postgres:\n  liferay:\n');
+  fs.writeFileSync(
+    path.join(repoRoot, 'docker', '.env'),
+    'COMPOSE_PROJECT_NAME=demo\nENV_DATA_ROOT=./data/default\nLDEV_STORAGE_PLATFORM=other\nPOSTGRES_USER=liferay\nPOSTGRES_DB=liferay\n',
+  );
+  fs.writeFileSync(path.join(repoRoot, 'liferay', 'build.gradle'), 'plugins {}\n');
+
+  return repoRoot;
+}
+
+function createChildProcessMock(options: {exitCode: number; stdout?: string; stderr?: string}): ChildProcess {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: PassThrough;
+    stderr: PassThrough;
+  };
+
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+
+  if (options.stdout) {
+    child.stdout.end(options.stdout);
+  } else {
+    child.stdout.end();
+  }
+
+  if (options.stderr) {
+    child.stderr.write(options.stderr);
+  }
+  child.stderr.end();
+
+  setImmediate(() => {
+    child.emit('close', options.exitCode);
+  });
+
+  return child as unknown as ChildProcess;
+}


### PR DESCRIPTION
## Summary
- Agrupa y entrega P1P5 en una sola rama con 5 commits ordenados (uno por prompt).
- Mantiene comportamiento y contratos del CLI mientras mejora testabilidad, modularidad y consistencia de errores.
- Incluye verificaci�n autom�tica completa en push hook (lint, format, typecheck, unit, build, smoke).

## Commits Incluidos
1. `test(db): P1 - add db-import unit tests with spawn injection`
   - Exporta helpers de db-import para pruebas.
   - Agrega inyecci�n opcional de `spawn`.
   - Agrega 13 pruebas unitarias enfocadas.

2. `test(snapshot): P2 - add snapshot unit tests with spawn injection`
   - Exporta helpers de snapshot para pruebas.
   - Agrega inyecci�n opcional de `spawn`.
   - Agrega pruebas unitarias de flujo y errores.

3. `refactor(oauth): P3 - decompose oauth-install into focused internal modules`
   - Extrae `oauth-install-bundle.ts`, `oauth-install-gogo.ts`, `oauth-install-verify.ts`.
   - Deja `oauth-install.ts` como facade delgada + orquestaci�n.

4. `refactor(env): P4 - add env-shared public facade and migrate consumer imports`
   - Crea `env-shared.ts` como fachada p�blica de re-export.
   - Migra consumidores desde `env-files.js` hacia `env-shared.js`.

5. `refactor(core): P5 - add formatProcessError helper and normalize error patterns`
   - Agrega `formatProcessError(result, fallback)` en `process.ts`.
   - Reemplaza patrones repetidos `stderr/stdout/fallback` en m�dulos de features.

## Validation
- Pre-push hook ejecutado correctamente:
  - `npm run lint` (solo warnings existentes en el repo)
  - `npm run format:check`
  - `npm run typecheck`
  - `npm run test:unit` (844/844)
  - `npm run build`
  - `npm run test:smoke` (61/61)

## Notes
- No cambios de contrato p�blico del CLI.
- Warnings de lint existentes en el repositorio se mantienen sin cambios funcionales.
