### PR TITLE
fix(resource): normalize ambiguous artifact error messages to English

### DIFF
--- a/src/features/liferay/resource/artifact-paths.ts
+++ b/src/features/liferay/resource/artifact-paths.ts
@@ -201,7 +201,7 @@ async function resolveStructureArtifactFile(config: AppConfig, key: string): Pro
     return matches[0]!;
   }
   if (matches.length > 1) {
-    throw new CliError(`Structure file ambiguo para ${key}: ${matches.join(', ')}`, {
+    throw new CliError(`Ambiguous structure file for ${key}: ${matches.join(', ')}`, {
       code: 'LIFERAY_RESOURCE_FILE_AMBIGUOUS',
     });
   }
@@ -234,7 +234,7 @@ async function resolveTemplateArtifactFile(config: AppConfig, siteToken: string,
     return matches[0]!;
   }
   if (matches.length > 1) {
-    throw new CliError(`Template file ambiguo para ${key}: ${matches.join(', ')}`, {
+    throw new CliError(`Ambiguous template file for ${key}: ${matches.join(', ')}`, {
       code: 'LIFERAY_RESOURCE_FILE_AMBIGUOUS',
     });
   }
@@ -260,7 +260,7 @@ async function resolveAdtArtifactFile(config: AppConfig, key: string, widgetType
     return matches[0]!;
   }
   if (matches.length > 1) {
-    throw new CliError(`ADT file ambiguo para ${key} (${widgetType}): ${matches.join(', ')}`, {
+    throw new CliError(`Ambiguous ADT file for ${key} (${widgetType}): ${matches.join(', ')}`, {
       code: 'LIFERAY_RESOURCE_FILE_AMBIGUOUS',
     });
   }


### PR DESCRIPTION
## Summary
- Normalizes 3 user-facing ambiguous artifact error messages to English in `artifact-paths.ts`.
- Keeps error codes, control flow, and matching logic unchanged.

## What Changed
- `Structure file ambiguo para ...` -> `Ambiguous structure file for ...`
- `Template file ambiguo para ...` -> `Ambiguous template file for ...`
- `ADT file ambiguo para ...` -> `Ambiguous ADT file for ...`

## Scope
- Only `src/features/liferay/resource/artifact-paths.ts`.
- No behavioral changes.
- No output contract changes.

## Validation
- `npm run test:unit -- tests/unit/liferay-resource-export.test.ts tests/unit/liferay-resource-import.test.ts tests/unit/liferay-resource-sync-fragments.test.ts`
- Result: pass (full unit suite executed in this run, 844/844 passing)
