### PR TITLE
chore: switch repository URL to HTTPS and remove dead authedGet

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/mordonez/ldev.git"
+    "url": "https://github.com/mordonez/ldev.git"
   },
   "homepage": "https://github.com/mordonez/ldev",
   "bugs": {

--- a/src/features/liferay/inventory/liferay-inventory-shared.ts
+++ b/src/features/liferay/inventory/liferay-inventory-shared.ts
@@ -2,7 +2,7 @@ import {CliError} from '../../../core/errors.js';
 import type {AppConfig} from '../../../core/config/load-config.js';
 import {createOAuthTokenClient, type OAuthTokenClient} from '../../../core/http/auth.js';
 import {createLiferayApiClient, type HttpResponse, type LiferayApiClient} from '../../../core/http/client.js';
-import {buildAuthOptions, expectJsonSuccess as expectJsonSuccessShared} from '../liferay-http-shared.js';
+import {expectJsonSuccess as expectJsonSuccessShared} from '../liferay-http-shared.js';
 import {createLiferayGateway, type LiferayGateway} from '../liferay-gateway.js';
 import {LookupCache} from '../lookup-cache.js';
 import {LiferayErrors} from '../errors/index.js';
@@ -133,15 +133,6 @@ export async function fetchPagedItems<T>(
   }
 
   return items;
-}
-
-export async function authedGet<T>(
-  config: AppConfig,
-  apiClient: LiferayApiClient,
-  accessToken: string,
-  path: string,
-): Promise<HttpResponse<T>> {
-  return apiClient.get<T>(config.liferay.url, path, buildAuthOptions(config, accessToken));
 }
 
 export async function expectJsonSuccess<T>(response: HttpResponse<T>, label: string): Promise<HttpResponse<T>> {


### PR DESCRIPTION
## Summary
- Updates package repository URL to HTTPS for public npm usability.
- Removes dead `authedGet` export from inventory shared module.

## What Changed
- `package.json`
  - `repository.url`: `git+ssh://git@github.com/mordonez/ldev.git` -> `https://github.com/mordonez/ldev.git`
- `src/features/liferay/inventory/liferay-inventory-shared.ts`
  - Removed unused `authedGet` helper export.
  - Removed now-unused `buildAuthOptions` import.

## Scope
- Mechanical cleanup only.
- No behavior changes in command flows.
- No output contract changes.

## Validation
- `npm run typecheck`
- `npm run test:unit -- tests/unit/liferay-inventory.test.ts tests/unit/liferay-inventory-page.test.ts tests/unit/liferay-inventory-pages.test.ts tests/unit/liferay-resource-get-structure.test.ts`
- Result: pass (full unit run executed in this invocation: 844/844)
