### PR TITLE
refactor(resource): migrate artifact-paths errors to LiferayErrors factories

### DIFF
--- a/src/features/liferay/resource/artifact-paths.ts
+++ b/src/features/liferay/resource/artifact-paths.ts
@@ -22,8 +22,8 @@ export const ADT_WIDGET_DIR_BY_TYPE: Record<string, string> = {
 
 export function requireRepoRoot(config: AppConfig): string {
   if (!config.repoRoot) {
-    throw new CliError('This command must be run inside a project repository.', {
-      code: 'LIFERAY_REPO_NOT_FOUND',
+    throw LiferayErrors.resourceRepoNotFound('project repository', {
+      details: {hint: 'This command must be run inside a project repository.'},
     });
   }
 
@@ -201,13 +201,13 @@ async function resolveStructureArtifactFile(config: AppConfig, key: string): Pro
     return matches[0]!;
   }
   if (matches.length > 1) {
-    throw new CliError(`Ambiguous structure file for ${key}: ${matches.join(', ')}`, {
-      code: 'LIFERAY_RESOURCE_FILE_AMBIGUOUS',
+    throw LiferayErrors.resourceFileAmbiguous(`structure:${key}`, matches, {
+      details: {key, type: 'structure', matches},
     });
   }
 
-  throw new CliError(`Structure file not found for ${key} in ${baseDir}. Use --file.`, {
-    code: 'LIFERAY_RESOURCE_FILE_NOT_FOUND',
+  throw LiferayErrors.resourceFileNotFound(`structure:${key} in ${baseDir} (use --file)`, {
+    details: {key, type: 'structure', baseDir},
   });
 }
 
@@ -234,13 +234,13 @@ async function resolveTemplateArtifactFile(config: AppConfig, siteToken: string,
     return matches[0]!;
   }
   if (matches.length > 1) {
-    throw new CliError(`Ambiguous template file for ${key}: ${matches.join(', ')}`, {
-      code: 'LIFERAY_RESOURCE_FILE_AMBIGUOUS',
+    throw LiferayErrors.resourceFileAmbiguous(`template:${key}`, matches, {
+      details: {key, type: 'template', siteToken, matches},
     });
   }
 
-  throw new CliError(`Template file not found for ${key} in ${baseDir}. Use --file.`, {
-    code: 'LIFERAY_RESOURCE_FILE_NOT_FOUND',
+  throw LiferayErrors.resourceFileNotFound(`template:${key} in ${baseDir} (use --file)`, {
+    details: {key, type: 'template', siteToken, baseDir},
   });
 }
 
@@ -260,13 +260,13 @@ async function resolveAdtArtifactFile(config: AppConfig, key: string, widgetType
     return matches[0]!;
   }
   if (matches.length > 1) {
-    throw new CliError(`Ambiguous ADT file for ${key} (${widgetType}): ${matches.join(', ')}`, {
-      code: 'LIFERAY_RESOURCE_FILE_AMBIGUOUS',
+    throw LiferayErrors.resourceFileAmbiguous(`adt:${key}:${widgetType}`, matches, {
+      details: {key, type: 'adt', widgetType, matches},
     });
   }
 
-  throw new CliError(`ADT file not found for ${key} (${widgetType}) in ${baseDir}. Use --file.`, {
-    code: 'LIFERAY_RESOURCE_FILE_NOT_FOUND',
+  throw LiferayErrors.resourceFileNotFound(`adt:${key}:${widgetType} in ${baseDir} (use --file)`, {
+    details: {key, type: 'adt', widgetType, baseDir},
   });
 }
 
@@ -293,8 +293,8 @@ async function resolveExistingArtifactFile(config: AppConfig, candidate: string)
     }
   }
 
-  throw new CliError(`File not found: ${candidate}`, {
-    code: 'LIFERAY_RESOURCE_FILE_NOT_FOUND',
+  throw LiferayErrors.resourceFileNotFound(candidate, {
+    details: {candidate},
   });
 }
 


### PR DESCRIPTION
## Summary
- Migrates `artifact-paths.ts` throw sites from direct `new CliError(..., {code})` to `LiferayErrors` factories for repo/file ambiguity/not-found cases.
- Keeps the existing `LIFERAY_CONFIG_INCOMPLETE` path unchanged.

## What Changed
- `requireRepoRoot(...)`
  - Replaced direct `LIFERAY_REPO_NOT_FOUND` throw with `LiferayErrors.resourceRepoNotFound(...)`.
- `resolveStructureArtifactFile(...)`
  - Replaced direct ambiguous/not-found throws with:
    - `LiferayErrors.resourceFileAmbiguous(...)`
    - `LiferayErrors.resourceFileNotFound(...)`
- `resolveTemplateArtifactFile(...)`
  - Replaced direct ambiguous/not-found throws with factories.
- `resolveAdtArtifactFile(...)`
  - Replaced direct ambiguous/not-found throws with factories.
- `resolveExistingArtifactFile(...)`
  - Replaced direct not-found throw with factory.

## Notes
- Added `details` payloads to preserve context (`key`, `type`, `siteToken`, `widgetType`, `baseDir`, `matches`) when using standardized factory messages.
- No command flow changes.

## Validation
- `npm run typecheck`
- `npm run test:unit -- tests/unit/liferay-artifact-paths.test.ts tests/unit/liferay-resource-import.test.ts tests/unit/liferay-resource-export.test.ts`
- Result: pass (run executed full unit suite in this invocation: 844/844)
