### PR TITLE
refactor(resource): migrate sync-shared postFormCandidates to LiferayGateway

### DIFF
--- a/src/features/liferay/liferay-gateway.ts
+++ b/src/features/liferay/liferay-gateway.ts
@@ -167,6 +167,15 @@ export class LiferayGateway {
   }
 
   /**
+   * POST form /path, return the raw HTTP response without asserting ok status.
+   * Use when callers need to inspect status/body across multiple fallback payload candidates.
+   */
+  async postFormRaw<T>(path: string, form: Record<string, string>): Promise<HttpResponse<T>> {
+    const accessToken = await this.getAccessToken();
+    return this.apiClient.postForm<T>(this.config.liferay.url, path, form, buildAuthOptions(this.config, accessToken));
+  }
+
+  /**
    * DELETE /path, parse JSON response if present, assert ok status, return data.
    * @throws CliError if response not ok
    */

--- a/src/features/liferay/resource/liferay-resource-sync-shared.ts
+++ b/src/features/liferay/resource/liferay-resource-sync-shared.ts
@@ -3,10 +3,10 @@ import {createHash} from 'node:crypto';
 import type {AppConfig} from '../../../core/config/load-config.js';
 import type {OAuthTokenClient} from '../../../core/http/auth.js';
 import type {LiferayApiClient} from '../../../core/http/client.js';
-import {createLiferayApiClient, type HttpResponse} from '../../../core/http/client.js';
+import type {HttpResponse} from '../../../core/http/client.js';
 import {LiferayErrors} from '../errors/index.js';
-import {buildAuthOptions, ensureData} from '../liferay-http-shared.js';
-import {fetchAccessToken} from '../inventory/liferay-inventory-shared.js';
+import {createLiferayGateway} from '../liferay-gateway.js';
+import {ensureData} from '../liferay-http-shared.js';
 
 type ResourceDependencies = {
   apiClient?: LiferayApiClient;
@@ -28,10 +28,8 @@ async function postFormCandidateResponse<T>(
   form: Record<string, string>,
   dependencies?: ResourceDependencies,
 ): Promise<HttpResponse<T>> {
-  const apiClient = dependencies?.apiClient ?? createLiferayApiClient();
-  const accessToken = await fetchAccessToken(config, dependencies);
-
-  return apiClient.postForm<T>(config.liferay.url, path, form, buildAuthOptions(config, accessToken));
+  const gateway = createLiferayGateway(config, dependencies?.apiClient, dependencies?.tokenClient);
+  return gateway.postFormRaw<T>(path, form);
 }
 
 export async function postFormCandidates<T>(

--- a/tests/unit/liferay-gateway.test.ts
+++ b/tests/unit/liferay-gateway.test.ts
@@ -221,6 +221,46 @@ describe('LiferayGateway', () => {
     });
   });
 
+  describe('postFormRaw', () => {
+    test('calls apiClient.postForm with Authorization header and returns raw response', async () => {
+      const apiClient = createMockApiClient();
+      const tokenClient = createMockTokenClient();
+      const response = mockHttpResponse(true, 201, {id: 123});
+
+      vi.mocked(apiClient.postForm).mockResolvedValue(response);
+
+      const gateway = new LiferayGateway(mockConfig, apiClient, tokenClient);
+      const form = {name: 'value'};
+      const result = await gateway.postFormRaw('/api/raw-submit', form);
+
+      expect(result).toBe(response);
+      expect(apiClient.postForm).toHaveBeenCalledWith(
+        'http://localhost:8080',
+        '/api/raw-submit',
+        form,
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'Bearer test-access-token',
+          }),
+        }),
+      );
+    });
+
+    test('does not throw for non-ok responses', async () => {
+      const apiClient = createMockApiClient();
+      const tokenClient = createMockTokenClient();
+      const response = mockHttpResponse(false, 409, null);
+
+      vi.mocked(apiClient.postForm).mockResolvedValue(response);
+
+      const gateway = new LiferayGateway(mockConfig, apiClient, tokenClient);
+      const result = await gateway.postFormRaw('/api/raw-submit', {key: 'x'});
+
+      expect(result.ok).toBe(false);
+      expect(result.status).toBe(409);
+    });
+  });
+
   describe('postMultipart', () => {
     test('calls apiClient.postMultipart with Authorization header', async () => {
       const apiClient = createMockApiClient();

--- a/tests/unit/liferay-resource-sync-shared.test.ts
+++ b/tests/unit/liferay-resource-sync-shared.test.ts
@@ -1,0 +1,114 @@
+import {describe, expect, test, vi} from 'vitest';
+
+import type {AppConfig} from '../../src/core/config/load-config.js';
+import type {OAuthTokenClient, TokenResponse} from '../../src/core/http/auth.js';
+import type {HttpResponse, LiferayApiClient} from '../../src/core/http/client.js';
+import {postFormCandidates} from '../../src/features/liferay/resource/liferay-resource-sync-shared.js';
+
+const mockConfig: AppConfig = {
+  cwd: '/repo',
+  repoRoot: '/repo',
+  dockerDir: null,
+  liferayDir: null,
+  files: {
+    dockerEnv: null,
+    liferayProfile: null,
+  },
+  liferay: {
+    url: 'http://localhost:8080',
+    timeoutSeconds: 45,
+    oauth2ClientId: 'test-client',
+    oauth2ClientSecret: 'test-secret',
+    scopeAliases: 'default',
+  },
+};
+
+const mockToken: TokenResponse = {
+  accessToken: 'test-access-token',
+  tokenType: 'Bearer',
+  expiresIn: 3600,
+};
+
+const createMockApiClient = (): LiferayApiClient => ({
+  get: vi.fn(),
+  delete: vi.fn(),
+  postJson: vi.fn(),
+  postForm: vi.fn(),
+  postMultipart: vi.fn(),
+  putJson: vi.fn(),
+});
+
+const createMockTokenClient = (): OAuthTokenClient => ({
+  fetchClientCredentialsToken: vi.fn(() => Promise.resolve(mockToken)),
+});
+
+const mockHttpResponse = <T>(ok: boolean, status: number, data: T, body?: string): HttpResponse<T> => ({
+  ok,
+  status,
+  data,
+  headers: new Headers(),
+  body: body ?? (data == null ? '' : JSON.stringify(data)),
+});
+
+describe('postFormCandidates', () => {
+  test('returns data on first successful candidate', async () => {
+    const apiClient = createMockApiClient();
+    const tokenClient = createMockTokenClient();
+
+    vi.mocked(apiClient.postForm).mockResolvedValue(
+      mockHttpResponse(true, 200, {templateId: 101, templateKey: 'BASIC'}),
+    );
+
+    const result = await postFormCandidates<{templateId: number; templateKey: string}>(
+      mockConfig,
+      '/api/jsonws/ddm.ddmtemplate/add-template',
+      [{nameMap: '{}'}],
+      'template-create',
+      {apiClient, tokenClient},
+    );
+
+    expect(result.templateId).toBe(101);
+    expect(apiClient.postForm).toHaveBeenCalledTimes(1);
+  });
+
+  test('tries next candidate when first fails', async () => {
+    const apiClient = createMockApiClient();
+    const tokenClient = createMockTokenClient();
+
+    vi.mocked(apiClient.postForm)
+      .mockResolvedValueOnce(mockHttpResponse(false, 400, null, 'first-invalid'))
+      .mockResolvedValueOnce(mockHttpResponse(true, 200, {templateId: 202}));
+
+    const result = await postFormCandidates<{templateId: number}>(
+      mockConfig,
+      '/api/jsonws/ddm.ddmtemplate/update-template',
+      [{language: 'x'}, {language: 'ftl'}],
+      'template-update',
+      {apiClient, tokenClient},
+    );
+
+    expect(result.templateId).toBe(202);
+    expect(apiClient.postForm).toHaveBeenCalledTimes(2);
+  });
+
+  test('aggregates status and body when all candidates fail', async () => {
+    const apiClient = createMockApiClient();
+    const tokenClient = createMockTokenClient();
+
+    vi.mocked(apiClient.postForm)
+      .mockResolvedValueOnce(mockHttpResponse(false, 400, null, 'bad-request'))
+      .mockResolvedValueOnce(mockHttpResponse(false, 403, null, 'forbidden'));
+
+    await expect(
+      postFormCandidates(
+        mockConfig,
+        '/api/jsonws/ddm.ddmtemplate/add-template',
+        [{nameMap: '{}'}, {nameMap: '{"x":"y"}'}],
+        'template-create',
+        {apiClient, tokenClient},
+      ),
+    ).rejects.toThrow(
+      /template-create failed on \/api\/jsonws\/ddm\.ddmtemplate\/add-template \(status=400 body=bad-request \| status=403 body=forbidden\)/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Migrates `postFormCandidates(...)` transport in `liferay-resource-sync-shared.ts` from manual token/auth wiring to `LiferayGateway`.
- Adds a raw gateway method (`postFormRaw`) to preserve candidate-fallback behavior that depends on inspecting non-ok responses.

## What Changed
- `src/features/liferay/liferay-gateway.ts`
  - Added `postFormRaw<T>(path, form): Promise<HttpResponse<T>>`.
  - Mirrors `getRaw` behavior for form POST: injects auth, returns raw response without status assertion.
- `src/features/liferay/resource/liferay-resource-sync-shared.ts`
  - Removed direct use of `fetchAccessToken` + `buildAuthOptions`.
  - `postFormCandidateResponse` now creates `LiferayGateway` and calls `gateway.postFormRaw(...)`.
- `tests/unit/liferay-gateway.test.ts`
  - Added tests for `postFormRaw` authorization wiring and non-ok pass-through semantics.
- `tests/unit/liferay-resource-sync-shared.test.ts`
  - Added unit tests for `postFormCandidates` first-success, fallback-to-next-candidate, and aggregated failure status/body message.

## Behavior
- No CLI contract changes.
- Candidate fallback semantics preserved.
- Error aggregation in `postFormCandidates` preserved (`status` + `body` per failed candidate).

## Validation
- `npm run typecheck`
- `npm run test:unit -- tests/unit/liferay-gateway.test.ts tests/unit/liferay-resource-sync-shared.test.ts tests/unit/liferay-resource-sync-template.test.ts`
- Result: pass (full unit suite executed in this run: 849/849)
