### PR TITLE
docs: add actionable OAuth troubleshooting playbook

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -102,6 +102,68 @@ ldev portal check                  # Retry
 
 **Fix**: Manually complete setup at http://localhost:8080, then retry OAuth install.
 
+### OAuth quick diagnosis checklist
+
+When OAuth keeps failing, run this sequence in order:
+
+```bash
+ldev context --json
+ldev portal check
+ldev liferay auth check
+ldev oauth install --write-env
+ldev portal check
+```
+
+What to verify in the output:
+- `liferay.url` points to the expected portal host/port.
+- `liferay.oauth2ClientId` and `liferay.oauth2ClientSecret` are present after install.
+- `ldev portal check` returns success after reinstalling OAuth.
+
+### OAuth error signatures and fixes
+
+#### `invalid_client` or `401` during token fetch
+
+**Cause**: Stale or mismatched OAuth credentials.
+
+**Fix**:
+```bash
+ldev oauth install --write-env
+ldev portal check
+```
+
+If it persists, check for conflicting shell variables overriding local config and unset them before retrying.
+
+#### `403 Forbidden` on API calls after successful token fetch
+
+**Cause**: OAuth app exists but scopes/permissions are incomplete for the endpoint.
+
+**Fix**:
+1. Re-run `ldev oauth install --write-env`.
+2. Retry the failing command.
+3. If still failing, confirm portal-side OAuth app permissions for the target API.
+
+#### Connection refused / timeout during OAuth install
+
+**Cause**: Portal is not reachable at the configured URL.
+
+**Fix**:
+```bash
+ldev doctor
+ldev status
+ldev logs diagnose
+```
+
+Then verify `.liferay-cli.local.yml` points to the active local portal URL.
+
+#### OAuth install succeeds but later commands still fail
+
+**Cause**: Credentials were written correctly, but another config source is overriding them.
+
+**Fix**:
+1. Check environment variables first (highest precedence).
+2. Confirm `.liferay-cli.local.yml` contains the expected OAuth values.
+3. Re-run `ldev context --json` to confirm the effective resolved values.
+
 ---
 
 ## Database & Import Issues


### PR DESCRIPTION
## Summary
- Expands OAuth troubleshooting guidance with a practical diagnosis checklist and explicit error signatures.
- Keeps existing troubleshooting sections intact and adds actionable steps for common OAuth failure patterns.

## What Changed
- Updated `docs/troubleshooting.md` under `## OAuth & Authentication` with:
  - `OAuth quick diagnosis checklist`
  - `OAuth error signatures and fixes`
- Added concrete flows for:
  - `invalid_client` / `401` during token fetch
  - `403 Forbidden` after token success (scope/permission drift)
  - connection refused / timeout during OAuth install
  - config precedence conflicts where env vars override local file values

## Why
- OAuth is one of the highest-friction onboarding and support areas.
- This section gives a deterministic command order and verification points to reduce trial-and-error.

## Validation
- `npm run docs:build` -> pass
- `npm run docs:check-links` -> fails in this environment with `spawn EINVAL`
- `npm run verify:docs` therefore fails due to the same checker runtime issue, not markdown build errors
