### PR TITLE
ci: add Windows smoke test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,8 +70,22 @@ jobs:
           ldev --help
           ldev --version
 
+  smoke-windows:
+    needs: check
+    runs-on: windows-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci --ignore-scripts
+      - run: npm run build
+      - run: npm run test:smoke
+
   package:
-    needs: [smoke, security-audit]
+    needs: [smoke, smoke-windows, security-audit]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
## Summary
- Adds an additional Windows smoke-test job to the CI workflow.
- The new job runs build and smoke tests on windows-latest.

## What Changed
- Updated: .github/workflows/ci.yml
  - Added smoke-windows job:
    - runs-on: windows-latest
    - npm ci --ignore-scripts
    - npm run build
    - npm run test:smoke
  - Updated package.needs to require smoke-windows together with smoke and security-audit.

## Why
- Validates CI on a platform used frequently for day-to-day development.
- Improves cross-platform confidence with low implementation risk.

## Validation
- Validated locally on Windows:
  - npm run build
  - npm run test:smoke
- Result: pass
