### PR TITLE
chore(i18n): normalize user-facing messages to English

### DIFF
--- a/src/features/db/db-sync.ts
+++ b/src/features/db/db-sync.ts
@@ -29,7 +29,7 @@ export async function runDbSync(
   });
 
   if (!download.databaseBackupFile) {
-    throw new Error('db sync esperaba un backup de base de datos descargado.');
+    throw new Error('db sync expected a downloaded database backup.');
   }
 
   const importResult = await runDbImport(config, {

--- a/src/features/env/env-health.ts
+++ b/src/features/env/env-health.ts
@@ -68,7 +68,7 @@ export async function waitForServiceHealthy(
 
         if (current.state === 'exited' || current.state === 'dead') {
           throw new Error(
-            `Servicio ${service} no pudo arrancar (state=${current.state}, health=${current.health ?? 'n/a'}).`,
+            `Service ${service} failed to start (state=${current.state}, health=${current.health ?? 'n/a'}).`,
           );
         }
 
@@ -77,16 +77,13 @@ export async function waitForServiceHealthy(
       {timeout: timeoutSeconds * 1000, interval: pollIntervalSeconds * 1000},
     );
   } catch (error) {
-    if (
-      error instanceof Error &&
-      (error.message.includes('no pudo arrancar') || !error.message.includes('Timed out'))
-    ) {
+    if (error instanceof Error && (error.message.includes('failed to start') || !error.message.includes('Timed out'))) {
       throw error;
     }
 
     const last = lastStatus ?? (await inspectComposeService(context, service, processOptions));
     throw new Error(
-      `Timeout esperando ${service} healthy/running (state=${last.state ?? 'unknown'}, health=${last.health ?? 'n/a'}).`,
+      `Timed out waiting for ${service} healthy/running (state=${last.state ?? 'unknown'}, health=${last.health ?? 'n/a'}).`,
       {cause: error},
     );
   }

--- a/src/features/env/env-logs-diagnose.ts
+++ b/src/features/env/env-logs-diagnose.ts
@@ -50,7 +50,7 @@ export async function runEnvLogsDiagnose(
   const capabilities = await detectCapabilities(config.cwd);
 
   if (!capabilities.hasDocker || !capabilities.hasDockerCompose) {
-    throw new CliError('Docker y docker compose son obligatorios para logs diagnose.', {
+    throw new CliError('Docker and docker compose are required for logs diagnose.', {
       code: 'ENV_CAPABILITY_MISSING',
     });
   }
@@ -204,16 +204,16 @@ function suggestCauses(exceptionClass: string, stackTrace: string): string[] {
     causes.add('Validate permissions, content references, or missing data');
   }
   if (lowerClass.includes('nullpointer')) {
-    causes.add('Revisar nulls en el cambio reciente y servicios OSGi no inicializados');
+    causes.add('Review recent null-handling changes and uninitialized OSGi services');
   }
   if (lowerClass.includes('nosuch') || lowerTrace.includes('nosuch')) {
     causes.add('The requested resource does not exist or the reference is stale');
   }
   if (lowerClass.includes('sql') || lowerTrace.includes('postgres') || lowerTrace.includes('jdbc')) {
-    causes.add('Inspeccionar cambios de esquema, consultas y conectividad con PostgreSQL');
+    causes.add('Inspect schema changes, queries, and PostgreSQL connectivity');
   }
   if (lowerTrace.includes('unsatisfied') || lowerTrace.includes('unresolved constraint')) {
-    causes.add('Hay bundles OSGi con dependencias sin resolver');
+    causes.add('There are OSGi bundles with unresolved dependencies');
   }
   if (lowerTrace.includes('permission') || lowerTrace.includes('principal')) {
     causes.add('Check permissions, technical user, and OAuth2 scope');

--- a/src/features/env/env-logs.ts
+++ b/src/features/env/env-logs.ts
@@ -24,7 +24,7 @@ export async function runEnvLogs(config: AppConfig, options?: EnvLogsOptions): P
   const capabilities = await detectCapabilities(config.cwd);
 
   if (!capabilities.hasDocker || !capabilities.hasDockerCompose) {
-    throw new CliError('Docker y docker compose son obligatorios para env logs.', {code: 'ENV_CAPABILITY_MISSING'});
+    throw new CliError('Docker and docker compose are required for env logs.', {code: 'ENV_CAPABILITY_MISSING'});
   }
 
   const args = ['logs'];

--- a/src/features/env/env-status.ts
+++ b/src/features/env/env-status.ts
@@ -14,7 +14,7 @@ export async function runEnvStatus(
 
 export function formatEnvStatus(report: EnvStatusReport): string {
   if (!report.liferay) {
-    throw new CliError('No se ha podido resolver el servicio liferay del compose.', {code: 'ENV_SERVICE_NOT_FOUND'});
+    throw new CliError('Could not resolve the liferay service from compose.', {code: 'ENV_SERVICE_NOT_FOUND'});
   }
 
   return [

--- a/src/features/oauth/oauth-env.ts
+++ b/src/features/oauth/oauth-env.ts
@@ -8,7 +8,7 @@ export async function writeCredentialsToLocalProfile(
   scopeAliases?: string[],
 ): Promise<boolean> {
   if (!localProfileFile) {
-    throw new CliError('No se ha detectado .liferay-cli.local.yml para persistir las credenciales OAuth2.', {
+    throw new CliError('No .liferay-cli.local.yml was detected to persist OAuth2 credentials.', {
       code: 'OAUTH_LOCAL_PROFILE_NOT_FOUND',
     });
   }

--- a/src/features/oauth/oauth-install.ts
+++ b/src/features/oauth/oauth-install.ts
@@ -164,14 +164,14 @@ export function formatOAuthInstall(result: OAuthInstallResult): string {
 
   if (result.readOnly) {
     lines.push('');
-    lines.push('--- App read-only (solo lectura) ---');
+    lines.push('--- App read-only ---');
     lines.push(`LIFERAY_CLI_OAUTH2_READONLY_CLIENT_ID=${result.readOnly.clientId}`);
     lines.push(`LIFERAY_CLI_OAUTH2_READONLY_CLIENT_SECRET=${result.readOnly.clientSecret}`);
   }
 
   if (result.localProfileUpdated && result.localProfileFile) {
     lines.push('');
-    lines.push(`.liferay-cli.local.yml actualizado: ${result.localProfileFile}`);
+    lines.push(`.liferay-cli.local.yml updated: ${result.localProfileFile}`);
   }
 
   if (result.verification.attempted) {

--- a/src/features/worktree/worktree-btrfs-refresh-base.ts
+++ b/src/features/worktree/worktree-btrfs-refresh-base.ts
@@ -40,7 +40,7 @@ export async function runWorktreeBtrfsRefreshBase(options: {
     });
 
   const refreshedSubdirs = options.printer
-    ? await withProgress(options.printer, 'Actualizando BTRFS_BASE desde el entorno principal', refresh)
+    ? await withProgress(options.printer, 'Refreshing BTRFS_BASE from the main environment', refresh)
     : await refresh();
 
   if (!btrfs.baseDir) {
@@ -60,8 +60,8 @@ export async function runWorktreeBtrfsRefreshBase(options: {
 
 export function formatWorktreeBtrfsRefreshBase(result: WorktreeBtrfsRefreshBaseResult): string {
   return [
-    `BTRFS_BASE actualizada: ${result.baseDataRoot}`,
-    `Origen: ${result.sourceDataRoot}`,
-    `Subdirectorios refrescados: ${result.refreshedSubdirs.join(', ')}`,
+    `BTRFS_BASE refreshed: ${result.baseDataRoot}`,
+    `Source: ${result.sourceDataRoot}`,
+    `Refreshed subdirectories: ${result.refreshedSubdirs.join(', ')}`,
   ].join('\n');
 }

--- a/src/features/worktree/worktree-clean.ts
+++ b/src/features/worktree/worktree-clean.ts
@@ -81,7 +81,7 @@ export async function runWorktreeClean(options: {
     !worktreeDirExists &&
     !isOwnedBtrfsWorktreeDataRoot(path.join(btrfs.envsDir ?? '', target.name), target.name, btrfs.envsDir)
   ) {
-    throw new CliError(`El path no es un git worktree registrado: ${target.worktreeDir}`, {
+    throw new CliError(`Path is not a registered git worktree: ${target.worktreeDir}`, {
       code: 'WORKTREE_NOT_REGISTERED',
     });
   }
@@ -167,7 +167,7 @@ export async function runWorktreeClean(options: {
   };
 
   if (options.printer) {
-    await withProgress(options.printer, `Eliminando worktree ${target.name}`, cleanTask);
+    await withProgress(options.printer, `Removing worktree ${target.name}`, cleanTask);
   } else {
     await cleanTask();
   }
@@ -234,12 +234,12 @@ export async function runWorktreeClean(options: {
 }
 
 export function formatWorktreeClean(result: WorktreeCleanResult): string {
-  const lines = [`Worktree eliminado: ${result.worktreeName}`];
+  const lines = [`Worktree removed: ${result.worktreeName}`];
   if (result.branchDeleted) {
     lines.push('Local branch deleted: yes');
   }
   if (result.dataRootsDeleted.length > 0) {
-    lines.push(`Data roots eliminados: ${result.dataRootsDeleted.length}`);
+    lines.push(`Data roots removed: ${result.dataRootsDeleted.length}`);
   }
   if (result.dataRootsSkipped.length > 0) {
     lines.push(`Data roots kept outside the cleanup perimeter: ${result.dataRootsSkipped.length}`);
@@ -257,7 +257,7 @@ function resolveTarget(
   if (context.isWorktree && context.currentWorktreeName) {
     return resolveWorktreeTarget(context.mainRepoRoot, context.currentWorktreeName);
   }
-  throw new CliError('worktree clean necesita un NAME o ejecutarse dentro del worktree objetivo.', {
+  throw new CliError('worktree clean requires a NAME or must run inside the target worktree.', {
     code: 'WORKTREE_NAME_REQUIRED',
   });
 }

--- a/src/features/worktree/worktree-env.ts
+++ b/src/features/worktree/worktree-env.ts
@@ -142,7 +142,7 @@ export async function runWorktreeEnv(options: {
   await ensurePortalExtLocalOverride(target.worktreeDir, ports.httpPort);
 
   if (options.printer) {
-    options.printer.info(`Worktree env preparado: ${target.name} (${ports.httpPort})`);
+    options.printer.info(`Worktree env prepared: ${target.name} (${ports.httpPort})`);
   }
 
   return {
@@ -178,7 +178,7 @@ function resolveTarget(context: ReturnType<typeof resolveWorktreeContext>, name?
   }
 
   if (!context.isWorktree || !context.currentWorktreeName) {
-    throw new CliError('worktree env debe ejecutarse dentro de un worktree o recibir --name.', {
+    throw new CliError('worktree env must run inside a worktree or receive --name.', {
       code: 'WORKTREE_NAME_REQUIRED',
     });
   }

--- a/src/features/worktree/worktree-gc.ts
+++ b/src/features/worktree/worktree-gc.ts
@@ -85,7 +85,7 @@ export function formatWorktreeGc(result: WorktreeGcResult): string {
   if (!result.apply) {
     return result.candidates.map((candidate) => `DRY-RUN GC candidate: ${candidate}`).join('\n');
   }
-  return result.cleaned.map((candidate) => `GC eliminado: ${candidate}`).join('\n');
+  return result.cleaned.map((candidate) => `GC removed: ${candidate}`).join('\n');
 }
 
 function loadComposePrefix(mainRepoRoot: string): string {


### PR DESCRIPTION
## Summary
- Normalizes user-facing messages from Spanish to English across worktree, env, db, and oauth flows.
- Keeps behavior, error codes, and CLI contracts unchanged.
- Includes only string/message changes (no business-logic refactor).

## What Changed
- `src/features/worktree/*`
  - translated progress, formatter, and validation/error messages.
- `src/features/env/*`
  - translated capability and status errors.
  - translated health timeout/startup errors while preserving matching logic.
  - translated diagnose suggested-cause messages.
- `src/features/db/db-sync.ts`
  - translated missing backup error text.
- `src/features/oauth/*`
  - translated local-profile and read-only/install output labels.

## Validation
- `npm run typecheck`
- Push hook passed:
  - `npm run lint`
  - `npm run format:check`
  - `npm run typecheck`
  - `npm run test:unit`
  - `npm run build`
  - `npm run test:smoke`

## Scope Notes
- No command names/flags/output schemas were changed.
- Existing lint warnings outside this PR scope remain as warnings.
