### PR TITLE
refactor(liferay): migrate residual CliError throws to LiferayErrors factory

### DIFF
--- a/src/features/liferay/content/liferay-content-journal-shared.ts
+++ b/src/features/liferay/content/liferay-content-journal-shared.ts
@@ -3,6 +3,7 @@ import {CliError} from '../../../core/errors.js';
 import type {OAuthTokenClient} from '../../../core/http/auth.js';
 import type {LiferayApiClient} from '../../../core/http/client.js';
 import type {LiferayGateway} from '../liferay-gateway.js';
+import {LiferayErrors} from '../errors/index.js';
 import {fetchPagedItems, normalizeLocalizedName} from '../inventory/liferay-inventory-shared.js';
 
 export type JsonwsJournalArticleRow = {
@@ -90,7 +91,6 @@ export async function fetchJournalArticleRowsInFolder(
   gateway: LiferayGateway,
   groupId: number,
   folderId: number,
-  errorCode: string,
 ): Promise<JsonwsJournalArticleRow[]> {
   const pageSize = 200;
   const rows: JsonwsJournalArticleRow[] = [];
@@ -107,17 +107,14 @@ export async function fetchJournalArticleRowsInFolder(
       );
     } catch (error) {
       if (isGatewayStatus(error, 403)) {
-        throw new CliError(`403 Forbidden on journal.journalfolder/get-folders-and-articles for folder ${folderId}.`, {
-          code: errorCode,
-        });
+        throw LiferayErrors.contentJournalError(
+          `403 Forbidden on journal.journalfolder/get-folders-and-articles for folder ${folderId}.`,
+        );
       }
 
       if (isGatewayError(error)) {
-        throw new CliError(
+        throw LiferayErrors.contentJournalError(
           `journal folder articles for folder ${folderId} failed with status=${getGatewayStatus(error) ?? 'unknown'}.`,
-          {
-            code: errorCode,
-          },
         );
       }
 
@@ -125,9 +122,9 @@ export async function fetchJournalArticleRowsInFolder(
     }
 
     if (!Array.isArray(rawPage)) {
-      throw new CliError(`journal folder articles for folder ${folderId} failed with status=unknown.`, {
-        code: errorCode,
-      });
+      throw LiferayErrors.contentJournalError(
+        `journal folder articles for folder ${folderId} failed with status=unknown.`,
+      );
     }
 
     const page = dedupeJournalRows(rawPage.filter(isJournalArticleRow));
@@ -147,7 +144,6 @@ export async function fetchJournalFoldersByParent(
   gateway: LiferayGateway,
   groupId: number,
   parentFolderId: number,
-  errorCode: string,
 ): Promise<Array<{folderId: number; name: string}>> {
   let folders: JsonwsJournalFolder[];
 
@@ -158,11 +154,8 @@ export async function fetchJournalFoldersByParent(
     );
   } catch (error) {
     if (isGatewayError(error)) {
-      throw new CliError(
+      throw LiferayErrors.contentJournalError(
         `journal folders for parent ${parentFolderId} failed with status=${getGatewayStatus(error) ?? 'unknown'}.`,
-        {
-          code: errorCode,
-        },
       );
     }
 
@@ -170,9 +163,7 @@ export async function fetchJournalFoldersByParent(
   }
 
   if (!Array.isArray(folders)) {
-    throw new CliError(`journal folders for parent ${parentFolderId} failed with status=unknown.`, {
-      code: errorCode,
-    });
+    throw LiferayErrors.contentJournalError(`journal folders for parent ${parentFolderId} failed with status=unknown.`);
   }
 
   return folders

--- a/src/features/liferay/content/liferay-content-prune-plan.ts
+++ b/src/features/liferay/content/liferay-content-prune-plan.ts
@@ -52,7 +52,7 @@ export async function fetchJournalArticlesInFolder(
   groupId: number,
   folderId: number,
 ): Promise<ArticleWithFolder[]> {
-  const rows = await fetchJournalArticleRowsInFolder(gateway, groupId, folderId, 'LIFERAY_CONTENT_PRUNE_ERROR');
+  const rows = await fetchJournalArticleRowsInFolder(gateway, groupId, folderId);
 
   return rows.map((article) => ({
     id: Number(article.resourcePrimKey ?? 0),

--- a/src/features/liferay/content/liferay-content-stats.ts
+++ b/src/features/liferay/content/liferay-content-stats.ts
@@ -385,9 +385,7 @@ async function enrichFoldersWithStructures(
     const counts = new Map<string, number>();
 
     await mapConcurrent(folder.subtreeFolderIds, JOURNAL_FOLDER_CONCURRENCY, async (folderId) => {
-      const rows = await runLimited(() =>
-        fetchJournalArticleRowsInFolder(articleGateway, groupId, folderId, 'LIFERAY_CONTENT_STATS_ERROR'),
-      );
+      const rows = await runLimited(() => fetchJournalArticleRowsInFolder(articleGateway, groupId, folderId));
 
       await hydrateMissingJournalStructureDefinitions(
         articleGateway,
@@ -429,9 +427,7 @@ async function collectJournalFolderTree(
   parentFolderId: number,
   runLimited: <T>(task: () => Promise<T>) => Promise<T>,
 ): Promise<JournalFolderNode[]> {
-  const folders = await runLimited(() =>
-    fetchJournalFoldersByParent(gateway, groupId, parentFolderId, 'LIFERAY_CONTENT_STATS_ERROR'),
-  );
+  const folders = await runLimited(() => fetchJournalFoldersByParent(gateway, groupId, parentFolderId));
 
   return mapConcurrent(folders, JOURNAL_FOLDER_CONCURRENCY, async (folder) => ({
     folderId: folder.folderId,
@@ -446,9 +442,7 @@ async function buildJournalFolderStats(
   folder: JournalFolderNode,
   runLimited: <T>(task: () => Promise<T>) => Promise<T>,
 ): Promise<ComputedFolderStats> {
-  const rows = await runLimited(() =>
-    fetchJournalArticleRowsInFolder(gateway, groupId, folder.folderId, 'LIFERAY_CONTENT_STATS_ERROR'),
-  );
+  const rows = await runLimited(() => fetchJournalArticleRowsInFolder(gateway, groupId, folder.folderId));
 
   const childStats = await mapConcurrent(folder.children, JOURNAL_FOLDER_CONCURRENCY, (child) =>
     buildJournalFolderStats(gateway, groupId, child, runLimited),

--- a/src/features/liferay/errors/liferay-error-codes.ts
+++ b/src/features/liferay/errors/liferay-error-codes.ts
@@ -23,6 +23,7 @@ export enum LiferayErrorCode {
   // Content errors
   CONTENT_PRUNE_ERROR = 'LIFERAY_CONTENT_PRUNE_ERROR',
   CONTENT_STATS_ERROR = 'LIFERAY_CONTENT_STATS_ERROR',
+  CONTENT_JOURNAL_ERROR = 'LIFERAY_CONTENT_JOURNAL_ERROR',
 
   // Gateway/HTTP errors
   GATEWAY_ERROR = 'LIFERAY_GATEWAY_ERROR',
@@ -72,6 +73,7 @@ export const errorCodeMetadata: Record<
 
   [LiferayErrorCode.CONTENT_PRUNE_ERROR]: {severity: 'error', retryable: false, logFullMessage: false},
   [LiferayErrorCode.CONTENT_STATS_ERROR]: {severity: 'error', retryable: false, logFullMessage: false},
+  [LiferayErrorCode.CONTENT_JOURNAL_ERROR]: {severity: 'error', retryable: false, logFullMessage: false},
 
   [LiferayErrorCode.GATEWAY_ERROR]: {severity: 'error', retryable: false, logFullMessage: false},
 

--- a/src/features/liferay/errors/liferay-error-factory.ts
+++ b/src/features/liferay/errors/liferay-error-factory.ts
@@ -121,6 +121,12 @@ export const LiferayErrors = {
     createLiferayError(message, LiferayErrorCode.CONTENT_STATS_ERROR, options),
 
   /**
+   * Journal transport operation failed (folder traversal, article fetch, folder fetch).
+   */
+  contentJournalError: (message: string, options?: LiferayErrorOptions): CliError =>
+    createLiferayError(message, LiferayErrorCode.CONTENT_JOURNAL_ERROR, options),
+
+  /**
    * HTTP gateway operation failed.
    */
   gatewayError: (message: string, options?: LiferayErrorOptions): CliError =>

--- a/src/features/liferay/inventory/liferay-inventory-shared.ts
+++ b/src/features/liferay/inventory/liferay-inventory-shared.ts
@@ -84,7 +84,7 @@ export async function resolveSite(
       createJsonwsFallbackStep(gateway, normalizeResolvedSite, normalizeFriendlyUrl, normalizeLocalizedName),
     );
 
-  const result = await pipeline.execute(site, `Could not resolve site "${site}".`);
+  const result = await pipeline.execute(site);
   resolvedSiteCache.set(cacheKey, result);
   return result;
 }
@@ -163,7 +163,7 @@ export function normalizeFriendlyUrl(value: string): string {
 function normalizeResolvedSite(payload: SiteLookupPayload | null, site: string): ResolvedSite {
   const id = payload?.id ?? -1;
   if (id <= 0) {
-    throw new CliError(`Site not found: ${site}.`, {code: 'LIFERAY_SITE_NOT_FOUND'});
+    throw LiferayErrors.siteNotFound(site);
   }
 
   return {

--- a/src/features/liferay/inventory/liferay-site-resolver.ts
+++ b/src/features/liferay/inventory/liferay-site-resolver.ts
@@ -1,5 +1,6 @@
 import {CliError} from '../../../core/errors.js';
 import type {LiferayGateway} from '../liferay-gateway.js';
+import {LiferayErrors} from '../errors/index.js';
 
 /**
  * Resolved site payload from Liferay API.
@@ -81,7 +82,7 @@ export class SiteResolutionPipeline {
    * - Steps throw 404/403 to continue (miss)
    * - Steps throw other errors to propagate (unexpected)
    */
-  async execute(site: string, fallbackErrorMessage: string): Promise<ResolvedSite> {
+  async execute(site: string): Promise<ResolvedSite> {
     for (const {name, step} of this.steps) {
       try {
         const result = await step(site);
@@ -101,7 +102,7 @@ export class SiteResolutionPipeline {
       }
     }
 
-    throw new CliError(fallbackErrorMessage, {code: 'LIFERAY_SITE_NOT_FOUND'});
+    throw LiferayErrors.siteNotFound(site);
   }
 }
 

--- a/src/features/liferay/resource/liferay-resource-sync-structure.ts
+++ b/src/features/liferay/resource/liferay-resource-sync-structure.ts
@@ -1,5 +1,4 @@
 import type {AppConfig} from '../../../core/config/load-config.js';
-import {CliError} from '../../../core/errors.js';
 import {LiferayErrors} from '../errors/index.js';
 import {resolveSite} from '../inventory/liferay-inventory-shared.js';
 import {resolveStructureFile} from './liferay-resource-paths.js';
@@ -58,10 +57,7 @@ export async function runLiferayResourceSyncStructure(
   // Call strategy methods
   const local = await structureSyncStrategy.resolveLocal(config, site, strategyOptions);
   if (!local) {
-    throw new CliError(`Structure file not found for key '${options.key}'.`, {
-      code: 'LIFERAY_RESOURCE_FILE_NOT_FOUND',
-      details: {key: options.key, structureFile},
-    });
+    throw LiferayErrors.resourceFileNotFound(options.key, {details: {key: options.key, structureFile}});
   }
 
   const remote = await structureSyncStrategy.findRemote(config, site, local, strategyOptions, dependencies);

--- a/src/features/liferay/resource/sync-engine.ts
+++ b/src/features/liferay/resource/sync-engine.ts
@@ -13,7 +13,6 @@
  */
 
 import type {AppConfig} from '../../../core/config/load-config.js';
-import {CliError} from '../../../core/errors.js';
 import type {ResolvedSite} from '../inventory/liferay-site-resolver.js';
 import {LiferayErrors} from '../errors/index.js';
 import type {ResourceSyncDependencies, ResourceSyncResult} from './liferay-resource-sync-shared.js';
@@ -131,7 +130,7 @@ export async function syncArtifact<Local = Record<string, unknown>, Remote = Rec
   // 1. Resolve local artifact
   const localArtifact = await strategy.resolveLocal(config, site, strategyOpts);
   if (!localArtifact) {
-    throw new CliError('Local artifact not found', {code: 'LIFERAY_RESOURCE_FILE_NOT_FOUND'});
+    throw LiferayErrors.resourceFileNotFound('local artifact');
   }
 
   // 2. Find remote artifact

--- a/tests/unit/liferay-inventory.test.ts
+++ b/tests/unit/liferay-inventory.test.ts
@@ -156,7 +156,7 @@ describe('liferay inventory shared', () => {
     });
 
     await expect(resolveSite(CONFIG, '/global', {apiClient, tokenClient: TOKEN_CLIENT})).rejects.toThrow(
-      'Could not resolve site "/global".',
+      'Site not found: /global.',
     );
   });
 

--- a/tests/unit/liferay-site-resolver.test.ts
+++ b/tests/unit/liferay-site-resolver.test.ts
@@ -62,7 +62,7 @@ describe('SiteResolutionPipeline', () => {
         throw new Error('Should not reach here');
       });
 
-    const result = await pipeline.execute('test-site', 'Not found');
+    const result = await pipeline.execute('test-site');
 
     expect(result).toEqual({id: 123, friendlyUrlPath: '/test', name: 'Test'});
   });
@@ -75,9 +75,7 @@ describe('SiteResolutionPipeline', () => {
       .addStep('step2', async () => null)
       .addStep('step3', async () => null);
 
-    await expect(pipeline.execute('missing', 'Custom error message')).rejects.toThrow(
-      new RegExp('Custom error message'),
-    );
+    await expect(pipeline.execute('missing')).rejects.toThrow(new RegExp('Site not found'));
   });
 
   test('calls onStepSuccess hook when step succeeds', async () => {
@@ -86,7 +84,7 @@ describe('SiteResolutionPipeline', () => {
 
     pipeline.addStep('success-step', async () => ({id: 1, friendlyUrlPath: '/test', name: 'Test'}));
 
-    await pipeline.execute('test', 'Not found');
+    await pipeline.execute('test');
 
     expect(onStepSuccess).toHaveBeenCalledWith('success-step', 'test');
   });
@@ -101,7 +99,7 @@ describe('SiteResolutionPipeline', () => {
       })
       .addStep('recovery-step', async () => ({id: 1, friendlyUrlPath: '/test', name: 'Test'}));
 
-    await expect(pipeline.execute('test', 'Not found')).rejects.toThrow('Test error');
+    await expect(pipeline.execute('test')).rejects.toThrow('Test error');
 
     expect(onStepFailure).toHaveBeenCalledWith('failing-step', expect.any(Error));
   });
@@ -113,7 +111,7 @@ describe('SiteResolutionPipeline', () => {
     const pipeline = new SiteResolutionPipeline();
     pipeline.addStep('step1', step1).addStep('step2', step2);
 
-    await pipeline.execute('test', 'Not found');
+    await pipeline.execute('test');
 
     expect(step1).toHaveBeenCalledWith('test');
     expect(step2).toHaveBeenCalledWith('test');
@@ -129,7 +127,7 @@ describe('SiteResolutionPipeline', () => {
     const pipeline = new SiteResolutionPipeline({onStepFailure});
     pipeline.addStep('step1', step1).addStep('step2', step2);
 
-    await expect(pipeline.execute('test', 'Not found')).rejects.toThrow('Transient error');
+    await expect(pipeline.execute('test')).rejects.toThrow('Transient error');
 
     expect(step1).toHaveBeenCalled();
     expect(step2).not.toHaveBeenCalled();
@@ -401,7 +399,7 @@ describe('SiteResolutionPipeline: Regression-hardening (R15)', () => {
         });
 
       // Use numeric input that matches by-id, so it succeeds on first step
-      const result = await pipeline.execute('123', 'not found');
+      const result = await pipeline.execute('123');
 
       expect(callOrder).toEqual(['by-id']);
       expect(result.id).toBe(123);
@@ -422,7 +420,7 @@ describe('SiteResolutionPipeline: Regression-hardening (R15)', () => {
         });
 
       // Use non-numeric input so by-id returns null and falls through to by-friendly-url
-      const result = await pipeline.execute('guest', 'not found');
+      const result = await pipeline.execute('guest');
 
       expect(callOrder).toEqual(['by-id', 'by-friendly-url']);
       expect(result.id).toBe(456);
@@ -446,7 +444,7 @@ describe('SiteResolutionPipeline: Regression-hardening (R15)', () => {
           return {id: 999, friendlyUrlPath: '/other', name: 'Other'};
         });
 
-      const result = await pipeline.execute('test', 'not found');
+      const result = await pipeline.execute('test');
 
       expect(result.id).toBe(789);
       expect(callOrder).toEqual(['step1', 'step2']);
@@ -472,7 +470,7 @@ describe('SiteResolutionPipeline: Regression-hardening (R15)', () => {
           return {id: 123, friendlyUrlPath: '/fallback', name: 'Fallback'};
         });
 
-      const result = await pipeline.execute('test', 'not found');
+      const result = await pipeline.execute('test');
 
       expect(result.id).toBe(123);
       expect(callOrder).toEqual(['step1', 'step2', 'step3']);
@@ -484,7 +482,7 @@ describe('SiteResolutionPipeline: Regression-hardening (R15)', () => {
         throw new CliError('resolve-site-by-id failed with status=500.', {code: 'LIFERAY_GATEWAY_ERROR'});
       });
 
-      await expect(pipeline.execute('test', 'custom not found message')).rejects.toThrow('status=500');
+      await expect(pipeline.execute('test')).rejects.toThrow('status=500');
     });
 
     test('all steps return miss (null/404/403) results in site-not-found', async () => {
@@ -498,9 +496,7 @@ describe('SiteResolutionPipeline: Regression-hardening (R15)', () => {
           throw new CliError('status=403', {code: 'LIFERAY_GATEWAY_ERROR'});
         });
 
-      await expect(pipeline.execute('missing', 'Could not find site "missing".')).rejects.toThrow(
-        'Could not find site "missing".',
-      );
+      await expect(pipeline.execute('missing')).rejects.toThrow('Site not found: missing.');
     });
 
     test('connection errors (non-gateway) propagate unchanged', async () => {
@@ -509,7 +505,7 @@ describe('SiteResolutionPipeline: Regression-hardening (R15)', () => {
         throw new Error('Connection timeout');
       });
 
-      await expect(pipeline.execute('test', 'not found')).rejects.toThrow('Connection timeout');
+      await expect(pipeline.execute('test')).rejects.toThrow('Connection timeout');
     });
   });
 
@@ -523,7 +519,7 @@ describe('SiteResolutionPipeline: Regression-hardening (R15)', () => {
         .addStep('step1', async () => null) // miss, skipped
         .addStep('step2', async () => ({id: 123, friendlyUrlPath: '/site', name: 'Site'})); // winner
 
-      await pipeline.execute('test', 'not found');
+      await pipeline.execute('test');
 
       expect(onStepSuccess).toHaveBeenCalledTimes(1);
       expect(onStepSuccess).toHaveBeenCalledWith('step2', 'test');
@@ -539,7 +535,7 @@ describe('SiteResolutionPipeline: Regression-hardening (R15)', () => {
         throw customError;
       });
 
-      await expect(pipeline.execute('test', 'not found')).rejects.toThrow();
+      await expect(pipeline.execute('test')).rejects.toThrow();
 
       expect(onStepFailure).toHaveBeenCalledTimes(1);
       expect(onStepFailure).toHaveBeenCalledWith('step1', expect.any(Error));
@@ -555,7 +551,7 @@ describe('SiteResolutionPipeline: Regression-hardening (R15)', () => {
         })
         .addStep('step2', async () => ({id: 123, friendlyUrlPath: '/site', name: 'Site'}));
 
-      await pipeline.execute('test', 'not found');
+      await pipeline.execute('test');
 
       expect(onStepSuccess).toHaveBeenCalledTimes(1);
       expect(onStepSuccess).toHaveBeenCalledWith('step2', 'test');
@@ -655,7 +651,7 @@ describe('SiteResolutionPipeline: Regression-hardening (R15)', () => {
         });
       });
 
-      const result = await pipeline.execute('test', 'not found');
+      const result = await pipeline.execute('test');
 
       expect(result.id).toBe(999);
       expect(callOrder).toEqual(['by-id', 'by-friendly-url-site', 'by-friendly-url-user', 'paginated-search']);
@@ -688,7 +684,7 @@ describe('SiteResolutionPipeline: Regression-hardening (R15)', () => {
           ),
         );
 
-      const result = await pipeline.execute('/global', 'not found');
+      const result = await pipeline.execute('/global');
 
       expect(result.id).toBe(777);
     });


### PR DESCRIPTION
## Summary

Adopt `LiferayErrors` factory pattern for all remaining `new CliError(...)` throw sites inside `features/liferay/**`.

## Changes

### New factory support
- **`liferay-error-codes.ts`**: Added `CONTENT_JOURNAL_ERROR` enum entry + metadata
- **`liferay-error-factory.ts`**: Added `contentJournalError(message, options?)` factory method

### Throw site migrations
- **`sync-engine.ts`**: `new CliError('Local artifact not found', ...)`  `LiferayErrors.resourceFileNotFound('local artifact')`
- **`liferay-resource-sync-structure.ts`**: structure key not found  `LiferayErrors.resourceFileNotFound(key, {details})`
- **`liferay-inventory-shared.ts`**: site not found throw  `LiferayErrors.siteNotFound(site)`
- **`liferay-site-resolver.ts`**: removed `fallbackErrorMessage` param from `execute()`; throw uses `LiferayErrors.siteNotFound(site)`
- **`liferay-content-journal-shared.ts`**: removed `errorCode: string` param from both fetch functions; all 5 throws use `LiferayErrors.contentJournalError(message)`
- **`liferay-content-stats.ts`**, **`liferay-content-prune-plan.ts`**: removed the now-unused errorCode arguments from 4 call sites

### Tests updated
- `liferay-site-resolver.test.ts`: removed 2nd arg from all `pipeline.execute()` calls; updated 2 message assertions
- `liferay-inventory.test.ts`: updated 1 message assertion

## Out of scope (intentionally left unchanged)
- `liferay-http-shared.ts` lines 42/56  dynamic errorCode param, correct pattern
- `liferay-error-factory.ts` lines 43/223  factory internals
- `liferay-resource-get-adt.ts:129`  details is array, incompatible with factory signature
- `artifact-paths.ts:182`  return pattern, not a throw
