### PR TITLE
fix(errors): replace throw new Error with CliError across src

### DIFF
--- a/src/commands/resource/resource-command-builder.ts
+++ b/src/commands/resource/resource-command-builder.ts
@@ -1,5 +1,7 @@
 import {Command} from 'commander';
 
+import {CliError} from '../../core/errors.js';
+
 import {createCommandContext} from '../../cli/command-context.js';
 import {addOutputFormatOption, createFormattedAction} from '../../cli/command-helpers.js';
 import {runLiferayPreflight} from '../../features/liferay/liferay-preflight.js';
@@ -258,7 +260,7 @@ export function buildResourceCommand(options: ResourceCommandOptions): Command {
     createFormattedAction(
       async (context, options) => {
         if (!options.key && !options.name) {
-          throw new Error('export-adt requires --key or --name');
+          throw new CliError('export-adt requires --key or --name', {code: 'RESOURCE_FLAG_REQUIRED'});
         }
         return runLiferayResourceExportAdts(context.config, {
           site: options.site,

--- a/src/features/ai/ai-install-project.ts
+++ b/src/features/ai/ai-install-project.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 
 import fs from 'fs-extra';
 
+import {CliError} from '../../core/errors.js';
 import type {ProjectType} from '../../core/config/project-type.js';
 import type {AiAssets} from './ai-manifest.js';
 import {copyAiTemplatePath, writeTextFileLf} from './ai-install-fs.js';
@@ -138,7 +139,9 @@ export function resolveSelectedSkills(vendorSkills: string[], requestedSkills: s
 
   const invalid = requestedSkills.filter((skillName) => !vendorSkills.includes(skillName));
   if (invalid.length > 0) {
-    throw new Error(`Unknown vendor skill(s): ${invalid.join(', ')}. Available skills: ${vendorSkills.join(', ')}`);
+    throw new CliError(`Unknown vendor skill(s): ${invalid.join(', ')}. Available skills: ${vendorSkills.join(', ')}`, {
+      code: 'AI_INSTALL_INVALID_VENDOR',
+    });
   }
 
   return requestedSkills;

--- a/src/features/ai/ai-manifest.ts
+++ b/src/features/ai/ai-manifest.ts
@@ -4,6 +4,8 @@ import {fileURLToPath} from 'node:url';
 
 import fs from 'fs-extra';
 
+import {CliError} from '../../core/errors.js';
+
 export type ManagedRuleNamespace = 'ldev' | 'ldev-workspace' | 'ldev-native';
 
 export type RuleLayer = 'ldev-common' | 'project-type';
@@ -169,7 +171,9 @@ function findPackageRoot(fromFile: string): string {
 
     const parent = path.dirname(current);
     if (parent === current) {
-      throw new Error(`Could not resolve the ldev package root from ${fromFile}`);
+      throw new CliError(`Could not resolve the ldev package root from ${fromFile}`, {
+        code: 'AI_PACKAGE_ROOT_NOT_FOUND',
+      });
     }
     current = parent;
   }

--- a/src/features/db/db-sync.ts
+++ b/src/features/db/db-sync.ts
@@ -1,6 +1,8 @@
 import type {AppConfig} from '../../core/config/load-config.js';
 import type {Printer} from '../../core/output/printer.js';
 
+import {CliError} from '../../core/errors.js';
+
 import {runDbDownload, type DbDownloadResult} from './db-download.js';
 import {runDbImport, type DbImportResult} from './db-import.js';
 
@@ -29,7 +31,7 @@ export async function runDbSync(
   });
 
   if (!download.databaseBackupFile) {
-    throw new Error('db sync expected a downloaded database backup.');
+    throw new CliError('db sync expected a downloaded database backup.', {code: 'DB_SYNC_STATE_MISSING'});
   }
 
   const importResult = await runDbImport(config, {

--- a/src/features/env/env-health.ts
+++ b/src/features/env/env-health.ts
@@ -1,5 +1,6 @@
 import pWaitFor from 'p-wait-for';
 
+import {CliError} from '../../core/errors.js';
 import type {RunProcessOptions} from '../../core/platform/process.js';
 import {runDocker, runDockerCompose} from '../../core/platform/docker.js';
 import {parseLines} from '../../core/utils/text.js';
@@ -67,8 +68,9 @@ export async function waitForServiceHealthy(
         lastStatus = current;
 
         if (current.state === 'exited' || current.state === 'dead') {
-          throw new Error(
+          throw new CliError(
             `Service ${service} failed to start (state=${current.state}, health=${current.health ?? 'n/a'}).`,
+            {code: 'ENV_SERVICE_FAILED_TO_START'},
           );
         }
 
@@ -82,9 +84,9 @@ export async function waitForServiceHealthy(
     }
 
     const last = lastStatus ?? (await inspectComposeService(context, service, processOptions));
-    throw new Error(
+    throw new CliError(
       `Timed out waiting for ${service} healthy/running (state=${last.state ?? 'unknown'}, health=${last.health ?? 'n/a'}).`,
-      {cause: error},
+      {code: 'ENV_SERVICE_TIMEOUT'},
     );
   }
 

--- a/src/features/env/env-restore.ts
+++ b/src/features/env/env-restore.ts
@@ -153,7 +153,7 @@ async function restoreDataSubdir(sourceDir: string, targetDir: string, processEn
     {env: processEnv, reject: false},
   );
   if (!result.ok) {
-    throw new Error(formatProcessError(result, `Could not restore ${sourceDir}`));
+    throw new CliError(formatProcessError(result, `Could not restore ${sourceDir}`), {code: 'ENV_RESTORE_FAILED'});
   }
 }
 
@@ -207,7 +207,9 @@ async function restorePostgresStorage(
     {env: processEnv, reject: false},
   );
   if (!result.ok) {
-    throw new Error(formatProcessError(result, 'Could not restore PostgreSQL storage'));
+    throw new CliError(formatProcessError(result, 'Could not restore PostgreSQL storage'), {
+      code: 'ENV_RESTORE_FAILED',
+    });
   }
 
   return true;

--- a/src/features/liferay/inventory/capabilities.ts
+++ b/src/features/liferay/inventory/capabilities.ts
@@ -12,6 +12,8 @@
  * - jsonws: Legacy Liferay JSONWS RPC API (/api/jsonws)
  */
 
+import {CliError} from '../../../core/errors.js';
+
 export type OperationName = 'site.resolve' | 'inventory.listSites' | 'inventory.listTemplates';
 
 export type TransportSurface = 'headless-admin-site' | 'headless-admin-user' | 'headless-delivery' | 'jsonws';
@@ -58,7 +60,7 @@ const POLICIES: ReadonlyMap<OperationName, OperationPolicy> = new Map<OperationN
 export function getOperationPolicy(operation: OperationName): OperationPolicy {
   const policy = POLICIES.get(operation);
   if (!policy) {
-    throw new Error(`No transport policy defined for operation: ${operation}`);
+    throw new CliError(`No transport policy defined for operation: ${operation}`, {code: 'LIFERAY_INVENTORY_ERROR'});
   }
   return policy;
 }

--- a/src/features/oauth/oauth-install-bundle.ts
+++ b/src/features/oauth/oauth-install-bundle.ts
@@ -150,7 +150,9 @@ function findPackageRoot(fromFile: string): string {
 
     const parent = path.dirname(current);
     if (parent === current) {
-      throw new Error(`Could not resolve the ldev package root from ${fromFile}`);
+      throw new CliError(`Could not resolve the ldev package root from ${fromFile}`, {
+        code: 'OAUTH_PACKAGE_ROOT_NOT_FOUND',
+      });
     }
     current = parent;
   }

--- a/src/features/project/project-scaffold.ts
+++ b/src/features/project/project-scaffold.ts
@@ -3,6 +3,8 @@ import {fileURLToPath} from 'node:url';
 
 import fs from 'fs-extra';
 
+import {CliError} from '../../core/errors.js';
+
 export type ProjectAssets = {
   repoRoot: string;
   scaffoldDir: string;
@@ -161,7 +163,7 @@ async function copyMissingFileFromCandidates(sourceCandidates: string[], destina
     }
   }
 
-  throw new Error(`Missing scaffold asset for ${destination}`);
+  throw new CliError(`Missing scaffold asset for ${destination}`, {code: 'PROJECT_SCAFFOLD_ASSET_MISSING'});
 }
 
 async function copyAsset(sourceRoot: string, destinationRoot: string, relativePath: string): Promise<void> {
@@ -182,7 +184,9 @@ async function copyAssetFromCandidates(
     }
   }
 
-  throw new Error(`Missing scaffold asset for ${destinationRelativePath} in ${sourceRoot}`);
+  throw new CliError(`Missing scaffold asset for ${destinationRelativePath} in ${sourceRoot}`, {
+    code: 'PROJECT_SCAFFOLD_ASSET_MISSING',
+  });
 }
 
 async function ensureFile(filePath: string): Promise<void> {
@@ -202,7 +206,9 @@ function findPackageRoot(fromFile: string): string {
 
     const parent = path.dirname(current);
     if (parent === current) {
-      throw new Error(`Could not resolve the ldev package root from ${fromFile}`);
+      throw new CliError(`Could not resolve the ldev package root from ${fromFile}`, {
+        code: 'PROJECT_PACKAGE_ROOT_NOT_FOUND',
+      });
     }
     current = parent;
   }


### PR DESCRIPTION
## Summary

Replaces all 14 `throw new Error(...)` sites across `src/` with `CliError` with thematic error codes, restoring the structured error contract (`.code`, `.exitCode`, `.details`) that `throw new Error` breaks.

## Motivation

`Error` has no `code`, `exitCode`, or `details`. The CLI entrypoint reports these as exit 1 without structured metadata and without sanitization. Every `throw new Error` was a gap in the error contract.

## What Changed

| File | Message | New code |
|---|---|---|
| `db/db-sync.ts` | missing backup file | `DB_SYNC_STATE_MISSING` |
| `env/env-health.ts` | service exited/dead | `ENV_SERVICE_FAILED_TO_START` |
| `env/env-health.ts` | wait-for timeout | `ENV_SERVICE_TIMEOUT` |
| `env/env-restore.ts` | docker copy failure (x2) | `ENV_RESTORE_FAILED` |
| `ai/ai-install-project.ts` | unknown vendor skills | `AI_INSTALL_INVALID_VENDOR` |
| `ai/ai-manifest.ts` | ldev root resolution | `AI_PACKAGE_ROOT_NOT_FOUND` |
| `project/project-scaffold.ts` | missing scaffold asset (x2) | `PROJECT_SCAFFOLD_ASSET_MISSING` |
| `project/project-scaffold.ts` | ldev root resolution | `PROJECT_PACKAGE_ROOT_NOT_FOUND` |
| `oauth/oauth-install-bundle.ts` | ldev root resolution | `OAUTH_PACKAGE_ROOT_NOT_FOUND` |
| `liferay/inventory/capabilities.ts` | missing operation policy | `LIFERAY_INVENTORY_ERROR` |
| `commands/resource/resource-command-builder.ts` | missing `--key`/`--name` flag | `RESOURCE_FLAG_REQUIRED` |

Added `CliError` imports to: `env-health.ts`, `ai-install-project.ts`, `ai-manifest.ts`, `project-scaffold.ts`, `capabilities.ts`, `resource-command-builder.ts`.

## Notes

- `ENV_SERVICE_TIMEOUT` drops the `{cause}` chain that `new Error` supported natively (ES2022 `cause`). `CliError` does not currently expose `cause` on its options  the error message retains full context via the inline state/health values.
- All codes are thematic and stable; no existing codes were reused incorrectly.

## Validation

- `npm run typecheck`  clean
- `npm run test:unit`  849/849 passed
