### PR TITLE
test(deploy): add unit tests for deploy-artifacts and deploy-gradle

### DIFF
--- a/tests/unit/deploy-artifacts.test.ts
+++ b/tests/unit/deploy-artifacts.test.ts
@@ -1,0 +1,273 @@
+import path from 'node:path';
+
+import fs from 'fs-extra';
+import {afterEach, beforeEach, describe, expect, test} from 'vitest';
+
+import {createTempDir} from '../../src/testing/temp-repo.js';
+import {CliError} from '../../src/core/errors.js';
+import {
+  listDeployArtifacts,
+  syncArtifactsToDirectory,
+  uniquePaths,
+  escapeSingleQuotes,
+  escapeShellArg,
+  ensureDeployArtifactsFound,
+  collectModuleArtifacts,
+} from '../../src/features/deploy/deploy-artifacts.js';
+
+// ---------------------------------------------------------------------------
+// uniquePaths — pure deduplication
+// ---------------------------------------------------------------------------
+
+describe('uniquePaths', () => {
+  test('removes duplicate paths', () => {
+    const result = uniquePaths(['/a/b.jar', '/a/b.jar', '/c/d.jar']);
+    expect(result).toEqual(['/a/b.jar', '/c/d.jar']);
+  });
+
+  test('preserves order of first occurrence', () => {
+    const result = uniquePaths(['/z.jar', '/a.jar', '/z.jar']);
+    expect(result).toEqual(['/z.jar', '/a.jar']);
+  });
+
+  test('returns empty array for empty input', () => {
+    expect(uniquePaths([])).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// escapeSingleQuotes — pure shell escaping
+// ---------------------------------------------------------------------------
+
+describe('escapeSingleQuotes', () => {
+  test('returns value unchanged when no single quotes', () => {
+    expect(escapeSingleQuotes('hello-world.jar')).toBe('hello-world.jar');
+  });
+
+  test('escapes a single quote', () => {
+    expect(escapeSingleQuotes("it's")).toBe("it'\"'\"'s");
+  });
+
+  test('escapes multiple single quotes', () => {
+    const result = escapeSingleQuotes("a'b'c");
+    expect(result).toBe("a'\"'\"'b'\"'\"'c");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// escapeShellArg — wraps in single quotes after escaping
+// ---------------------------------------------------------------------------
+
+describe('escapeShellArg', () => {
+  test('wraps a plain value in single quotes', () => {
+    expect(escapeShellArg('hello.jar')).toBe("'hello.jar'");
+  });
+
+  test('escapes and wraps a value with a space', () => {
+    expect(escapeShellArg('my file.jar')).toBe("'my file.jar'");
+  });
+
+  test('escapes a single quote inside the value', () => {
+    expect(escapeShellArg("it's.jar")).toBe("'it'\"'\"'s.jar'");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ensureDeployArtifactsFound — throws CliError when empty
+// ---------------------------------------------------------------------------
+
+describe('ensureDeployArtifactsFound', () => {
+  test('does not throw when artifacts array is non-empty', () => {
+    expect(() => ensureDeployArtifactsFound(['/a/b.jar'], 'module-a')).not.toThrow();
+  });
+
+  test('throws CliError with DEPLOY_ARTIFACTS_NOT_FOUND when empty', () => {
+    expect(() => ensureDeployArtifactsFound([], 'module-a')).toThrow(CliError);
+    try {
+      ensureDeployArtifactsFound([], 'module-a');
+    } catch (error) {
+      expect((error as CliError).code).toBe('DEPLOY_ARTIFACTS_NOT_FOUND');
+    }
+  });
+
+  test('includes the label in the error message', () => {
+    try {
+      ensureDeployArtifactsFound([], 'my-module');
+    } catch (error) {
+      expect((error as CliError).message).toContain('my-module');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listDeployArtifacts — file system
+// ---------------------------------------------------------------------------
+
+describe('listDeployArtifacts', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = createTempDir('dev-cli-deploy-artifacts-');
+  });
+
+  afterEach(async () => {
+    await fs.remove(tmpDir);
+  });
+
+  test('returns empty array when directory does not exist', async () => {
+    const result = await listDeployArtifacts(path.join(tmpDir, 'absent'));
+    expect(result).toEqual([]);
+  });
+
+  test('returns empty array for an empty directory', async () => {
+    const dir = path.join(tmpDir, 'empty');
+    await fs.ensureDir(dir);
+    expect(await listDeployArtifacts(dir)).toEqual([]);
+  });
+
+  test('returns .jar files', async () => {
+    const dir = path.join(tmpDir, 'jars');
+    await fs.ensureDir(dir);
+    await fs.writeFile(path.join(dir, 'module-a.jar'), '');
+    const result = await listDeployArtifacts(dir);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toContain('module-a.jar');
+  });
+
+  test('returns .war files', async () => {
+    const dir = path.join(tmpDir, 'wars');
+    await fs.ensureDir(dir);
+    await fs.writeFile(path.join(dir, 'theme.war'), '');
+    const result = await listDeployArtifacts(dir);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toContain('theme.war');
+  });
+
+  test('returns .xml files', async () => {
+    const dir = path.join(tmpDir, 'xmls');
+    await fs.ensureDir(dir);
+    await fs.writeFile(path.join(dir, 'config.xml'), '');
+    const result = await listDeployArtifacts(dir);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toContain('config.xml');
+  });
+
+  test('excludes non-artifact files', async () => {
+    const dir = path.join(tmpDir, 'mixed');
+    await fs.ensureDir(dir);
+    await fs.writeFile(path.join(dir, 'module.jar'), '');
+    await fs.writeFile(path.join(dir, 'readme.txt'), '');
+    await fs.writeFile(path.join(dir, 'config.json'), '');
+    const result = await listDeployArtifacts(dir);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toContain('module.jar');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// syncArtifactsToDirectory — copies files with deduplication
+// ---------------------------------------------------------------------------
+
+describe('syncArtifactsToDirectory', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = createTempDir('dev-cli-deploy-sync-');
+  });
+
+  afterEach(async () => {
+    await fs.remove(tmpDir);
+  });
+
+  test('returns 0 when artifacts list is empty', async () => {
+    const target = path.join(tmpDir, 'target');
+    expect(await syncArtifactsToDirectory(target, [])).toBe(0);
+  });
+
+  test('copies artifact to target directory', async () => {
+    const src = path.join(tmpDir, 'src');
+    const target = path.join(tmpDir, 'target');
+    await fs.ensureDir(src);
+    await fs.writeFile(path.join(src, 'module.jar'), 'compiled');
+
+    const count = await syncArtifactsToDirectory(target, [path.join(src, 'module.jar')]);
+    expect(count).toBe(1);
+    expect(await fs.pathExists(path.join(target, 'module.jar'))).toBe(true);
+  });
+
+  test('skips non-existent source files', async () => {
+    const target = path.join(tmpDir, 'target');
+    const count = await syncArtifactsToDirectory(target, [path.join(tmpDir, 'absent.jar')]);
+    expect(count).toBe(0);
+  });
+
+  test('deduplicates paths before copying', async () => {
+    const src = path.join(tmpDir, 'src');
+    const target = path.join(tmpDir, 'target');
+    await fs.ensureDir(src);
+    await fs.writeFile(path.join(src, 'module.jar'), 'compiled');
+
+    const artifact = path.join(src, 'module.jar');
+    const count = await syncArtifactsToDirectory(target, [artifact, artifact]);
+    expect(count).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// collectModuleArtifacts — builds candidate paths from context
+// ---------------------------------------------------------------------------
+
+describe('collectModuleArtifacts', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = createTempDir('dev-cli-deploy-collect-');
+  });
+
+  afterEach(async () => {
+    await fs.remove(tmpDir);
+  });
+
+  function makeContext(liferayDir: string) {
+    return {
+      repoRoot: path.dirname(liferayDir),
+      liferayDir,
+      dockerDir: path.join(path.dirname(liferayDir), 'docker'),
+      gradlewPath: path.join(liferayDir, 'gradlew'),
+      buildDir: path.join(liferayDir, 'build', 'docker'),
+      buildDeployDir: path.join(liferayDir, 'build', 'docker', 'deploy'),
+    };
+  }
+
+  test('returns empty array when no candidate dirs exist', async () => {
+    const liferayDir = path.join(tmpDir, 'liferay');
+    await fs.ensureDir(liferayDir);
+    const ctx = makeContext(liferayDir);
+    const result = await collectModuleArtifacts(ctx, 'my-module');
+    expect(result).toEqual([]);
+  });
+
+  test('finds artifact in modules build/libs', async () => {
+    const liferayDir = path.join(tmpDir, 'liferay');
+    const libsDir = path.join(liferayDir, 'modules', 'my-module', 'build', 'libs');
+    await fs.ensureDir(libsDir);
+    await fs.writeFile(path.join(libsDir, 'my-module-1.0.0.jar'), '');
+
+    const ctx = makeContext(liferayDir);
+    const result = await collectModuleArtifacts(ctx, 'my-module');
+    expect(result).toHaveLength(1);
+    expect(result[0]).toContain('my-module-1.0.0.jar');
+  });
+
+  test('finds artifact in theme dist dir', async () => {
+    const liferayDir = path.join(tmpDir, 'liferay');
+    const distDir = path.join(liferayDir, 'themes', 'my-theme', 'dist');
+    await fs.ensureDir(distDir);
+    await fs.writeFile(path.join(distDir, 'my-theme.war'), '');
+
+    const ctx = makeContext(liferayDir);
+    const result = await collectModuleArtifacts(ctx, 'my-theme');
+    expect(result).toHaveLength(1);
+    expect(result[0]).toContain('my-theme.war');
+  });
+});

--- a/tests/unit/deploy-gradle.test.ts
+++ b/tests/unit/deploy-gradle.test.ts
@@ -1,0 +1,157 @@
+import path from 'node:path';
+
+import fs from 'fs-extra';
+import {afterEach, beforeEach, describe, expect, test} from 'vitest';
+
+import {createTempDir} from '../../src/testing/temp-repo.js';
+import {
+  readPrepareCommit,
+  writePrepareCommit,
+  seedBuildDockerConfigs,
+  shouldRunBuildService,
+} from '../../src/features/deploy/deploy-gradle.js';
+
+// ---------------------------------------------------------------------------
+// writePrepareCommit / readPrepareCommit — round-trip
+// ---------------------------------------------------------------------------
+
+describe('writePrepareCommit / readPrepareCommit', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = createTempDir('dev-cli-deploy-gradle-');
+  });
+
+  afterEach(async () => {
+    await fs.remove(tmpDir);
+  });
+
+  function makeContext(buildDir: string) {
+    const liferayDir = path.dirname(buildDir);
+    return {
+      repoRoot: path.dirname(liferayDir),
+      liferayDir,
+      dockerDir: path.join(path.dirname(liferayDir), 'docker'),
+      gradlewPath: path.join(liferayDir, 'gradlew'),
+      buildDir,
+      buildDeployDir: path.join(buildDir, 'deploy'),
+    };
+  }
+
+  test('readPrepareCommit returns null when file does not exist', async () => {
+    const buildDir = path.join(tmpDir, 'build');
+    expect(await readPrepareCommit(buildDir)).toBeNull();
+  });
+
+  test('writePrepareCommit creates the marker file', async () => {
+    const buildDir = path.join(tmpDir, 'build');
+    const ctx = makeContext(buildDir);
+    await writePrepareCommit(ctx, 'abc1234');
+    const markerPath = path.join(buildDir, '.prepare-commit');
+    expect(await fs.pathExists(markerPath)).toBe(true);
+  });
+
+  test('readPrepareCommit returns the written commit hash', async () => {
+    const buildDir = path.join(tmpDir, 'build');
+    const ctx = makeContext(buildDir);
+    await writePrepareCommit(ctx, 'deadbeef');
+    expect(await readPrepareCommit(buildDir)).toBe('deadbeef');
+  });
+
+  test('readPrepareCommit returns null for empty file', async () => {
+    const buildDir = path.join(tmpDir, 'build');
+    await fs.ensureDir(buildDir);
+    await fs.writeFile(path.join(buildDir, '.prepare-commit'), '');
+    expect(await readPrepareCommit(buildDir)).toBeNull();
+  });
+
+  test('readPrepareCommit trims trailing newlines', async () => {
+    const buildDir = path.join(tmpDir, 'build');
+    await fs.ensureDir(buildDir);
+    await fs.writeFile(path.join(buildDir, '.prepare-commit'), 'abc1234\n');
+    expect(await readPrepareCommit(buildDir)).toBe('abc1234');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// seedBuildDockerConfigs — copies dockerenv configs
+// ---------------------------------------------------------------------------
+
+describe('seedBuildDockerConfigs', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = createTempDir('dev-cli-deploy-seed-');
+  });
+
+  afterEach(async () => {
+    await fs.remove(tmpDir);
+  });
+
+  function makeContext(liferayDir: string) {
+    return {
+      repoRoot: path.dirname(liferayDir),
+      liferayDir,
+      dockerDir: path.join(path.dirname(liferayDir), 'docker'),
+      gradlewPath: path.join(liferayDir, 'gradlew'),
+      buildDir: path.join(liferayDir, 'build', 'docker'),
+      buildDeployDir: path.join(liferayDir, 'build', 'docker', 'deploy'),
+    };
+  }
+
+  test('returns false when dockerenv source does not exist', async () => {
+    const liferayDir = path.join(tmpDir, 'liferay');
+    await fs.ensureDir(liferayDir);
+    const ctx = makeContext(liferayDir);
+    expect(await seedBuildDockerConfigs(ctx)).toBe(false);
+  });
+
+  test('returns true and copies files when dockerenv source exists', async () => {
+    const liferayDir = path.join(tmpDir, 'liferay');
+    const sourceDir = path.join(liferayDir, 'configs', 'dockerenv');
+    await fs.ensureDir(sourceDir);
+    await fs.writeFile(path.join(sourceDir, 'portal-ext.properties'), 'web.server.http.port=8080\n');
+
+    const ctx = makeContext(liferayDir);
+    expect(await seedBuildDockerConfigs(ctx)).toBe(true);
+
+    const targetFile = path.join(ctx.buildDir, 'configs', 'dockerenv', 'portal-ext.properties');
+    expect(await fs.pathExists(targetFile)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// shouldRunBuildService — detects service.xml recursively
+// ---------------------------------------------------------------------------
+
+describe('shouldRunBuildService', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = createTempDir('dev-cli-deploy-service-');
+  });
+
+  afterEach(async () => {
+    await fs.remove(tmpDir);
+  });
+
+  test('returns false when directory does not exist', async () => {
+    const absent = path.join(tmpDir, 'absent');
+    expect(await shouldRunBuildService(absent)).toBe(false);
+  });
+
+  test('returns false when no service.xml is present', async () => {
+    const modulesDir = path.join(tmpDir, 'modules');
+    await fs.ensureDir(path.join(modulesDir, 'my-module', 'src', 'main'));
+    await fs.writeFile(path.join(modulesDir, 'my-module', 'build.gradle'), '');
+    expect(await shouldRunBuildService(modulesDir)).toBe(false);
+  });
+
+  test('returns true when service.xml exists in a nested module', async () => {
+    const modulesDir = path.join(tmpDir, 'modules');
+    const serviceDir = path.join(modulesDir, 'my-module', 'my-module-service');
+    await fs.ensureDir(serviceDir);
+    await fs.writeFile(path.join(serviceDir, 'service.xml'), '<service-builder />');
+    expect(await shouldRunBuildService(modulesDir)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Adds focused unit tests for `deploy-artifacts` and `deploy-gradle` modules covering pure helpers, file-system operations, and the prepare-commit round-trip.

## Coverage

### `deploy-artifacts`
- `uniquePaths`  deduplication and order preservation
- `escapeSingleQuotes`  shell-safe quoting of single quotes
- `escapeShellArg`  wraps in single quotes after escaping
- `ensureDeployArtifactsFound`  throws `DEPLOY_ARTIFACTS_NOT_FOUND` with label in message
- `listDeployArtifacts`  returns empty for absent/empty dir; filters .jar/.war/.xml; excludes non-artifact files
- `syncArtifactsToDirectory`  copies files, skips absent sources, deduplicates
- `collectModuleArtifacts`  builds candidate paths; finds artifacts in modules/themes dirs

### `deploy-gradle`
- `writePrepareCommit` / `readPrepareCommit`  creates marker, round-trips commit hash, handles empty file and newline trimming
- `seedBuildDockerConfigs`  returns false when source absent; copies files and returns true when present
- `shouldRunBuildService`  returns false when dir absent or no service.xml; returns true when service.xml found recursively

## Test counts
- 35 new tests across 2 files
- Full suite: 988/988 passed

## Notes
- `hotDeployArtifactsToRunningLiferay` and `runGradleTask` are excluded due to docker/execa process dependency.
- `deploy-cache.ts` docker-volume paths are excluded to avoid docker daemon dependency in CI.
