### PR TITLE
chore(release): align package version metadata to 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.5.0](https://github.com/mordonez/ldev/compare/ldev-v0.4.0...ldev-v0.5.0) (2026-04-18)
+
+### Miscellaneous Chores
+
+* align package version metadata with release-please workflow
+
 ## [0.4.0](https://github.com/mordonez/ldev/compare/ldev-v0.3.0...ldev-v0.4.0) (2026-04-13)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mordonezdev/ldev",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Advanced developer workflows for Liferay local environments",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Bumps package version from 0.4.0 to 0.5.0 in package.json.
- Adds 0.5.0 heading to changelog so release metadata is consistent.

## Why
- release-please had already advanced to 0.5.0, but repository metadata still showed 0.4.0.
- This keeps npm/package metadata and changelog in sync.

## Scope
- package.json version only.
- changelog header alignment only.
- no runtime code changes.