### PR TITLE
refactor(env): add EnvErrors factory and migrate key env throw sites

### DIFF
--- a/src/features/env/env-clean.ts
+++ b/src/features/env/env-clean.ts
@@ -1,12 +1,12 @@
 import path from 'node:path';
 
-import {CliError} from '../../core/errors.js';
 import type {AppConfig} from '../../core/config/load-config.js';
 import type {Printer} from '../../core/output/printer.js';
 import {withProgress} from '../../core/output/printer.js';
 import {detectCapabilities} from '../../core/platform/capabilities.js';
 import {removePathRobust} from '../../core/platform/fs.js';
 import {runDockerOrThrow, runDockerComposeOrThrow} from '../../core/platform/docker.js';
+import {EnvErrors} from './errors/index.js';
 import {buildComposeEnv, resolveEnvContext, resolveManagedStorages} from './env-files.js';
 
 export type EnvCleanResult = {
@@ -23,14 +23,14 @@ export async function runEnvClean(
   options?: {force?: boolean; processEnv?: NodeJS.ProcessEnv; printer?: Printer},
 ): Promise<EnvCleanResult> {
   if (!(options?.force ?? false)) {
-    throw new CliError('env clean is destructive; run it again with --force.', {code: 'ENV_FORCE_REQUIRED'});
+    throw EnvErrors.forceRequired('env clean is destructive; run it again with --force.');
   }
 
   const context = resolveEnvContext(config);
   const capabilities = await detectCapabilities(config.cwd);
 
   if (!capabilities.hasDocker || !capabilities.hasDockerCompose) {
-    throw new CliError('Docker and docker compose are required for env clean.', {code: 'ENV_CAPABILITY_MISSING'});
+    throw EnvErrors.capabilityMissing('Docker and docker compose are required for env clean.');
   }
 
   const cleanTask = async () => {

--- a/src/features/env/env-logs-diagnose.ts
+++ b/src/features/env/env-logs-diagnose.ts
@@ -1,7 +1,7 @@
-import {CliError} from '../../core/errors.js';
 import type {AppConfig} from '../../core/config/load-config.js';
 import {detectCapabilities} from '../../core/platform/capabilities.js';
 import {runDockerComposeOrThrow} from '../../core/platform/docker.js';
+import {EnvErrors} from './errors/index.js';
 
 import {resolveEnvContext} from './env-files.js';
 
@@ -50,9 +50,7 @@ export async function runEnvLogsDiagnose(
   const capabilities = await detectCapabilities(config.cwd);
 
   if (!capabilities.hasDocker || !capabilities.hasDockerCompose) {
-    throw new CliError('Docker and docker compose are required for logs diagnose.', {
-      code: 'ENV_CAPABILITY_MISSING',
-    });
+    throw EnvErrors.capabilityMissing('Docker and docker compose are required for logs diagnose.');
   }
 
   const args = ['logs', '--no-color'];

--- a/src/features/env/env-logs.ts
+++ b/src/features/env/env-logs.ts
@@ -1,7 +1,7 @@
-import {CliError} from '../../core/errors.js';
 import type {AppConfig} from '../../core/config/load-config.js';
 import {detectCapabilities} from '../../core/platform/capabilities.js';
 import {runDockerComposeOrThrow} from '../../core/platform/docker.js';
+import {EnvErrors} from './errors/index.js';
 
 import {resolveEnvContext} from './env-files.js';
 
@@ -24,7 +24,7 @@ export async function runEnvLogs(config: AppConfig, options?: EnvLogsOptions): P
   const capabilities = await detectCapabilities(config.cwd);
 
   if (!capabilities.hasDocker || !capabilities.hasDockerCompose) {
-    throw new CliError('Docker and docker compose are required for env logs.', {code: 'ENV_CAPABILITY_MISSING'});
+    throw EnvErrors.capabilityMissing('Docker and docker compose are required for env logs.');
   }
 
   const args = ['logs'];

--- a/src/features/env/env-start.ts
+++ b/src/features/env/env-start.ts
@@ -1,6 +1,5 @@
 import fs from 'fs-extra';
 
-import {CliError} from '../../core/errors.js';
 import type {AppConfig} from '../../core/config/load-config.js';
 import type {Printer} from '../../core/output/printer.js';
 import {withProgress} from '../../core/output/printer.js';
@@ -11,6 +10,7 @@ import {resolveWorktreeContext} from '../worktree/worktree-paths.js';
 import {runWorktreeEnv} from '../worktree/worktree-env.js';
 
 import {ensureActivationKeyPrepared} from './env-activation-key.js';
+import {EnvErrors} from './errors/index.js';
 import {waitForServiceHealthy, waitForPortalReady} from './env-health.js';
 import {buildComposeEnv, ensureDoclibVolume, resolveEnvContext, seedBuildDockerConfigs} from './env-files.js';
 
@@ -40,7 +40,7 @@ export async function runEnvStart(
   const capabilities = await detectCapabilities(config.cwd, {processEnv: options?.processEnv});
 
   if (!capabilities.hasDocker || !capabilities.hasDockerCompose) {
-    throw new CliError('Docker and docker compose are required for env start.', {code: 'ENV_CAPABILITY_MISSING'});
+    throw EnvErrors.capabilityMissing('Docker and docker compose are required for env start.');
   }
 
   const activationKey = await ensureActivationKeyPrepared(config, options?.activationKeyFile);
@@ -87,7 +87,7 @@ export async function runEnvStart(
     } catch (error) {
       const message =
         error instanceof Error ? error.message : 'Timed out while waiting for the Liferay service health.';
-      throw new CliError(message, {code: 'ENV_START_TIMEOUT'});
+      throw EnvErrors.startTimeout(message);
     }
   }
 

--- a/src/features/env/env-stop.ts
+++ b/src/features/env/env-stop.ts
@@ -1,10 +1,10 @@
-import {CliError} from '../../core/errors.js';
 import type {AppConfig} from '../../core/config/load-config.js';
 import type {Printer} from '../../core/output/printer.js';
 import {withProgress} from '../../core/output/printer.js';
 import {detectCapabilities} from '../../core/platform/capabilities.js';
 import {runDockerComposeOrThrow} from '../../core/platform/docker.js';
 
+import {EnvErrors} from './errors/index.js';
 import {buildComposeEnv, resolveEnvContext} from './env-files.js';
 
 export type EnvStopResult = {
@@ -21,7 +21,7 @@ export async function runEnvStop(
   const capabilities = await detectCapabilities(config.cwd);
 
   if (!capabilities.hasDocker || !capabilities.hasDockerCompose) {
-    throw new CliError('Docker and docker compose are required for env stop.', {code: 'ENV_CAPABILITY_MISSING'});
+    throw EnvErrors.capabilityMissing('Docker and docker compose are required for env stop.');
   }
 
   const stopTask = async () => {

--- a/src/features/env/errors/env-error-codes.ts
+++ b/src/features/env/errors/env-error-codes.ts
@@ -1,0 +1,7 @@
+export const EnvErrorCode = {
+  CAPABILITY_MISSING: 'ENV_CAPABILITY_MISSING',
+  FORCE_REQUIRED: 'ENV_FORCE_REQUIRED',
+  START_TIMEOUT: 'ENV_START_TIMEOUT',
+} as const;
+
+export type EnvErrorCode = (typeof EnvErrorCode)[keyof typeof EnvErrorCode];

--- a/src/features/env/errors/env-error-factory.ts
+++ b/src/features/env/errors/env-error-factory.ts
@@ -1,0 +1,31 @@
+import {CliError} from '../../../core/errors.js';
+import {sanitizeErrorDetails, sanitizeErrorMessage} from '../../../core/errors-sanitize.js';
+import {EnvErrorCode} from './env-error-codes.js';
+
+type EnvErrorOptions = {
+  sanitize?: boolean;
+  details?: Record<string, unknown>;
+};
+
+function createEnvError(message: string, code: EnvErrorCode, options?: EnvErrorOptions): CliError {
+  const sanitize = options?.sanitize !== false;
+  const finalMessage = sanitize ? sanitizeErrorMessage(message) : message;
+  const finalDetails = options?.details
+    ? sanitize
+      ? sanitizeErrorDetails(options.details)
+      : options.details
+    : undefined;
+
+  return new CliError(finalMessage, {code, details: finalDetails});
+}
+
+export const EnvErrors = {
+  capabilityMissing: (message: string, options?: EnvErrorOptions): CliError =>
+    createEnvError(message, EnvErrorCode.CAPABILITY_MISSING, options),
+
+  forceRequired: (message: string, options?: EnvErrorOptions): CliError =>
+    createEnvError(message, EnvErrorCode.FORCE_REQUIRED, options),
+
+  startTimeout: (message: string, options?: EnvErrorOptions): CliError =>
+    createEnvError(message, EnvErrorCode.START_TIMEOUT, options),
+};

--- a/src/features/env/errors/index.ts
+++ b/src/features/env/errors/index.ts
@@ -1,0 +1,2 @@
+export {EnvErrors} from './env-error-factory.js';
+export {EnvErrorCode} from './env-error-codes.js';


### PR DESCRIPTION
## Summary
- Adds EnvErrors factory with env error codes and sanitization support.
- Migrates key env modules to use factory-based errors.

## Added
- src/features/env/errors/env-error-codes.ts
- src/features/env/errors/env-error-factory.ts
- src/features/env/errors/index.ts

## Migrated modules
- env-start.ts
- env-stop.ts
- env-clean.ts
- env-logs.ts
- env-logs-diagnose.ts

## Validation
- npm run typecheck
- npm run test:unit -- tests/unit/env.test.ts tests/unit/env-logs-diagnose.test.ts