### PR TITLE
refactor(deploy): add DeployErrors factory and migrate core throws

### DIFF
--- a/src/features/deploy/deploy-all.ts
+++ b/src/features/deploy/deploy-all.ts
@@ -4,7 +4,7 @@ import type {AppConfig} from '../../core/config/load-config.js';
 import type {Printer} from '../../core/output/printer.js';
 import {runProcess} from '../../core/platform/process.js';
 import {resolveProjectContext} from '../../core/config/project-context.js';
-import {CliError} from '../../core/errors.js';
+import {DeployErrors} from './errors/index.js';
 
 import {
   ensureGradleWrapper,
@@ -93,7 +93,7 @@ async function runWorkspaceDeployAll(config: AppConfig, options?: {printer?: Pri
   const repoRoot = config.repoRoot;
 
   if (!repoRoot) {
-    throw new CliError('deploy all requires a workspace root.', {code: 'WORKSPACE_ROOT_NOT_FOUND'});
+    throw DeployErrors.workspaceRootNotFound('deploy all requires a workspace root.');
   }
 
   await runDeployStep(options?.printer, 'Running workspace deploy', async () => {
@@ -110,14 +110,11 @@ async function runWorkspaceDeployAll(config: AppConfig, options?: {printer?: Pri
     });
 
     if (!gradleResult.ok) {
-      throw new CliError(
+      throw DeployErrors.gradleError(
         gradleResult.stderr.trim() ||
           gradleResult.stdout.trim() ||
           bladeResult.stderr.trim() ||
           bladeResult.stdout.trim(),
-        {
-          code: 'DEPLOY_GRADLE_ERROR',
-        },
       );
     }
   });

--- a/src/features/deploy/deploy-cache-update.ts
+++ b/src/features/deploy/deploy-cache-update.ts
@@ -1,6 +1,6 @@
-import {CliError} from '../../core/errors.js';
 import type {AppConfig} from '../../core/config/load-config.js';
 import type {Printer} from '../../core/output/printer.js';
+import {DeployErrors} from './errors/index.js';
 
 import {
   currentArtifactCommit,
@@ -29,9 +29,9 @@ export async function runDeployCacheUpdate(
 
   const artifacts = await listDeployArtifacts(context.buildDeployDir);
   if (artifacts.length === 0) {
-    throw new CliError(`No artifacts were found in ${context.buildDeployDir}. Run 'ldev deploy prepare'.`, {
-      code: 'DEPLOY_ARTIFACTS_NOT_FOUND',
-    });
+    throw DeployErrors.artifactsNotFound(
+      `No artifacts were found in ${context.buildDeployDir}. Run 'ldev deploy prepare'.`,
+    );
   }
 
   const cache = await runDeployStep(options?.printer, 'Updating deploy cache', async () =>

--- a/src/features/deploy/deploy-module.ts
+++ b/src/features/deploy/deploy-module.ts
@@ -1,9 +1,9 @@
 import fs from 'fs-extra';
 import path from 'node:path';
 
-import {CliError} from '../../core/errors.js';
 import type {AppConfig} from '../../core/config/load-config.js';
 import type {Printer} from '../../core/output/printer.js';
+import {DeployErrors} from './errors/index.js';
 
 import {
   collectModuleArtifacts,
@@ -37,7 +37,7 @@ export async function runDeployModule(
 ): Promise<DeployModuleResult> {
   const module = options.module.trim();
   if (module === '') {
-    throw new CliError('deploy module requires a MODULE.', {code: 'DEPLOY_MODULE_REQUIRED'});
+    throw DeployErrors.moduleRequired('deploy module requires a MODULE.');
   }
 
   const context = resolveDeployContext(config);
@@ -111,7 +111,5 @@ async function runGradleTasksForModule(
     return;
   }
 
-  throw new CliError(`No module or theme named ${module} exists.`, {
-    code: 'DEPLOY_MODULE_NOT_FOUND',
-  });
+  throw DeployErrors.moduleNotFound(`No module or theme named ${module} exists.`);
 }

--- a/src/features/deploy/errors/deploy-error-codes.ts
+++ b/src/features/deploy/errors/deploy-error-codes.ts
@@ -1,0 +1,9 @@
+export const DeployErrorCode = {
+  MODULE_REQUIRED: 'DEPLOY_MODULE_REQUIRED',
+  MODULE_NOT_FOUND: 'DEPLOY_MODULE_NOT_FOUND',
+  GRADLE_ERROR: 'DEPLOY_GRADLE_ERROR',
+  ARTIFACTS_NOT_FOUND: 'DEPLOY_ARTIFACTS_NOT_FOUND',
+  WORKSPACE_ROOT_NOT_FOUND: 'WORKSPACE_ROOT_NOT_FOUND',
+} as const;
+
+export type DeployErrorCode = (typeof DeployErrorCode)[keyof typeof DeployErrorCode];

--- a/src/features/deploy/errors/deploy-error-factory.ts
+++ b/src/features/deploy/errors/deploy-error-factory.ts
@@ -1,0 +1,37 @@
+import {CliError} from '../../../core/errors.js';
+import {sanitizeErrorDetails, sanitizeErrorMessage} from '../../../core/errors-sanitize.js';
+import {DeployErrorCode} from './deploy-error-codes.js';
+
+type DeployErrorOptions = {
+  sanitize?: boolean;
+  details?: Record<string, unknown>;
+};
+
+function createDeployError(message: string, code: DeployErrorCode, options?: DeployErrorOptions): CliError {
+  const sanitize = options?.sanitize !== false;
+  const finalMessage = sanitize ? sanitizeErrorMessage(message) : message;
+  const finalDetails = options?.details
+    ? sanitize
+      ? sanitizeErrorDetails(options.details)
+      : options.details
+    : undefined;
+
+  return new CliError(finalMessage, {code, details: finalDetails});
+}
+
+export const DeployErrors = {
+  moduleRequired: (message: string, options?: DeployErrorOptions): CliError =>
+    createDeployError(message, DeployErrorCode.MODULE_REQUIRED, options),
+
+  moduleNotFound: (message: string, options?: DeployErrorOptions): CliError =>
+    createDeployError(message, DeployErrorCode.MODULE_NOT_FOUND, options),
+
+  gradleError: (message: string, options?: DeployErrorOptions): CliError =>
+    createDeployError(message, DeployErrorCode.GRADLE_ERROR, options),
+
+  artifactsNotFound: (message: string, options?: DeployErrorOptions): CliError =>
+    createDeployError(message, DeployErrorCode.ARTIFACTS_NOT_FOUND, options),
+
+  workspaceRootNotFound: (message: string, options?: DeployErrorOptions): CliError =>
+    createDeployError(message, DeployErrorCode.WORKSPACE_ROOT_NOT_FOUND, options),
+};

--- a/src/features/deploy/errors/index.ts
+++ b/src/features/deploy/errors/index.ts
@@ -1,0 +1,2 @@
+export {DeployErrors} from './deploy-error-factory.js';
+export {DeployErrorCode} from './deploy-error-codes.js';


### PR DESCRIPTION
## Summary
- Adds DeployErrors factory with deploy error codes and sanitizer integration.
- Migrates selected deploy throw sites to factory-based errors.

## Added
- src/features/deploy/errors/deploy-error-codes.ts
- src/features/deploy/errors/deploy-error-factory.ts
- src/features/deploy/errors/index.ts

## Migrated modules
- deploy-module.ts
- deploy-all.ts
- deploy-cache-update.ts

## Validation
- npm run typecheck
- npm run test:unit -- tests/unit/deploy-artifacts.test.ts tests/unit/deploy-gradle.test.ts tests/unit/deploy-watch.test.ts