### PR TITLE
refactor(db,oauth): add DbErrors/OAuthErrors and migrate key throws

### DIFF
--- a/src/features/db/db-sync.ts
+++ b/src/features/db/db-sync.ts
@@ -1,7 +1,7 @@
 import type {AppConfig} from '../../core/config/load-config.js';
 import type {Printer} from '../../core/output/printer.js';
 
-import {CliError} from '../../core/errors.js';
+import {DbErrors} from './errors/index.js';
 
 import {runDbDownload, type DbDownloadResult} from './db-download.js';
 import {runDbImport, type DbImportResult} from './db-import.js';
@@ -31,7 +31,7 @@ export async function runDbSync(
   });
 
   if (!download.databaseBackupFile) {
-    throw new CliError('db sync expected a downloaded database backup.', {code: 'DB_SYNC_STATE_MISSING'});
+    throw DbErrors.syncStateMissing('db sync expected a downloaded database backup.');
   }
 
   const importResult = await runDbImport(config, {

--- a/src/features/db/errors/db-error-codes.ts
+++ b/src/features/db/errors/db-error-codes.ts
@@ -1,0 +1,5 @@
+export const DbErrorCode = {
+  SYNC_STATE_MISSING: 'DB_SYNC_STATE_MISSING',
+} as const;
+
+export type DbErrorCode = (typeof DbErrorCode)[keyof typeof DbErrorCode];

--- a/src/features/db/errors/db-error-factory.ts
+++ b/src/features/db/errors/db-error-factory.ts
@@ -1,0 +1,25 @@
+import {CliError} from '../../../core/errors.js';
+import {sanitizeErrorDetails, sanitizeErrorMessage} from '../../../core/errors-sanitize.js';
+import {DbErrorCode} from './db-error-codes.js';
+
+type DbErrorOptions = {
+  sanitize?: boolean;
+  details?: Record<string, unknown>;
+};
+
+function createDbError(message: string, code: DbErrorCode, options?: DbErrorOptions): CliError {
+  const sanitize = options?.sanitize !== false;
+  const finalMessage = sanitize ? sanitizeErrorMessage(message) : message;
+  const finalDetails = options?.details
+    ? sanitize
+      ? sanitizeErrorDetails(options.details)
+      : options.details
+    : undefined;
+
+  return new CliError(finalMessage, {code, details: finalDetails});
+}
+
+export const DbErrors = {
+  syncStateMissing: (message: string, options?: DbErrorOptions): CliError =>
+    createDbError(message, DbErrorCode.SYNC_STATE_MISSING, options),
+};

--- a/src/features/db/errors/index.ts
+++ b/src/features/db/errors/index.ts
@@ -1,0 +1,2 @@
+export {DbErrors} from './db-error-factory.js';
+export {DbErrorCode} from './db-error-codes.js';

--- a/src/features/oauth/errors/index.ts
+++ b/src/features/oauth/errors/index.ts
@@ -1,0 +1,2 @@
+export {OAuthErrors} from './oauth-error-factory.js';
+export {OAuthErrorCode} from './oauth-error-codes.js';

--- a/src/features/oauth/errors/oauth-error-codes.ts
+++ b/src/features/oauth/errors/oauth-error-codes.ts
@@ -1,0 +1,6 @@
+export const OAuthErrorCode = {
+  LOCAL_PROFILE_NOT_FOUND: 'OAUTH_LOCAL_PROFILE_NOT_FOUND',
+  INSTALL_PARSE_ERROR: 'OAUTH_INSTALL_PARSE_ERROR',
+} as const;
+
+export type OAuthErrorCode = (typeof OAuthErrorCode)[keyof typeof OAuthErrorCode];

--- a/src/features/oauth/errors/oauth-error-factory.ts
+++ b/src/features/oauth/errors/oauth-error-factory.ts
@@ -1,0 +1,28 @@
+import {CliError} from '../../../core/errors.js';
+import {sanitizeErrorDetails, sanitizeErrorMessage} from '../../../core/errors-sanitize.js';
+import {OAuthErrorCode} from './oauth-error-codes.js';
+
+type OAuthErrorOptions = {
+  sanitize?: boolean;
+  details?: Record<string, unknown>;
+};
+
+function createOAuthError(message: string, code: OAuthErrorCode, options?: OAuthErrorOptions): CliError {
+  const sanitize = options?.sanitize !== false;
+  const finalMessage = sanitize ? sanitizeErrorMessage(message) : message;
+  const finalDetails = options?.details
+    ? sanitize
+      ? sanitizeErrorDetails(options.details)
+      : options.details
+    : undefined;
+
+  return new CliError(finalMessage, {code, details: finalDetails});
+}
+
+export const OAuthErrors = {
+  localProfileNotFound: (message: string, options?: OAuthErrorOptions): CliError =>
+    createOAuthError(message, OAuthErrorCode.LOCAL_PROFILE_NOT_FOUND, options),
+
+  installParseError: (message: string, options?: OAuthErrorOptions): CliError =>
+    createOAuthError(message, OAuthErrorCode.INSTALL_PARSE_ERROR, options),
+};

--- a/src/features/oauth/oauth-admin-unblock.ts
+++ b/src/features/oauth/oauth-admin-unblock.ts
@@ -1,6 +1,6 @@
-import {CliError} from '../../core/errors.js';
 import type {AppConfig} from '../../core/config/load-config.js';
 import type {Printer} from '../../core/output/printer.js';
+import {OAuthErrors} from './errors/index.js';
 import {
   deployBundledOAuthInstallerJar,
   executeOAuthInstallerCommand,
@@ -23,9 +23,7 @@ export async function runOAuthAdminUnblock(
 
   for (const key of ['companyId', 'companyWebId', 'userId', 'userEmail', 'passwordReset']) {
     if (!values[key]) {
-      throw new CliError(`OAuth admin-unblock output is missing '${key}'.`, {
-        code: 'OAUTH_INSTALL_PARSE_ERROR',
-      });
+      throw OAuthErrors.installParseError(`OAuth admin-unblock output is missing '${key}'.`);
     }
   }
 

--- a/src/features/oauth/oauth-env.ts
+++ b/src/features/oauth/oauth-env.ts
@@ -1,4 +1,4 @@
-import {CliError} from '../../core/errors.js';
+import {OAuthErrors} from './errors/index.js';
 import {writeLocalLiferayProfile} from '../../core/config/liferay-profile.js';
 
 export async function writeCredentialsToLocalProfile(
@@ -8,9 +8,7 @@ export async function writeCredentialsToLocalProfile(
   scopeAliases?: string[],
 ): Promise<boolean> {
   if (!localProfileFile) {
-    throw new CliError('No .liferay-cli.local.yml was detected to persist OAuth2 credentials.', {
-      code: 'OAUTH_LOCAL_PROFILE_NOT_FOUND',
-    });
+    throw OAuthErrors.localProfileNotFound('No .liferay-cli.local.yml was detected to persist OAuth2 credentials.');
   }
 
   await writeLocalLiferayProfile(localProfileFile, {

--- a/src/features/oauth/oauth-install.ts
+++ b/src/features/oauth/oauth-install.ts
@@ -1,7 +1,6 @@
 ﻿import {randomUUID} from 'node:crypto';
 import path from 'node:path';
 
-import {CliError} from '../../core/errors.js';
 import type {AppConfig} from '../../core/config/load-config.js';
 import {LIFERAY_LOCAL_PROFILE_FILE} from '../../core/config/liferay-profile.js';
 import {resolveProjectContext} from '../../core/config/project-context.js';
@@ -11,6 +10,7 @@ import {
   resolveOAuthScopeProfileAliases,
   type OAuthScopeProfileName,
 } from './oauth-scope-aliases.js';
+import {OAuthErrors} from './errors/index.js';
 import {writeCredentialsToLocalProfile} from './oauth-env.js';
 import {deployBundledOAuthInstallerJar, writeOAuthInstallerOsgiConfig} from './oauth-install-bundle.js';
 import {executeOAuthInstallerCommand, buildOAuthInstallGogoCommand, parseKeyValueOutput} from './oauth-install-gogo.js';
@@ -307,9 +307,7 @@ function parseOAuthInstallOutput(output: string): {
 
   for (const key of requiredKeys) {
     if (!values[key]) {
-      throw new CliError(`OAuth installer output is missing '${key}'.`, {
-        code: 'OAUTH_INSTALL_PARSE_ERROR',
-      });
+      throw OAuthErrors.installParseError(`OAuth installer output is missing '${key}'.`);
     }
   }
 


### PR DESCRIPTION
## Summary
- Adds DbErrors and OAuthErrors factories with sanitizer integration.
- Migrates selected db/oauth throw sites to factory-based errors.

## Added
- src/features/db/errors/db-error-codes.ts
- src/features/db/errors/db-error-factory.ts
- src/features/db/errors/index.ts
- src/features/oauth/errors/oauth-error-codes.ts
- src/features/oauth/errors/oauth-error-factory.ts
- src/features/oauth/errors/index.ts

## Migrated modules
- db-sync.ts
- oauth-env.ts
- oauth-admin-unblock.ts
- oauth-install.ts (parse output path)

## Validation
- npm run typecheck
- npm run test:unit -- tests/unit/oauth-install-modules.test.ts tests/unit/oauth.test.ts tests/unit/db-import.test.ts