### PR TITLE
fix(resource): replace stale get-structure command references in errors and docs

### DIFF
--- a/src/features/liferay/resource/liferay-resource-get-structure.ts
+++ b/src/features/liferay/resource/liferay-resource-get-structure.ts
@@ -67,7 +67,7 @@ export async function runLiferayResourceGetStructure(
 
   if (!payload) {
     if (lastKeyLookupStatus !== null) {
-      throw LiferayErrors.resourceError(`resource get-structure failed with status=${lastKeyLookupStatus}.`);
+      throw LiferayErrors.resourceError(`structure lookup failed with status=${lastKeyLookupStatus}.`);
     }
     throw LiferayErrors.resourceError(`Estructura no encontrada: ${identifier}`);
   }

--- a/src/features/liferay/resource/sync-strategies/structure-sync-strategy.ts
+++ b/src/features/liferay/resource/sync-strategies/structure-sync-strategy.ts
@@ -238,6 +238,7 @@ export const structureSyncStrategy: SyncStrategy<StructureLocalData, StructureRe
     const updated = await updateStructureWithRecovery(
       gateway,
       site.id,
+      site.friendlyUrlPath,
       runtimeId,
       opts.key,
       payload,
@@ -347,6 +348,7 @@ async function putJsonAsResource<T>(
 async function updateStructureWithRecovery(
   gateway: LiferayGateway,
   siteId: number,
+  siteFriendlyUrl: string,
   runtimeId: string,
   key: string,
   payload: Record<string, unknown>,
@@ -380,7 +382,7 @@ async function updateStructureWithRecovery(
     }
 
     throw LiferayErrors.resourceTimeoutRecoverable(
-      `structure-update timed out, and ldev could not confirm whether the update eventually applied. Re-run 'ldev resource get-structure --site ${siteId} --key ${key}' or retry the import once the portal is responsive again.`,
+      `structure-update timed out, and ldev could not confirm whether the update eventually applied. Re-run 'ldev resource structure --site ${siteFriendlyUrl} --key ${key}' or retry the import once the portal is responsive again.`,
       {details: {operation: 'structure-update', key, siteId, recoverable: true}},
     );
   }

--- a/templates/ai/skills/developing-liferay/references/structures.md
+++ b/templates/ai/skills/developing-liferay/references/structures.md
@@ -91,13 +91,13 @@ current portal state after mutation:
 
 ```bash
 # Structure: confirm current remote payload
-ldev resource get-structure --site /<site> --key <STRUCTURE_KEY> --json
+ldev resource structure --site /<site> --key <STRUCTURE_KEY> --json
 
 # Template: confirm current remote payload
-ldev resource get-template --site /<site> --id <TEMPLATE_ID> --json
+ldev resource template --site /<site> --id <TEMPLATE_ID> --json
 
 # ADT: confirm current remote payload
-ldev resource get-adt --site /<site> --id <ADT_ID> --json
+ldev resource adt --site /<site> --key <ADT_KEY> --json
 
 # Cross-check mapping and ownership
 ldev portal inventory structures --site /<site> --with-templates --json

--- a/tests/unit/liferay-resource-export.test.ts
+++ b/tests/unit/liferay-resource-export.test.ts
@@ -471,7 +471,7 @@ describe('liferay resource export', () => {
         {site: '/global', key: 'MISSING', output: outputPath},
         {apiClient, tokenClient: TOKEN_CLIENT},
       ),
-    ).rejects.toThrow('resource get-structure failed with status=404');
+    ).rejects.toThrow('structure lookup failed with status=404');
   });
 
   test('exports all structures of a site to the local structures layout', async () => {

--- a/tests/unit/liferay-resource-get-structure.test.ts
+++ b/tests/unit/liferay-resource-get-structure.test.ts
@@ -94,7 +94,7 @@ describe('liferay resource get-structure', () => {
 
     await expect(
       runLiferayResourceGetStructure(CONFIG, {site: '/global', key: 'MISSING'}, {apiClient, tokenClient: TOKEN_CLIENT}),
-    ).rejects.toThrow('resource get-structure failed with status=404');
+    ).rejects.toThrow('structure lookup failed with status=404');
   });
 
   test('resolves structure by numeric id', async () => {


### PR DESCRIPTION
## Summary

Fixes two stale `ldev resource get-structure` references that surfaced in user-facing error messages and skill documentation. The command was renamed in a previous refactor but a handful of references were not updated.

## What Changed

**`src/features/liferay/resource/sync-strategies/structure-sync-strategy.ts`**
- Added `siteFriendlyUrl` parameter to `updateStructureWithRecovery` so the timeout-recovery error message can use the friendly site URL instead of the raw numeric site ID.
- Updated the timeout recovery message from:
  ```
  Re-run 'ldev resource get-structure --site <numericId> --key <key>'
  ```
  to:
  ```
  Re-run 'ldev resource structure --site <friendlyUrl> --key <key>'
  ```

**`src/features/liferay/resource/liferay-resource-get-structure.ts`**
- Changed the internal error message from `resource get-structure failed with status=` to `structure lookup failed with status=` so it no longer surfaces an internal module name to the user.

**`templates/ai/skills/developing-liferay/references/structures.md`**
- Updated three command examples from obsolete `get-structure` / `get-template` / `get-adt` to the current `structure` / `template` / `adt` subcommands.

**`tests/unit/liferay-resource-get-structure.test.ts`**
**`tests/unit/liferay-resource-export.test.ts`**
- Updated two `.rejects.toThrow(...)` assertions to match the new error message text.

## Validation

- `npm run typecheck`  clean
- Tests updated to match new messages

## Backward Compatibility

- No public CLI contract changes.
- Only error message text changed (user-visible improvement).
