### PR TITLE
feat(resource): improve migration progress UX and harden structure sync flows

### DIFF
--- a/docs/commands/discovery.md
+++ b/docs/commands/discovery.md
@@ -5,6 +5,12 @@ description: Minimal reference for understanding portal and runtime state.
 
 # Discovery Commands
 
+Global connection overrides are available for remote execution and must be passed before subcommands, for example:
+
+```bash
+ldev --liferay-url https://portal.example.com portal inventory sites --json
+```
+
 ## `ldev context`
 
 Resolve repo, runtime, and Liferay context as one snapshot.

--- a/docs/commands/resources.md
+++ b/docs/commands/resources.md
@@ -66,3 +66,7 @@ ldev resource migration-pipeline --migration-file path/to/MY_STRUCTURE.migration
 ```
 
 Use migration commands when structure changes affect existing content.
+
+Use `migration-pipeline` as the default command for real migrations. It is the end-to-end workflow and is the safer choice for both humans and agents.
+
+Use `migration-run` only when you intentionally need one phase in isolation, such as debugging, retrying only `introduce` or `cleanup`, or validating a specific stage without running the full pipeline.

--- a/docs/core-concepts/oauth.md
+++ b/docs/core-concepts/oauth.md
@@ -74,6 +74,77 @@ The user-facing contract is the same in both cases:
 - verify that the credentials work when possible
 - persist local credentials for the CLI
 
+## Manual setup for remote environments (no `ldev oauth install`)
+
+In some remote environments you cannot use `ldev oauth install --write-env` (for example, no bundle deployment or no Gogo access). In that case, create the OAuth2 app manually in Liferay and pass credentials with global CLI overrides.
+
+### 1. Create the OAuth2 app in Liferay
+
+In Control Panel, create a new OAuth2 application (client credentials flow):
+
+- grant type: client credentials
+- token endpoint auth method: client secret basic (default in most portals)
+- keep generated client id and client secret
+- set a clear name like `ldev-remote-ops`
+
+### 2. Add required scopes
+
+For typical `ldev` portal/resource usage, include at least:
+
+- `Liferay.Headless.Admin.User.everything.read`
+- `Liferay.Headless.Admin.Site.everything.read`
+- `Liferay.Data.Engine.REST.everything.read`
+- `Liferay.Data.Engine.REST.everything.write`
+- `Liferay.Headless.Delivery.everything.read`
+- `Liferay.Headless.Delivery.everything.write`
+- `liferay-json-web-services.everything.read`
+- `liferay-json-web-services.everything.write`
+- `Liferay.Headless.Discovery.API.everything.read`
+- `Liferay.Headless.Discovery.OpenAPI.everything.read`
+
+If your security policy requires least privilege, start with read scopes only and add write scopes only for commands that modify resources.
+
+### 3. Store credentials securely in the execution host
+
+Prefer environment variables over inline secrets:
+
+```bash
+export LIFERAY_REMOTE_URL=https://portal.example.com
+export LIFERAY_REMOTE_CLIENT_ID=ldev-remote-ops
+export LIFERAY_REMOTE_CLIENT_SECRET='***'
+```
+
+### 4. Run `ldev` using global overrides
+
+Global connection options must be placed before subcommands:
+
+```bash
+ldev \
+	--liferay-url "$LIFERAY_REMOTE_URL" \
+	--liferay-client-id "$LIFERAY_REMOTE_CLIENT_ID" \
+	--liferay-client-secret-env LIFERAY_REMOTE_CLIENT_SECRET \
+	portal check --json
+```
+
+```bash
+ldev \
+	--liferay-url "$LIFERAY_REMOTE_URL" \
+	--liferay-client-id "$LIFERAY_REMOTE_CLIENT_ID" \
+	--liferay-client-secret-env LIFERAY_REMOTE_CLIENT_SECRET \
+	portal inventory sites --json
+```
+
+### 5. Validate before running write operations
+
+Run this sequence first:
+
+```bash
+ldev --liferay-url "$LIFERAY_REMOTE_URL" --liferay-client-id "$LIFERAY_REMOTE_CLIENT_ID" --liferay-client-secret-env LIFERAY_REMOTE_CLIENT_SECRET portal check --json
+ldev --liferay-url "$LIFERAY_REMOTE_URL" --liferay-client-id "$LIFERAY_REMOTE_CLIENT_ID" --liferay-client-secret-env LIFERAY_REMOTE_CLIENT_SECRET portal inventory sites --json
+```
+
+If those commands fail with auth/scope errors, update the OAuth app scopes and retry.
+
 ## When OAuth is not ready yet
 
 If the portal setup wizard is not complete, or the local portal is not reachable yet, OAuth-based commands will fail or stay pending.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -54,6 +54,41 @@ export LDEV_ACTIVATION_KEY_FILE=/path/to/activation-key.xml
 export REPO_ROOT=/path/to/project
 ```
 
+## Remote execution with connection overrides
+
+When you run `ldev` from automation hosts, CI jobs, or jumpboxes, you can override Liferay connection values per command instead of changing project files.
+
+Supported global options:
+
+- `--liferay-url <url>`
+- `--liferay-client-id <clientId>`
+- `--liferay-client-secret <clientSecret>`
+- `--liferay-client-secret-env <envVar>`
+- `--liferay-scope-aliases <aliases>`
+- `--liferay-timeout-seconds <seconds>`
+
+Important: these are root options. Place them before the command group/subcommand.
+
+```bash
+ldev --liferay-url https://portal.example.com portal check --json
+ldev --liferay-url https://portal.example.com portal inventory sites --json
+```
+
+For secrets, prefer environment-variable indirection:
+
+```bash
+export LIFERAY_REMOTE_SECRET='***'
+ldev \
+	--liferay-url https://portal.example.com \
+	--liferay-client-id remote-client \
+	--liferay-client-secret-env LIFERAY_REMOTE_SECRET \
+	portal inventory page --url /home --json
+```
+
+If both `--liferay-client-secret` and `--liferay-client-secret-env` are provided, `--liferay-client-secret` wins.
+
+If your environment cannot run `ldev oauth install --write-env`, see the manual app setup guide in [OAuth](/core-concepts/oauth#manual-setup-for-remote-environments-no-ldev-oauth-install).
+
 ## Runtime Storage Modes
 
 `ldev` supports three persistence modes for selected runtime directories:

--- a/src/cli/command-context.ts
+++ b/src/cli/command-context.ts
@@ -199,7 +199,14 @@ function findArgvOptionValue(argv: string[], flag: string): string {
 
     const prefix = `${flag}=`;
     if (current.startsWith(prefix)) {
-      return current.slice(prefix.length).trim();
+      const value = current.slice(prefix.length).trim();
+      if (value === '') {
+        throw new CliError(`${flag} requires a value.`, {
+          code: 'LIFERAY_CONFIG_INCOMPLETE',
+        });
+      }
+
+      return value;
     }
   }
 

--- a/src/cli/command-context.ts
+++ b/src/cli/command-context.ts
@@ -1,5 +1,6 @@
 import {type AppConfig} from '../core/config/load-config.js';
 import {resolveProjectContext, type ProjectContext} from '../core/config/project-context.js';
+import {CliError} from '../core/errors.js';
 import {resolveOutputFormatFromArgv} from './errors.js';
 import {outputFormatSchema, type OutputFormat} from '../core/output/formats.js';
 import {createPrinter, type Printer} from '../core/output/printer.js';
@@ -12,10 +13,33 @@ export type CommandContext = {
   strict: boolean;
 };
 
-export function createCommandContext(options?: {cwd?: string; format?: string; strict?: boolean}): CommandContext {
+type CommandContextOptions = {
+  cwd?: string;
+  format?: string;
+  strict?: boolean;
+  json?: boolean;
+  ndjson?: boolean;
+  liferayUrl?: string;
+  liferayClientId?: string;
+  liferayClientSecret?: string;
+  liferayClientSecretEnv?: string;
+  liferayScopeAliases?: string;
+  liferayTimeoutSeconds?: string | number;
+};
+
+type LiferayConnectionOverrides = {
+  url?: string;
+  oauth2ClientId?: string;
+  oauth2ClientSecret?: string;
+  scopeAliases?: string;
+  timeoutSeconds?: number;
+};
+
+export function createCommandContext(options?: CommandContextOptions): CommandContext {
   const cwd = process.env.REPO_ROOT?.trim() || options?.cwd || process.cwd();
   const project = resolveProjectContext({cwd, env: process.env});
-  const config = project.config;
+  const overrides = resolveLiferayConnectionOverrides(options, process.argv, process.env);
+  const config = applyLiferayConnectionOverrides(project.config, overrides);
   const resolvedFormat = resolveOutputFormatOption(options);
   const format = outputFormatSchema.parse(resolvedFormat) as OutputFormat;
   const strict = resolveStrictMode(options);
@@ -52,4 +76,146 @@ function resolveOutputFormatOption(options?: {format?: string; json?: boolean; n
   }
 
   return resolveOutputFormatFromArgv(process.argv);
+}
+
+function resolveLiferayConnectionOverrides(
+  options: CommandContextOptions | undefined,
+  argv: string[],
+  env: NodeJS.ProcessEnv,
+): LiferayConnectionOverrides {
+  const url = resolveStringOverride(options?.liferayUrl, '--liferay-url', argv);
+  const oauth2ClientId = resolveStringOverride(options?.liferayClientId, '--liferay-client-id', argv);
+  const scopeAliases = resolveStringOverride(options?.liferayScopeAliases, '--liferay-scope-aliases', argv);
+  const timeoutSeconds = resolveTimeoutOverride(options?.liferayTimeoutSeconds, '--liferay-timeout-seconds', argv);
+
+  const cliSecret = resolveStringOverride(options?.liferayClientSecret, '--liferay-client-secret', argv);
+  const secretEnvName = resolveStringOverride(options?.liferayClientSecretEnv, '--liferay-client-secret-env', argv);
+  const oauth2ClientSecret = resolveSecretOverride(cliSecret, secretEnvName, env);
+
+  return {
+    ...(url ? {url} : {}),
+    ...(oauth2ClientId ? {oauth2ClientId} : {}),
+    ...(oauth2ClientSecret ? {oauth2ClientSecret} : {}),
+    ...(scopeAliases ? {scopeAliases} : {}),
+    ...(timeoutSeconds !== undefined ? {timeoutSeconds} : {}),
+  };
+}
+
+function resolveStringOverride(optionValue: unknown, flag: string, argv: string[]): string {
+  const fromOptions = typeof optionValue === 'string' ? optionValue.trim() : '';
+  if (fromOptions !== '') {
+    return validateStringOverride(fromOptions, flag);
+  }
+
+  return validateStringOverride(findArgvOptionValue(argv, flag), flag);
+}
+
+function resolveTimeoutOverride(optionValue: unknown, flag: string, argv: string[]): number | undefined {
+  let candidate = '';
+  if (typeof optionValue === 'number' && Number.isFinite(optionValue)) {
+    candidate = String(optionValue);
+  } else if (typeof optionValue === 'string') {
+    candidate = optionValue.trim();
+  }
+  if (candidate === '') {
+    candidate = findArgvOptionValue(argv, flag);
+  }
+
+  if (candidate === '') {
+    return undefined;
+  }
+
+  if (!/^\d+$/.test(candidate)) {
+    throw new CliError('--liferay-timeout-seconds must be a positive integer.', {
+      code: 'LIFERAY_CONFIG_INCOMPLETE',
+    });
+  }
+
+  const parsed = Number.parseInt(candidate, 10);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new CliError('--liferay-timeout-seconds must be a positive integer.', {
+      code: 'LIFERAY_CONFIG_INCOMPLETE',
+    });
+  }
+
+  return parsed;
+}
+
+function resolveSecretOverride(cliSecret: string, secretEnvName: string, env: NodeJS.ProcessEnv): string {
+  if (cliSecret !== '') {
+    return cliSecret;
+  }
+
+  if (secretEnvName === '') {
+    return '';
+  }
+
+  const secret = env[secretEnvName]?.trim() ?? '';
+  if (secret === '') {
+    throw new CliError(
+      `--liferay-client-secret-env points to '${secretEnvName}' but that environment variable is empty or missing.`,
+      {
+        code: 'LIFERAY_CONFIG_INCOMPLETE',
+      },
+    );
+  }
+
+  return secret;
+}
+
+function validateStringOverride(value: string, flag: string): string {
+  if (value === '') {
+    return value;
+  }
+
+  if (flag === '--liferay-url') {
+    try {
+      const parsed = new URL(value);
+      if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+        throw new Error('invalid protocol');
+      }
+    } catch {
+      throw new CliError('--liferay-url must be a valid http(s) URL.', {
+        code: 'LIFERAY_CONFIG_INCOMPLETE',
+      });
+    }
+  }
+
+  return value;
+}
+
+function findArgvOptionValue(argv: string[], flag: string): string {
+  for (let i = argv.length - 1; i >= 0; i -= 1) {
+    const current = argv[i];
+    if (current === flag) {
+      const next = argv[i + 1];
+      if (next && !next.startsWith('--')) {
+        return next.trim();
+      }
+      throw new CliError(`${flag} requires a value.`, {
+        code: 'LIFERAY_CONFIG_INCOMPLETE',
+      });
+    }
+
+    const prefix = `${flag}=`;
+    if (current.startsWith(prefix)) {
+      return current.slice(prefix.length).trim();
+    }
+  }
+
+  return '';
+}
+
+function applyLiferayConnectionOverrides(config: AppConfig, overrides: LiferayConnectionOverrides): AppConfig {
+  if (Object.keys(overrides).length === 0) {
+    return config;
+  }
+
+  return {
+    ...config,
+    liferay: {
+      ...config.liferay,
+      ...overrides,
+    },
+  };
 }

--- a/src/cli/create-cli.ts
+++ b/src/cli/create-cli.ts
@@ -42,8 +42,25 @@ export function createCli(cwd = process.cwd(), groups: CommandGroup[] = COMMAND_
     .name('ldev')
     .version(version)
     .description('Liferay local development CLI')
+    .option('--liferay-url <url>', 'Override Liferay base URL for this command')
+    .option('--liferay-client-id <clientId>', 'Override Liferay OAuth2 client id for this command')
+    .option(
+      '--liferay-client-secret <clientSecret>',
+      'Override Liferay OAuth2 client secret for this command (less secure; prefer --liferay-client-secret-env)',
+    )
+    .option(
+      '--liferay-client-secret-env <envVar>',
+      'Read Liferay OAuth2 client secret from an environment variable (recommended)',
+    )
+    .option('--liferay-scope-aliases <aliases>', 'Override OAuth2 scope aliases (comma-separated) for this command')
+    .option('--liferay-timeout-seconds <seconds>', 'Override Liferay HTTP timeout in seconds for this command')
     .enablePositionalOptions()
     .showHelpAfterError()
+    .addHelpText(
+      'after',
+      '\nOverride precedence: --liferay-client-secret has priority over --liferay-client-secret-env.\n' +
+        'Security tip: prefer --liferay-client-secret-env in local shells and CI to avoid exposing secrets in process args/history.\n',
+    )
     .addHelpText('after', () => `\n${buildContextualRootHelp(cwd)}`);
 
   for (const group of groups) {

--- a/src/commands/liferay/resource.command.ts
+++ b/src/commands/liferay/resource.command.ts
@@ -20,7 +20,13 @@ Import:
   import-structure, import-template, import-adt, import-fragment, import-fragments, import-structures, import-templates, import-adts
 
 Migration:
-  migration-init, migration-run, migration-pipeline
+  migration-init, migration-pipeline, migration-run
+
+Recommended:
+  migration-pipeline for normal end-to-end migrations
+
+Advanced:
+  migration-run for running one phase only while debugging or recovering
 `,
     }),
   );

--- a/src/commands/resource/resource-command-builder.ts
+++ b/src/commands/resource/resource-command-builder.ts
@@ -736,7 +736,7 @@ function buildResourceMigrationSubcommands(resource: Command): void {
   addOutputFormatOption(
     resource
       .command('migration-run')
-      .description('Execute a structure migration descriptor with a persisted migration plan')
+      .description('Advanced: run a single migration stage from a descriptor; prefer migration-pipeline for normal use')
       .requiredOption('--migration-file <file>', 'Migration descriptor JSON file')
       .option('--stage <stage>', 'Stage to run: introduce or cleanup', 'introduce')
       .option('--check-only', 'Validate only; do not mutate structures')
@@ -751,6 +751,7 @@ function buildResourceMigrationSubcommands(resource: Command): void {
           checkOnly: Boolean(options.checkOnly),
           migrationDryRun: Boolean(options.migrationDryRun),
           skipUpdate: Boolean(options.skipUpdate),
+          printer: context.printer,
         }),
       {text: formatLiferayResourceMigrationRun},
     ),
@@ -759,7 +760,9 @@ function buildResourceMigrationSubcommands(resource: Command): void {
   addOutputFormatOption(
     resource
       .command('migration-pipeline')
-      .description('Run the introduce phase and optionally the cleanup phase from a single descriptor')
+      .description(
+        'Recommended: run the full migration workflow from one descriptor, including validation and optional cleanup',
+      )
       .requiredOption('--migration-file <file>', 'Migration descriptor JSON file')
       .option('--check-only', 'Validate only; do not mutate structures or templates')
       .option('--migration-dry-run', 'Do not persist structured content migration updates')
@@ -776,6 +779,7 @@ function buildResourceMigrationSubcommands(resource: Command): void {
           runCleanup: Boolean(options.runCleanup),
           skipValidation: Boolean(options.skipValidation),
           createMissingTemplates: Boolean(options.createMissingTemplates),
+          printer: context.printer,
         }),
       {text: formatLiferayResourceMigrationPipeline},
     ),

--- a/src/commands/resource/resource.command.ts
+++ b/src/commands/resource/resource.command.ts
@@ -19,7 +19,13 @@ Import:
   import-structure, import-template, import-adt, import-fragment, import-fragments, import-structures, import-templates, import-adts
 
 Migration:
-  migration-init, migration-run, migration-pipeline
+  migration-init, migration-pipeline, migration-run
+
+Recommended:
+  migration-pipeline for normal end-to-end migrations
+
+Advanced:
+  migration-run for running one phase only while debugging or recovering
 `,
   });
 }

--- a/src/core/output/printer.ts
+++ b/src/core/output/printer.ts
@@ -2,6 +2,8 @@ import pc from 'picocolors';
 
 import type {OutputFormat} from './formats.js';
 
+let activeTtyProgressCount = 0;
+
 export type Printer = {
   write: (value: unknown) => void;
   error: (message: string) => void;
@@ -13,6 +15,7 @@ export function createPrinter(format: OutputFormat): Printer {
   return {
     format,
     write(value) {
+      prepareForTerminalOutput();
       if (format === 'text') {
         if (typeof value === 'string') {
           process.stdout.write(`${value}\n`);
@@ -30,9 +33,11 @@ export function createPrinter(format: OutputFormat): Printer {
       process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
     },
     error(message) {
+      prepareForTerminalOutput();
       process.stderr.write(`${format === 'text' ? pc.red(message) : message}\n`);
     },
     info(message) {
+      prepareForTerminalOutput();
       process.stderr.write(`${format === 'text' ? pc.cyan(message) : message}\n`);
     },
   };
@@ -70,6 +75,7 @@ export async function withProgress<T>(printer: Printer, message: string, task: (
     index += 1;
   };
 
+  activeTtyProgressCount += 1;
   render();
   const timer = setInterval(render, 120);
 
@@ -77,13 +83,21 @@ export async function withProgress<T>(printer: Printer, message: string, task: (
     const result = await task();
     clearInterval(timer);
     clearCurrentLine();
+    activeTtyProgressCount = Math.max(0, activeTtyProgressCount - 1);
     printer.info(`${message}: ok (${formatElapsed(Date.now() - startedAt)})`);
     return result;
   } catch (error) {
     clearInterval(timer);
     clearCurrentLine();
+    activeTtyProgressCount = Math.max(0, activeTtyProgressCount - 1);
     printer.error(`${message}: error (${formatElapsed(Date.now() - startedAt)})`);
     throw error;
+  }
+}
+
+function prepareForTerminalOutput(): void {
+  if (activeTtyProgressCount > 0 && process.stderr.isTTY) {
+    clearCurrentLine();
   }
 }
 

--- a/src/features/liferay/liferay-gateway.ts
+++ b/src/features/liferay/liferay-gateway.ts
@@ -68,20 +68,37 @@ export class LiferayGateway {
     this.accessTokenCache.set(this.getCacheKey(), {token: accessToken, cachedAt: Date.now()});
   }
 
+  private async requestWith401Retry<T>(
+    request: (accessToken: string) => Promise<HttpResponse<T>>,
+  ): Promise<HttpResponse<T>> {
+    const firstToken = await this.getAccessToken();
+    const firstResponse = await request(firstToken);
+
+    if (firstResponse.status !== 401) {
+      return firstResponse;
+    }
+
+    // Token may be stale/revoked; refresh once and retry the same request.
+    this.clearTokenCache();
+    const refreshedToken = await this.getAccessToken();
+    return request(refreshedToken);
+  }
+
   /**
    * GET /path, parse JSON, assert ok status, return data.
    * @throws CliError if response not ok
    */
   async getJson<T>(path: string, label: string, requestOptions?: HttpRequestOptions): Promise<T> {
-    const accessToken = await this.getAccessToken();
-    const authOptions = buildAuthOptions(this.config, accessToken);
-    const response = await this.apiClient.get<T>(this.config.liferay.url, path, {
-      ...authOptions,
-      ...requestOptions,
-      headers: {
-        ...authOptions.headers,
-        ...requestOptions?.headers,
-      },
+    const response = await this.requestWith401Retry((accessToken) => {
+      const authOptions = buildAuthOptions(this.config, accessToken);
+      return this.apiClient.get<T>(this.config.liferay.url, path, {
+        ...authOptions,
+        ...requestOptions,
+        headers: {
+          ...authOptions.headers,
+          ...requestOptions?.headers,
+        },
+      });
     });
 
     const success = await expectJsonSuccess(response, label, 'LIFERAY_GATEWAY_ERROR');
@@ -93,12 +110,8 @@ export class LiferayGateway {
    * @throws CliError if response not ok
    */
   async postJson<T>(path: string, payload: unknown, label: string): Promise<T> {
-    const accessToken = await this.getAccessToken();
-    const response = await this.apiClient.postJson<T>(
-      this.config.liferay.url,
-      path,
-      payload,
-      buildAuthOptions(this.config, accessToken),
+    const response = await this.requestWith401Retry((accessToken) =>
+      this.apiClient.postJson<T>(this.config.liferay.url, path, payload, buildAuthOptions(this.config, accessToken)),
     );
 
     const success = await expectJsonSuccess(response, label, 'LIFERAY_GATEWAY_ERROR');
@@ -110,12 +123,8 @@ export class LiferayGateway {
    * @throws CliError if response not ok
    */
   async postForm<T>(path: string, form: Record<string, string>, label: string): Promise<T> {
-    const accessToken = await this.getAccessToken();
-    const response = await this.apiClient.postForm<T>(
-      this.config.liferay.url,
-      path,
-      form,
-      buildAuthOptions(this.config, accessToken),
+    const response = await this.requestWith401Retry((accessToken) =>
+      this.apiClient.postForm<T>(this.config.liferay.url, path, form, buildAuthOptions(this.config, accessToken)),
     );
 
     const success = await expectJsonSuccess(response, label, 'LIFERAY_GATEWAY_ERROR');
@@ -127,12 +136,8 @@ export class LiferayGateway {
    * @throws CliError if response not ok
    */
   async postMultipart<T>(path: string, form: FormData, label: string): Promise<T> {
-    const accessToken = await this.getAccessToken();
-    const response = await this.apiClient.postMultipart<T>(
-      this.config.liferay.url,
-      path,
-      form,
-      buildAuthOptions(this.config, accessToken),
+    const response = await this.requestWith401Retry((accessToken) =>
+      this.apiClient.postMultipart<T>(this.config.liferay.url, path, form, buildAuthOptions(this.config, accessToken)),
     );
 
     const success = await expectJsonSuccess(response, label, 'LIFERAY_GATEWAY_ERROR');
@@ -144,15 +149,16 @@ export class LiferayGateway {
    * @throws CliError if response not ok
    */
   async putJson<T>(path: string, payload: unknown, label: string, requestOptions?: HttpRequestOptions): Promise<T> {
-    const accessToken = await this.getAccessToken();
-    const authOpts = buildAuthOptions(this.config, accessToken);
-    const response = await this.apiClient.putJson<T>(this.config.liferay.url, path, payload, {
-      ...authOpts,
-      ...requestOptions,
-      headers: {
-        ...authOpts.headers,
-        ...requestOptions?.headers,
-      },
+    const response = await this.requestWith401Retry((accessToken) => {
+      const authOpts = buildAuthOptions(this.config, accessToken);
+      return this.apiClient.putJson<T>(this.config.liferay.url, path, payload, {
+        ...authOpts,
+        ...requestOptions,
+        headers: {
+          ...authOpts.headers,
+          ...requestOptions?.headers,
+        },
+      });
     });
 
     const success = await expectJsonSuccess(response, label, 'LIFERAY_GATEWAY_ERROR');
@@ -164,9 +170,10 @@ export class LiferayGateway {
    * Use when the caller needs to inspect specific status codes (e.g., 403, 404) instead of a unified error throw.
    */
   async getRaw<T>(path: string): Promise<HttpResponse<T>> {
-    const accessToken = await this.getAccessToken();
-    const authOptions = buildAuthOptions(this.config, accessToken);
-    return this.apiClient.get<T>(this.config.liferay.url, path, authOptions);
+    return this.requestWith401Retry((accessToken) => {
+      const authOptions = buildAuthOptions(this.config, accessToken);
+      return this.apiClient.get<T>(this.config.liferay.url, path, authOptions);
+    });
   }
 
   /**
@@ -174,8 +181,9 @@ export class LiferayGateway {
    * Use when callers need to inspect status/body across multiple fallback payload candidates.
    */
   async postFormRaw<T>(path: string, form: Record<string, string>): Promise<HttpResponse<T>> {
-    const accessToken = await this.getAccessToken();
-    return this.apiClient.postForm<T>(this.config.liferay.url, path, form, buildAuthOptions(this.config, accessToken));
+    return this.requestWith401Retry((accessToken) =>
+      this.apiClient.postForm<T>(this.config.liferay.url, path, form, buildAuthOptions(this.config, accessToken)),
+    );
   }
 
   /**
@@ -183,11 +191,8 @@ export class LiferayGateway {
    * @throws CliError if response not ok
    */
   async deleteJson<T>(path: string, label: string): Promise<T> {
-    const accessToken = await this.getAccessToken();
-    const response = await this.apiClient.delete<T>(
-      this.config.liferay.url,
-      path,
-      buildAuthOptions(this.config, accessToken),
+    const response = await this.requestWith401Retry((accessToken) =>
+      this.apiClient.delete<T>(this.config.liferay.url, path, buildAuthOptions(this.config, accessToken)),
     );
 
     const success = await expectJsonSuccess(response, label, 'LIFERAY_GATEWAY_ERROR');

--- a/src/features/liferay/resource/liferay-resource-migration.ts
+++ b/src/features/liferay/resource/liferay-resource-migration.ts
@@ -82,6 +82,7 @@ export async function runLiferayResourceMigrationRun(
           migrationPhase: stage === 'cleanup' ? 'pre' : 'post',
           migrationDryRun: Boolean(options.checkOnly) || Boolean(options.migrationDryRun),
           cleanupMigration: stageDescriptor.cleanupMigration,
+          printer: options.printer,
         },
         dependencies,
       );
@@ -92,6 +93,9 @@ export async function runLiferayResourceMigrationRun(
     if (result.migration) {
       options.printer?.info(
         `Migration complete: ${result.migration.migrated} updated, ${result.migration.unchanged} unchanged, ${result.migration.failed} failed out of ${result.migration.scanned} scanned`,
+      );
+      options.printer?.info(
+        `Migration reasons: copied=${result.migration.reasonBreakdown.copiedToNewField}, already-target=${result.migration.reasonBreakdown.alreadyHadTargetValue}, source-empty=${result.migration.reasonBreakdown.sourceEmpty}, no-delta=${result.migration.reasonBreakdown.noEffectiveChange}, source-cleaned=${result.migration.reasonBreakdown.sourceCleaned}`,
       );
     } else {
       options.printer?.info(`Migration phase completed: ${result.status}`);

--- a/src/features/liferay/resource/liferay-resource-migration.ts
+++ b/src/features/liferay/resource/liferay-resource-migration.ts
@@ -3,6 +3,8 @@ import os from 'node:os';
 import path from 'node:path';
 
 import type {AppConfig} from '../../../core/config/load-config.js';
+import {withProgress, type Printer} from '../../../core/output/printer.js';
+import {toBooleanOrFalse} from '../../../core/utils/coerce.js';
 import {LiferayErrors} from '../errors/index.js';
 import {runLiferayInventoryTemplates} from '../inventory/liferay-inventory-templates.js';
 import {runLiferayResourceGetStructure} from './liferay-resource-get-structure.js';
@@ -55,6 +57,7 @@ export async function runLiferayResourceMigrationRun(
     checkOnly?: boolean;
     migrationDryRun?: boolean;
     skipUpdate?: boolean;
+    printer?: Printer;
   },
   dependencies?: ResourceSyncDependencies,
 ): Promise<LiferayResourceMigrationRunResult> {
@@ -66,29 +69,40 @@ export async function runLiferayResourceMigrationRun(
   const planFile = await writeTempPlanFile(stageDescriptor.planNode);
 
   try {
-    const result = await runLiferayResourceSyncStructure(
-      config,
-      {
-        site: descriptor.site,
-        key: descriptor.structureKey,
-        file: structureFile,
-        checkOnly: Boolean(options.checkOnly),
-        skipUpdate: Boolean(options.skipUpdate),
-        migrationPlan: planFile,
-        migrationPhase: stage === 'cleanup' ? 'pre' : 'post',
-        migrationDryRun: Boolean(options.checkOnly) || Boolean(options.migrationDryRun),
-        cleanupMigration: stageDescriptor.cleanupMigration,
-      },
-      dependencies,
-    );
+    const syncTask = async () =>
+      runLiferayResourceSyncStructure(
+        config,
+        {
+          site: descriptor.site,
+          key: descriptor.structureKey,
+          file: structureFile,
+          checkOnly: Boolean(options.checkOnly),
+          skipUpdate: Boolean(options.skipUpdate),
+          migrationPlan: planFile,
+          migrationPhase: stage === 'cleanup' ? 'pre' : 'post',
+          migrationDryRun: Boolean(options.checkOnly) || Boolean(options.migrationDryRun),
+          cleanupMigration: stageDescriptor.cleanupMigration,
+        },
+        dependencies,
+      );
 
+    const progressMessage = `Running ${stage} migration for structure: ${descriptor.structureKey} (site: ${descriptor.site})`;
+    const result = options.printer ? await withProgress(options.printer, progressMessage, syncTask) : await syncTask();
+
+    if (result.migration) {
+      options.printer?.info(
+        `Migration complete: ${result.migration.migrated} updated, ${result.migration.unchanged} unchanged, ${result.migration.failed} failed out of ${result.migration.scanned} scanned`,
+      );
+    } else {
+      options.printer?.info(`Migration phase completed: ${result.status}`);
+    }
     return {
       site: descriptor.site,
       structureKey: descriptor.structureKey,
       stage,
       status: result.status,
       id: result.id,
-      migrationApplied: Boolean(result.migration),
+      migrationApplied: Boolean(result.migration) && !result.migration?.dryRun,
       migratedArticleKeys: result.migration?.articleKeys ?? [],
     };
   } finally {
@@ -105,11 +119,19 @@ export async function runLiferayResourceMigrationPipeline(
     runCleanup?: boolean;
     skipValidation?: boolean;
     createMissingTemplates?: boolean;
+    printer?: Printer;
   },
   dependencies?: ResourceSyncDependencies,
 ): Promise<LiferayResourceMigrationPipelineResult> {
   const descriptor = await readMigrationDescriptor(config, options.migrationFile);
+  options.printer?.info(
+    `Starting migration pipeline for structure: ${descriptor.structureKey} (site: ${descriptor.site})`,
+  );
   const dependentStructureResults: Array<{key: string; status: string; id: string}> = [];
+
+  if (descriptor.dependentStructures.length > 0) {
+    options.printer?.info(`Processing ${descriptor.dependentStructures.length} dependent structure(s)...`);
+  }
 
   for (const dependentKey of descriptor.dependentStructures) {
     const checked = await runLiferayResourceSyncStructure(
@@ -138,6 +160,7 @@ export async function runLiferayResourceMigrationPipeline(
     dependentStructureResults.push({key: dependentKey, status: checked.status, id: checked.id});
   }
 
+  options.printer?.info(`Running introduce phase of structure migration...`);
   const structure = await runLiferayResourceMigrationRun(
     config,
     {
@@ -145,6 +168,7 @@ export async function runLiferayResourceMigrationPipeline(
       stage: 'introduce',
       checkOnly: options.checkOnly,
       migrationDryRun: options.migrationDryRun,
+      printer: options.printer,
     },
     dependencies,
   );
@@ -152,75 +176,115 @@ export async function runLiferayResourceMigrationPipeline(
   const pipelineTemplates = await resolvePipelineTemplates(config, descriptor, dependencies);
   const templateResults: Array<{name: string; status: string; id: string}> = [];
   for (const templateName of pipelineTemplates) {
-    const result = await runLiferayResourceSyncTemplate(
-      config,
-      {
-        site: descriptor.site,
-        key: templateName,
-        checkOnly: Boolean(options.checkOnly),
-        createMissing: Boolean(options.createMissingTemplates),
-      },
-      dependencies,
-    );
-    templateResults.push({name: templateName, status: result.status, id: result.id});
-  }
-
-  if (options.runCleanup) {
-    await runCleanupStage(
-      config,
-      descriptor,
-      structure.migratedArticleKeys,
-      {
-        checkOnly: options.checkOnly,
-        migrationDryRun: options.migrationDryRun,
-      },
-      dependencies,
-    );
-  }
-
-  if (!options.skipValidation) {
-    if (options.runCleanup) {
-      await runCleanupStage(
-        config,
-        descriptor,
-        structure.migratedArticleKeys,
-        {
-          checkOnly: true,
-          migrationDryRun: true,
-        },
-        dependencies,
-      );
-    } else {
-      const validationPlanFile = await writeTempPlanFile(descriptor.introduce.planNode);
-      try {
-        await runLiferayResourceSyncStructure(
-          config,
-          {
-            site: descriptor.site,
-            key: descriptor.structureKey,
-            file: await resolveMigrationStructureFile(config, descriptor, descriptor.introduce),
-            checkOnly: true,
-            migrationPlan: validationPlanFile,
-            migrationPhase: 'post',
-            cleanupMigration: false,
-          },
-          dependencies,
-        );
-      } finally {
-        await fs.remove(validationPlanFile);
-      }
-    }
-
-    for (const templateName of pipelineTemplates) {
-      await runLiferayResourceSyncTemplate(
+    const templateTask = async () =>
+      runLiferayResourceSyncTemplate(
         config,
         {
           site: descriptor.site,
           key: templateName,
-          checkOnly: true,
+          checkOnly: Boolean(options.checkOnly),
+          createMissing: Boolean(options.createMissingTemplates),
         },
         dependencies,
       );
+    const result = options.printer
+      ? await withProgress(
+          options.printer,
+          `Syncing template: ${templateName} (site: ${descriptor.site})`,
+          templateTask,
+        )
+      : await templateTask();
+    templateResults.push({name: templateName, status: result.status, id: result.id});
+  }
+
+  if (options.runCleanup) {
+    const cleanupTask = async () =>
+      runCleanupStage(
+        config,
+        descriptor,
+        structure.migratedArticleKeys,
+        {
+          checkOnly: options.checkOnly,
+          migrationDryRun: options.migrationDryRun,
+        },
+        dependencies,
+      );
+    const cleanupMessage = `Running cleanup phase of structure migration: ${descriptor.structureKey} (site: ${descriptor.site})`;
+    if (options.printer) {
+      await withProgress(options.printer, cleanupMessage, cleanupTask);
+    } else {
+      await cleanupTask();
+    }
+  }
+
+  if (!options.skipValidation) {
+    if (options.runCleanup) {
+      const validationCleanupTask = async () =>
+        runCleanupStage(
+          config,
+          descriptor,
+          structure.migratedArticleKeys,
+          {
+            checkOnly: true,
+            migrationDryRun: true,
+          },
+          dependencies,
+        );
+      const validationCleanupMessage = `Validating cleanup phase of structure migration: ${descriptor.structureKey} (site: ${descriptor.site})`;
+      if (options.printer) {
+        await withProgress(options.printer, validationCleanupMessage, validationCleanupTask);
+      } else {
+        await validationCleanupTask();
+      }
+    } else {
+      const validationMessage = `Validating structure migration: ${descriptor.structureKey} (site: ${descriptor.site})`;
+      const validationTask = async () => {
+        const validationPlanFile = await writeTempPlanFile(descriptor.introduce.planNode);
+        try {
+          await runLiferayResourceSyncStructure(
+            config,
+            {
+              site: descriptor.site,
+              key: descriptor.structureKey,
+              file: await resolveMigrationStructureFile(config, descriptor, descriptor.introduce),
+              checkOnly: true,
+              migrationPlan: validationPlanFile,
+              migrationPhase: 'post',
+              cleanupMigration: false,
+            },
+            dependencies,
+          );
+        } finally {
+          await fs.remove(validationPlanFile);
+        }
+      };
+      if (options.printer) {
+        await withProgress(options.printer, validationMessage, validationTask);
+      } else {
+        await validationTask();
+      }
+    }
+
+    for (const templateName of pipelineTemplates) {
+      const validateTemplateTask = async () =>
+        runLiferayResourceSyncTemplate(
+          config,
+          {
+            site: descriptor.site,
+            key: templateName,
+            checkOnly: true,
+          },
+          dependencies,
+        );
+      if (options.printer) {
+        await withProgress(
+          options.printer,
+          `Validating template: ${templateName} (site: ${descriptor.site})`,
+          validateTemplateTask,
+        );
+      } else {
+        await validateTemplateTask();
+      }
     }
   }
 
@@ -328,7 +392,7 @@ function normalizeMappingsArray(value: unknown): Array<Record<string, unknown>> 
       {
         source,
         target,
-        cleanupSource: Boolean((row as Record<string, unknown>).cleanupSource),
+        cleanupSource: toBooleanOrFalse((row as Record<string, unknown>).cleanupSource),
       },
     ];
   });
@@ -400,7 +464,7 @@ function buildCleanupPlanNode(
   migratedArticleKeys: string[],
 ): Record<string, unknown> {
   const cleanupMappings = normalizeMappingsArray(introducePlanNode.mappings)
-    .filter((mapping) => Boolean((mapping as Record<string, unknown>).cleanupSource))
+    .filter((mapping) => mapping.cleanupSource)
     .map((mapping) => ({
       source: String((mapping as Record<string, unknown>).source ?? '').trim(),
       target: String((mapping as Record<string, unknown>).target ?? '').trim(),
@@ -447,7 +511,7 @@ async function resolveMigrationStructureFile(
 
 function cleanupSourceFields(planNode: Record<string, unknown>): string[] {
   return normalizeMappingsArray(planNode.mappings)
-    .filter((mapping) => Boolean((mapping as Record<string, unknown>).cleanupSource))
+    .filter((mapping) => mapping.cleanupSource)
     .map((mapping) => String((mapping as Record<string, unknown>).source ?? '').trim())
     .filter(Boolean);
 }
@@ -461,7 +525,14 @@ async function writeDerivedCleanupStructureFile(
     ? structureFile
     : path.resolve(config.repoRoot ?? config.cwd, structureFile);
   const payload = (await fs.readJson(absoluteStructureFile)) as Record<string, unknown>;
-  payload.dataDefinitionFields = removeFieldsRecursive(payload.dataDefinitionFields, new Set(cleanupSources));
+  const cleanupSourceSet = new Set(cleanupSources);
+  payload.dataDefinitionFields = removeFieldsRecursive(payload.dataDefinitionFields, cleanupSourceSet);
+  if (payload.defaultDataLayout && typeof payload.defaultDataLayout === 'object') {
+    payload.defaultDataLayout = removeLayoutReferences(payload.defaultDataLayout, cleanupSourceSet);
+  }
+  if (payload.dataLayout && typeof payload.dataLayout === 'object') {
+    payload.dataLayout = removeLayoutReferences(payload.dataLayout, cleanupSourceSet);
+  }
   const target = path.join(await fs.mkdtemp(path.join(os.tmpdir(), 'dev-cli-migration-cleanup-')), 'structure.json');
   await fs.writeJson(target, payload, {spaces: 2});
   return target;
@@ -489,6 +560,190 @@ function removeFieldsRecursive(fields: unknown, cleanupSources: Set<string>): Ar
     }
     kept.push(record);
   }
+  return kept;
+}
+
+function removeLayoutReferences(layout: unknown, cleanupSources: Set<string>): Record<string, unknown> {
+  if (!layout || typeof layout !== 'object') {
+    return {};
+  }
+
+  const record = structuredClone(layout) as Record<string, unknown>;
+
+  if (Array.isArray(record.dataLayoutPages)) {
+    record.dataLayoutPages = removeDataLayoutPages(record.dataLayoutPages, cleanupSources);
+  }
+
+  if (Array.isArray(record.pages)) {
+    record.pages = removeLegacyLayoutPages(record.pages, cleanupSources);
+  }
+
+  return record;
+}
+
+function removeDataLayoutPages(pages: unknown, cleanupSources: Set<string>): Array<Record<string, unknown>> {
+  if (!Array.isArray(pages)) {
+    return [];
+  }
+
+  const kept: Array<Record<string, unknown>> = [];
+
+  for (const page of pages) {
+    if (!page || typeof page !== 'object') {
+      continue;
+    }
+
+    const record = structuredClone(page) as Record<string, unknown>;
+    if (Array.isArray(record.dataLayoutRows)) {
+      record.dataLayoutRows = removeDataLayoutRows(record.dataLayoutRows, cleanupSources);
+    }
+
+    if (!Array.isArray(record.dataLayoutRows) || record.dataLayoutRows.length > 0) {
+      kept.push(record);
+    }
+  }
+
+  return kept;
+}
+
+function removeDataLayoutRows(rows: unknown, cleanupSources: Set<string>): Array<Record<string, unknown>> {
+  if (!Array.isArray(rows)) {
+    return [];
+  }
+
+  const kept: Array<Record<string, unknown>> = [];
+
+  for (const row of rows) {
+    if (!row || typeof row !== 'object') {
+      continue;
+    }
+
+    const record = structuredClone(row) as Record<string, unknown>;
+    if (Array.isArray(record.dataLayoutColumns)) {
+      record.dataLayoutColumns = removeDataLayoutColumns(record.dataLayoutColumns, cleanupSources);
+    }
+
+    if (!Array.isArray(record.dataLayoutColumns) || record.dataLayoutColumns.length > 0) {
+      kept.push(record);
+    }
+  }
+
+  return kept;
+}
+
+function removeDataLayoutColumns(columns: unknown, cleanupSources: Set<string>): Array<Record<string, unknown>> {
+  if (!Array.isArray(columns)) {
+    return [];
+  }
+
+  const kept: Array<Record<string, unknown>> = [];
+
+  for (const column of columns) {
+    if (!column || typeof column !== 'object') {
+      continue;
+    }
+
+    const record = structuredClone(column) as Record<string, unknown>;
+    const fieldNames = Array.isArray(record.fieldNames)
+      ? (record.fieldNames as unknown[])
+          .map((fieldName) => String(fieldName).trim())
+          .filter((fieldName) => fieldName !== '' && !cleanupSources.has(fieldName))
+      : undefined;
+
+    if (fieldNames && fieldNames.length === 0) {
+      continue;
+    }
+
+    if (fieldNames) {
+      record.fieldNames = fieldNames;
+    }
+
+    kept.push(record);
+  }
+
+  return kept;
+}
+
+function removeLegacyLayoutPages(pages: unknown, cleanupSources: Set<string>): Array<Record<string, unknown>> {
+  if (!Array.isArray(pages)) {
+    return [];
+  }
+
+  const kept: Array<Record<string, unknown>> = [];
+
+  for (const page of pages) {
+    if (!page || typeof page !== 'object') {
+      continue;
+    }
+
+    const record = structuredClone(page) as Record<string, unknown>;
+    if (Array.isArray(record.rows)) {
+      record.rows = removeLegacyLayoutRows(record.rows, cleanupSources);
+    }
+
+    if (!Array.isArray(record.rows) || record.rows.length > 0) {
+      kept.push(record);
+    }
+  }
+
+  return kept;
+}
+
+function removeLegacyLayoutRows(rows: unknown, cleanupSources: Set<string>): Array<Record<string, unknown>> {
+  if (!Array.isArray(rows)) {
+    return [];
+  }
+
+  const kept: Array<Record<string, unknown>> = [];
+
+  for (const row of rows) {
+    if (!row || typeof row !== 'object') {
+      continue;
+    }
+
+    const record = structuredClone(row) as Record<string, unknown>;
+    if (Array.isArray(record.columns)) {
+      record.columns = removeLegacyLayoutColumns(record.columns, cleanupSources);
+    }
+
+    if (!Array.isArray(record.columns) || record.columns.length > 0) {
+      kept.push(record);
+    }
+  }
+
+  return kept;
+}
+
+function removeLegacyLayoutColumns(columns: unknown, cleanupSources: Set<string>): Array<Record<string, unknown>> {
+  if (!Array.isArray(columns)) {
+    return [];
+  }
+
+  const kept: Array<Record<string, unknown>> = [];
+
+  for (const column of columns) {
+    if (!column || typeof column !== 'object') {
+      continue;
+    }
+
+    const record = structuredClone(column) as Record<string, unknown>;
+    const fields = Array.isArray(record.fields)
+      ? (record.fields as unknown[])
+          .map((fieldName) => String(fieldName).trim())
+          .filter((fieldName) => fieldName !== '' && !cleanupSources.has(fieldName))
+      : undefined;
+
+    if (fields && fields.length === 0) {
+      continue;
+    }
+
+    if (fields) {
+      record.fields = fields;
+    }
+
+    kept.push(record);
+  }
+
   return kept;
 }
 

--- a/src/features/liferay/resource/liferay-resource-sync-structure-migration.ts
+++ b/src/features/liferay/resource/liferay-resource-sync-structure-migration.ts
@@ -140,11 +140,18 @@ export async function runStructureMigration(
       const before = await fetchStructuredContentForMigration(options.gateway, contentId);
       const sourceSnapshots = options.sourceSnapshots?.get(contentId);
       const locales = resolveMigrationLocales(before, sourceSnapshots);
+      const localizedSnapshots = new Map<string, StructuredContentRow>();
+      for (const locale of locales) {
+        localizedSnapshots.set(
+          locale,
+          locale === '' ? before : await fetchStructuredContentForMigration(options.gateway, contentId, locale),
+        );
+      }
+      const titleI18n = buildTitleI18n(localizedSnapshots);
       let changedAcrossLocales = false;
 
       for (const locale of locales) {
-        const beforeLocalized =
-          locale === '' ? before : await fetchStructuredContentForMigration(options.gateway, contentId, locale);
+        const beforeLocalized = localizedSnapshots.get(locale) ?? before;
         const source = sourceSnapshots?.get(locale) ?? beforeLocalized;
         const after = structuredClone(beforeLocalized);
         const changed = applyMappings(after, source, planData.rules, options.cleanupSource);
@@ -163,6 +170,9 @@ export async function runStructureMigration(
           ]);
           if (payload.contentFields !== undefined) {
             payload.contentFields = toApiContentFields(payload.contentFields, runtimeDefinitionFields);
+          }
+          if (Object.keys(titleI18n).length > 0) {
+            payload.title_i18n = titleI18n;
           }
           await options.gateway.putJson(
             `/o/headless-delivery/v1.0/structured-contents/${encodeURIComponent(contentId)}`,
@@ -486,6 +496,26 @@ function resolveMigrationLocales(content: StructuredContentRow, snapshots?: Loca
   }
 
   return [''];
+}
+
+function buildTitleI18n(localizedSnapshots: Map<string, StructuredContentRow>): Record<string, string> {
+  const titles: Record<string, string> = {};
+
+  for (const [locale, snapshot] of localizedSnapshots) {
+    const normalizedLocale = locale.trim();
+    if (normalizedLocale === '') {
+      continue;
+    }
+
+    const title = String(snapshot.title ?? '').trim();
+    if (title === '') {
+      continue;
+    }
+
+    titles[normalizedLocale] = title;
+  }
+
+  return titles;
 }
 
 export function parseMigrationPlan(plan: MigrationPlanShape): MigrationPlanData {

--- a/src/features/liferay/resource/liferay-resource-sync-structure-migration.ts
+++ b/src/features/liferay/resource/liferay-resource-sync-structure-migration.ts
@@ -12,6 +12,14 @@ export type MigrationRule = {
   cleanupSource: boolean;
 };
 
+export type MigrationReasonBreakdown = {
+  copiedToNewField: number;
+  alreadyHadTargetValue: number;
+  sourceEmpty: number;
+  noEffectiveChange: number;
+  sourceCleaned: number;
+};
+
 export type MigrationStats = {
   scanned: number;
   migrated: number;
@@ -19,6 +27,7 @@ export type MigrationStats = {
   failed: number;
   dryRun: boolean;
   articleKeys: string[];
+  reasonBreakdown: MigrationReasonBreakdown;
 };
 
 type MigrationFailure = {
@@ -123,6 +132,13 @@ export async function runStructureMigration(
     failed: 0,
     dryRun: options.dryRun,
     articleKeys: [],
+    reasonBreakdown: {
+      copiedToNewField: 0,
+      alreadyHadTargetValue: 0,
+      sourceEmpty: 0,
+      noEffectiveChange: 0,
+      sourceCleaned: 0,
+    },
   };
 
   const progressInterval = 10; // Print progress every 10 items
@@ -149,13 +165,30 @@ export async function runStructureMigration(
       }
       const titleI18n = buildTitleI18n(localizedSnapshots);
       let changedAcrossLocales = false;
+      let sourceValueFound = false;
+      let sourceValueMissing = false;
+      let targetValueAlreadyPresent = false;
+      let copiedToTarget = false;
+      let sourceCleaned = false;
+      let noEffectiveChange = false;
 
       for (const locale of locales) {
         const beforeLocalized = localizedSnapshots.get(locale) ?? before;
         const source = sourceSnapshots?.get(locale) ?? beforeLocalized;
         const after = structuredClone(beforeLocalized);
-        const changed = applyMappings(after, source, planData.rules, options.cleanupSource);
-        if (!changed || contentFieldsEqual(beforeLocalized, after)) {
+        const diagnostics = applyMappings(after, source, planData.rules, options.cleanupSource);
+        sourceValueFound = sourceValueFound || diagnostics.sourceWithValue > 0;
+        sourceValueMissing = sourceValueMissing || diagnostics.sourceEmpty > 0;
+        targetValueAlreadyPresent = targetValueAlreadyPresent || diagnostics.targetAlreadySet > 0;
+        copiedToTarget = copiedToTarget || diagnostics.targetWritten > 0;
+        sourceCleaned = sourceCleaned || diagnostics.sourceCleaned > 0;
+
+        if (!diagnostics.changed) {
+          continue;
+        }
+
+        if (contentFieldsEqual(beforeLocalized, after)) {
+          noEffectiveChange = true;
           continue;
         }
         changedAcrossLocales = true;
@@ -186,10 +219,28 @@ export async function runStructureMigration(
 
       if (!changedAcrossLocales) {
         stats.unchanged += 1;
+
+        if (targetValueAlreadyPresent && !copiedToTarget) {
+          stats.reasonBreakdown.alreadyHadTargetValue += 1;
+        } else if (!sourceValueFound && sourceValueMissing) {
+          stats.reasonBreakdown.sourceEmpty += 1;
+        } else if (noEffectiveChange) {
+          stats.reasonBreakdown.noEffectiveChange += 1;
+        } else if (sourceValueMissing) {
+          stats.reasonBreakdown.sourceEmpty += 1;
+        } else {
+          stats.reasonBreakdown.noEffectiveChange += 1;
+        }
         continue;
       }
 
       stats.migrated += 1;
+      if (copiedToTarget) {
+        stats.reasonBreakdown.copiedToNewField += 1;
+      }
+      if (sourceCleaned) {
+        stats.reasonBreakdown.sourceCleaned += 1;
+      }
       if (articleKey !== '') {
         migratedArticleKeys.add(articleKey);
       }
@@ -397,14 +448,21 @@ async function fetchLatestJournalArticle(
   siteId: number,
   articleId: string,
 ): Promise<JsonMap | null> {
-  try {
-    return await gateway.getJson<JsonMap>(
-      `/api/jsonws/journal.journalarticle/get-latest-article?groupId=${siteId}&articleId=${encodeURIComponent(articleId)}&status=0`,
-      'structure-migrate get-latest-article',
-    );
-  } catch {
+  const response = await gateway.getRaw<JsonMap>(
+    `/api/jsonws/journal.journalarticle/get-latest-article?groupId=${siteId}&articleId=${encodeURIComponent(articleId)}&status=0`,
+  );
+
+  if (response.status === 404) {
     return null;
   }
+
+  if (!response.ok) {
+    throw LiferayErrors.resourceError(
+      `structure-migrate get-latest-article failed with status=${response.status} for articleId=${articleId}`,
+    );
+  }
+
+  return (response.data as JsonMap | null) ?? null;
 }
 
 async function fetchStructureDefinitionFields(
@@ -572,23 +630,52 @@ function applyMappings(
   sourceItem: StructuredContentRow,
   mappings: MigrationRule[],
   cleanupSource: boolean,
-): boolean {
+): {
+  changed: boolean;
+  sourceEmpty: number;
+  sourceWithValue: number;
+  targetWritten: number;
+  targetAlreadySet: number;
+  sourceCleaned: number;
+} {
   let changed = false;
+  let sourceEmpty = 0;
+  let sourceWithValue = 0;
+  let targetWritten = 0;
+  let targetAlreadySet = 0;
+  let sourceCleaned = 0;
+
   for (const mapping of mappings) {
     const value = firstSourceValue(sourceItem.contentFields, mapping.source);
     if (!value || isEmptyValue(value)) {
+      sourceEmpty += 1;
       continue;
     }
+
+    sourceWithValue += 1;
     if (setTargetValue(item, mapping.target, structuredClone(value))) {
       changed = true;
+      targetWritten += 1;
+    } else {
+      targetAlreadySet += 1;
     }
+
     if (cleanupSource) {
       if (cleanupSourceField(item, mapping.source)) {
         changed = true;
+        sourceCleaned += 1;
       }
     }
   }
-  return changed;
+
+  return {
+    changed,
+    sourceEmpty,
+    sourceWithValue,
+    targetWritten,
+    targetAlreadySet,
+    sourceCleaned,
+  };
 }
 
 function firstSourceValue(contentFields: unknown, source: string): unknown | null {

--- a/src/features/liferay/resource/liferay-resource-sync-structure-migration.ts
+++ b/src/features/liferay/resource/liferay-resource-sync-structure-migration.ts
@@ -1,6 +1,8 @@
 import fs from 'fs-extra';
 
 import type {AppConfig} from '../../../core/config/load-config.js';
+import type {Printer} from '../../../core/output/printer.js';
+import {toBooleanOrFalse} from '../../../core/utils/coerce.js';
 import {LiferayErrors} from '../errors/index.js';
 import type {LiferayGateway} from '../liferay-gateway.js';
 
@@ -62,6 +64,12 @@ type MigrationPlanShape = {
 
 type LocalizedContentSnapshots = Map<string, StructuredContentRow>;
 
+type DataDefinitionField = JsonMap & {
+  name?: string;
+  customProperties?: JsonMap;
+  nestedDataDefinitionFields?: unknown;
+};
+
 export async function runStructureMigration(
   config: AppConfig,
   structureKey: string,
@@ -72,6 +80,7 @@ export async function runStructureMigration(
     dryRun: boolean;
     cleanupSource: boolean;
     sourceSnapshots?: Map<string, LocalizedContentSnapshots>;
+    printer?: Printer;
     fetchStructureByKeyFn: (
       config: AppConfig,
       gateway: LiferayGateway,
@@ -90,12 +99,20 @@ export async function runStructureMigration(
     throw LiferayErrors.resourceError('Invalid migration plan: missing mappings[]');
   }
 
+  options.printer?.info(
+    `Migrating structure content: resolving structure definition and selecting targeted content...`,
+  );
   const structure = await options.fetchStructureByKeyFn(config, options.gateway, siteId, structureKey);
   if (!structure?.id) {
     throw LiferayErrors.resourceError(`Could not resolve structure ${structureKey}`);
   }
 
+  const runtimeDefinitionFields = await fetchStructureDefinitionFields(options.gateway, String(structure.id));
+
   const selected = await selectStructureContents(options.gateway, siteId, String(structure.id), planData);
+  options.printer?.info(
+    `Found ${selected.length} content item(s) matching migration criteria; processing migrations...`,
+  );
 
   const migratedArticleKeys = new Set<string>();
   const failures: MigrationFailure[] = [];
@@ -108,8 +125,15 @@ export async function runStructureMigration(
     articleKeys: [],
   };
 
+  const progressInterval = 10; // Print progress every 10 items
+
   for (const item of selected) {
     stats.scanned += 1;
+    if (options.printer && selected.length > progressInterval && (stats.scanned - 1) % progressInterval === 0) {
+      options.printer.info(
+        `Migrating content: ${stats.scanned}/${selected.length} scanned (${stats.migrated} migrated, ${stats.unchanged} unchanged, ${stats.failed} failed)`,
+      );
+    }
     try {
       const contentId = String(item.id ?? '');
       const articleKey = String(item.key ?? '').trim();
@@ -137,6 +161,9 @@ export async function runStructureMigration(
             'title',
             'contentFields',
           ]);
+          if (payload.contentFields !== undefined) {
+            payload.contentFields = toApiContentFields(payload.contentFields, runtimeDefinitionFields);
+          }
           await options.gateway.putJson(
             `/o/headless-delivery/v1.0/structured-contents/${encodeURIComponent(contentId)}`,
             payload,
@@ -167,6 +194,10 @@ export async function runStructureMigration(
   }
 
   stats.articleKeys = [...migratedArticleKeys].sort();
+
+  options.printer?.info(
+    `Migration phase complete: ${stats.migrated} updated, ${stats.unchanged} unchanged, ${stats.failed} failed out of ${stats.scanned} total (${options.dryRun ? 'dry-run' : 'persisted'})`,
+  );
 
   if (failures.length > 0) {
     const summary = failures
@@ -228,6 +259,20 @@ async function selectStructureContents(
       : []),
   ]);
   const articleIds = new Set(planData.articleIds);
+
+  if (articleIds.size > 0) {
+    const selected = await listStructureContentsByArticleIds(gateway, siteId, planData.articleIds);
+
+    return selected.filter((item) => {
+      const folderId = Number(item.structuredContentFolderId ?? Number.MIN_SAFE_INTEGER);
+      const articleId = String(item.key ?? '');
+      const folderOk = scopedFolderIds.size === 0 || scopedFolderIds.has(folderId);
+      const articleOk = articleIds.has(articleId);
+      const structureOk = String(item.contentStructureId ?? '') === structureId;
+      return folderOk && articleOk && structureOk;
+    });
+  }
+
   const contents =
     scopedFolderIds.size > 0
       ? await listStructureContentsByFolders(gateway, [...scopedFolderIds], structureId)
@@ -240,6 +285,32 @@ async function selectStructureContents(
     const articleOk = articleIds.size === 0 || articleIds.has(articleId);
     return folderOk && articleOk;
   });
+}
+
+async function listStructureContentsByArticleIds(
+  gateway: LiferayGateway,
+  siteId: number,
+  articleIds: string[],
+): Promise<StructuredContentRow[]> {
+  const deduped = new Map<string, StructuredContentRow>();
+
+  for (const articleId of articleIds) {
+    const article = await fetchLatestJournalArticle(gateway, siteId, articleId);
+    const structuredContentId = Number(article?.resourcePrimKey ?? article?.id ?? -1);
+
+    if (!Number.isFinite(structuredContentId) || structuredContentId <= 0) {
+      continue;
+    }
+
+    const content = await fetchStructuredContentForMigration(gateway, String(structuredContentId));
+    const contentId = String(content.id ?? '').trim();
+
+    if (contentId !== '' && !deduped.has(contentId)) {
+      deduped.set(contentId, content);
+    }
+  }
+
+  return [...deduped.values()];
 }
 
 async function listStructureContents(gateway: LiferayGateway, structureId: string): Promise<StructuredContentRow[]> {
@@ -311,6 +382,35 @@ async function fetchStructuredContentForMigration(
   );
 }
 
+async function fetchLatestJournalArticle(
+  gateway: LiferayGateway,
+  siteId: number,
+  articleId: string,
+): Promise<JsonMap | null> {
+  try {
+    return await gateway.getJson<JsonMap>(
+      `/api/jsonws/journal.journalarticle/get-latest-article?groupId=${siteId}&articleId=${encodeURIComponent(articleId)}&status=0`,
+      'structure-migrate get-latest-article',
+    );
+  } catch {
+    return null;
+  }
+}
+
+async function fetchStructureDefinitionFields(
+  gateway: LiferayGateway,
+  structureId: string,
+): Promise<DataDefinitionField[]> {
+  const definition = await gateway.getJson<JsonMap>(
+    `/o/data-engine/v2.0/data-definitions/${encodeURIComponent(structureId)}`,
+    'structure-migrate definition',
+  );
+
+  return Array.isArray(definition.dataDefinitionFields)
+    ? (definition.dataDefinitionFields as DataDefinitionField[])
+    : [];
+}
+
 async function expandRootFolderScope(
   gateway: LiferayGateway,
   siteId: number,
@@ -346,21 +446,31 @@ async function verifyStructuredContentPersistence(
   expected: StructuredContentRow,
   acceptLanguage = '',
 ): Promise<void> {
-  const maxAttempts = 4;
-  const retryDelayMs = 500;
+  const maxAttempts = 8;
+  const baseRetryDelayMs = 500;
+  let lastPersisted: StructuredContentRow | null = null;
 
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
     const persisted = await fetchStructuredContentForMigration(gateway, contentId, acceptLanguage);
+    lastPersisted = persisted;
     if (contentFieldsEqual(expected, persisted)) {
       return;
     }
+
     if (attempt < maxAttempts) {
-      await sleep(retryDelayMs);
+      // Liferay may persist structured content asynchronously; use bounded backoff.
+      const delayMs = baseRetryDelayMs * attempt;
+      await sleep(delayMs);
     }
   }
 
+  const expectedKey = String(expected.key ?? '').trim();
+  const persistedId = String(lastPersisted?.id ?? '').trim();
+
   throw LiferayErrors.resourceError(
-    `structure-migrate update was accepted but contentFields were not persisted for content ${contentId}.`,
+    `structure-migrate update was accepted but contentFields were not persisted after ${maxAttempts} verification attempts for contentId=${contentId}${
+      expectedKey !== '' ? ` (articleKey=${expectedKey})` : ''
+    }${persistedId !== '' ? `; latest fetched contentId=${persistedId}` : ''}.`,
   );
 }
 
@@ -407,7 +517,7 @@ function parseMappings(rawMappings: unknown): MigrationRule[] {
       {
         source,
         target,
-        cleanupSource: Boolean(mapping.cleanupSource),
+        cleanupSource: toBooleanOrFalse(mapping.cleanupSource),
       },
     ];
   });
@@ -541,7 +651,70 @@ function cleanupSourceInFields(fields: Array<Record<string, unknown>>, source: s
 }
 
 function contentFieldsEqual(left: Record<string, unknown>, right: Record<string, unknown>): boolean {
-  return JSON.stringify(left.contentFields ?? []) === JSON.stringify(right.contentFields ?? []);
+  return (
+    JSON.stringify(normalizeComparableValue(left.contentFields ?? [])) ===
+    JSON.stringify(normalizeComparableValue(right.contentFields ?? []))
+  );
+}
+
+function toApiContentFields(contentFields: unknown, definitionFields: unknown): unknown {
+  if (!Array.isArray(contentFields)) {
+    return contentFields;
+  }
+
+  const scope = Array.isArray(definitionFields) ? (definitionFields as DataDefinitionField[]) : [];
+
+  return contentFields.map((entry) => {
+    if (!entry || typeof entry !== 'object') {
+      return entry;
+    }
+
+    const field = structuredClone(entry) as Record<string, unknown>;
+    const definition = findDefinitionField(scope, String(field.name ?? '').trim());
+
+    if (definition?.name) {
+      field.name = definition.name;
+    }
+
+    if (Array.isArray(field.nestedContentFields)) {
+      field.nestedContentFields = toApiContentFields(field.nestedContentFields, definition?.nestedDataDefinitionFields);
+    }
+
+    return field;
+  });
+}
+
+function findDefinitionField(scope: DataDefinitionField[], fieldName: string): DataDefinitionField | null {
+  if (fieldName === '') {
+    return null;
+  }
+
+  for (const definition of scope) {
+    const internalName = String(definition.name ?? '').trim();
+    const fieldReference = String((definition.customProperties?.fieldReference as string | undefined) ?? '').trim();
+
+    if (fieldName === internalName || fieldName === fieldReference) {
+      return definition;
+    }
+  }
+
+  return null;
+}
+
+function normalizeComparableValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => normalizeComparableValue(entry));
+  }
+
+  if (value && typeof value === 'object') {
+    const normalized: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+      normalized[key] = normalizeComparableValue((value as Record<string, unknown>)[key]);
+    }
+    return normalized;
+  }
+
+  return value;
 }
 
 function ensureContentFields(item: Record<string, unknown>): Array<Record<string, unknown>> {

--- a/src/features/liferay/resource/liferay-resource-sync-structure.ts
+++ b/src/features/liferay/resource/liferay-resource-sync-structure.ts
@@ -122,6 +122,9 @@ export function formatLiferayResourceSyncStructure(result: LiferayResourceSyncSt
     lines.push(
       `migration scanned=${result.migration.scanned} migrated=${result.migration.migrated} unchanged=${result.migration.unchanged} failed=${result.migration.failed} dryRun=${result.migration.dryRun}`,
     );
+    lines.push(
+      `migration reasons copied=${result.migration.reasonBreakdown.copiedToNewField} alreadyTarget=${result.migration.reasonBreakdown.alreadyHadTargetValue} sourceEmpty=${result.migration.reasonBreakdown.sourceEmpty} noDelta=${result.migration.reasonBreakdown.noEffectiveChange} sourceCleaned=${result.migration.reasonBreakdown.sourceCleaned}`,
+    );
   }
   return lines.join('\n');
 }

--- a/src/features/liferay/resource/liferay-resource-sync-structure.ts
+++ b/src/features/liferay/resource/liferay-resource-sync-structure.ts
@@ -1,4 +1,5 @@
 import type {AppConfig} from '../../../core/config/load-config.js';
+import type {Printer} from '../../../core/output/printer.js';
 import {LiferayErrors} from '../errors/index.js';
 import {resolveSite} from '../inventory/liferay-inventory-shared.js';
 import {resolveStructureFile} from './liferay-resource-paths.js';
@@ -33,6 +34,7 @@ export async function runLiferayResourceSyncStructure(
     migrationDryRun?: boolean;
     cleanupMigration?: boolean;
     allowBreakingChange?: boolean;
+    printer?: Printer;
   },
   dependencies?: ResourceDependencies,
 ): Promise<LiferayResourceSyncStructureResult> {
@@ -52,6 +54,7 @@ export async function runLiferayResourceSyncStructure(
     migrationDryRun: options.migrationDryRun,
     cleanupMigration: options.cleanupMigration,
     allowBreakingChange: options.allowBreakingChange,
+    printer: options.printer,
   };
 
   // Call strategy methods

--- a/src/features/liferay/resource/sync-strategies/structure-sync-strategy.ts
+++ b/src/features/liferay/resource/sync-strategies/structure-sync-strategy.ts
@@ -6,6 +6,7 @@
 import fs from 'fs-extra';
 
 import type {AppConfig} from '../../../../core/config/load-config.js';
+import type {Printer} from '../../../../core/output/printer.js';
 import {CliError} from '../../../../core/errors.js';
 import {createLiferayApiClient} from '../../../../core/http/client.js';
 import {createLiferayGateway, type LiferayGateway} from '../../liferay-gateway.js';
@@ -54,6 +55,7 @@ type StructureSyncOptions = {
   migrationDryRun?: boolean;
   cleanupMigration?: boolean;
   allowBreakingChange?: boolean;
+  printer?: Printer;
 };
 
 export type StructureResourceDependencies = ResourceSyncDependencies & {
@@ -152,6 +154,7 @@ export const structureSyncStrategy: SyncStrategy<StructureLocalData, StructureRe
       cleanupSource: Boolean(opts.cleanupMigration),
       dryRun: Boolean(opts.migrationDryRun),
       fetchStructureByKeyFn: fetchStructureByKey,
+      printer: opts.printer,
     };
 
     // ---- checkOnly/skipUpdate path ----
@@ -160,6 +163,7 @@ export const structureSyncStrategy: SyncStrategy<StructureLocalData, StructureRe
         migration = await runStructureMigration(config, opts.key, site.id, opts.migrationPlan, {
           ...migrationOptions,
           dryRun: true,
+          printer: opts.printer,
         });
       }
 
@@ -232,6 +236,7 @@ export const structureSyncStrategy: SyncStrategy<StructureLocalData, StructureRe
       migration = await runStructureMigration(config, opts.key, site.id, opts.migrationPlan!, {
         ...migrationOptions,
         sourceSnapshots,
+        printer: opts.printer,
       });
     }
 

--- a/src/features/liferay/resource/sync-strategies/structure-sync-strategy.ts
+++ b/src/features/liferay/resource/sync-strategies/structure-sync-strategy.ts
@@ -163,7 +163,6 @@ export const structureSyncStrategy: SyncStrategy<StructureLocalData, StructureRe
         migration = await runStructureMigration(config, opts.key, site.id, opts.migrationPlan, {
           ...migrationOptions,
           dryRun: true,
-          printer: opts.printer,
         });
       }
 
@@ -236,7 +235,6 @@ export const structureSyncStrategy: SyncStrategy<StructureLocalData, StructureRe
       migration = await runStructureMigration(config, opts.key, site.id, opts.migrationPlan!, {
         ...migrationOptions,
         sourceSnapshots,
-        printer: opts.printer,
       });
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
 import {normalizeCliError, resolveOutputFormatFromArgv, toCliErrorPayload} from './cli/errors.js';
 import {createCli} from './cli/create-cli.js';
 import {buildContextualRootSummary} from './cli/contextual-help.js';
+import {sanitizeErrorMessage} from './core/errors-sanitize.js';
 
 async function main(): Promise<void> {
   const cli = createCli();
@@ -14,13 +15,17 @@ async function main(): Promise<void> {
 
 main().catch((error: unknown) => {
   const cliError = normalizeCliError(error);
+  const safeMessage = sanitizeErrorMessage(cliError.message);
+  const safeCliError = safeMessage === cliError.message ? cliError : {...cliError, message: safeMessage};
   const format = resolveOutputFormatFromArgv(process.argv);
 
   if (format === 'text') {
-    process.stderr.write(`${cliError.code}: ${cliError.message}\n`);
+    process.stderr.write(`${safeCliError.code}: ${safeCliError.message}\n`);
   } else {
-    process.stderr.write(`${JSON.stringify(toCliErrorPayload(cliError), null, format === 'json' ? 2 : undefined)}\n`);
+    process.stderr.write(
+      `${JSON.stringify(toCliErrorPayload(safeCliError), null, format === 'json' ? 2 : undefined)}\n`,
+    );
   }
 
-  process.exit(cliError.exitCode);
+  process.exit(safeCliError.exitCode);
 });

--- a/templates/ai/skills/migrating-journal-structures/SKILL.md
+++ b/templates/ai/skills/migrating-journal-structures/SKILL.md
@@ -18,7 +18,42 @@ ldev start
 > `ldev context --json` returns `paths.migrations` and `paths.structures` — the
 > local directories where descriptors and structure files are expected by default.
 
+> **Always run migrations inside a worktree, never against the main environment.**
+> Worktrees provide an isolated portal instance that can be restored or discarded
+> if the migration produces unexpected results. Running migrations against a shared
+> or production-like environment without a worktree makes rollback difficult or
+> impossible. Create and start an isolated environment first:
+> ```bash
+> ldev worktree setup --name <issue-name>
+> ldev worktree start <issue-name>
+> ```
+
 ## Recommended workflow
+
+### 0. Create dependent structures first (if needed)
+
+If the migration targets fields that will live inside a **new** structure that
+does not yet exist in the portal (for example, a new repeatable fieldset
+structure), create it from source before running `migration-init`.
+
+Do **not** use the Liferay UI for this. Edit the structure JSON directly and
+import it:
+
+```bash
+# 1. Write or edit the structure JSON under paths.structures/<site>/<KEY>.json
+#    Use ../developing-liferay/references/structure-field-catalog.md for the correct field shapes.
+
+# 2. Validate before importing:
+ldev resource import-structure --site /<site> --key <KEY> --check-only
+
+# 3. Import to the portal:
+ldev resource import-structure --site /<site> --key <KEY>
+
+# 4. Confirm the structure exists:
+ldev resource structure --site /<site> --key <KEY> --json
+```
+
+Reference: `../developing-liferay/references/structure-field-catalog.md`
 
 ### 1. Inspect current portal state
 
@@ -41,16 +76,41 @@ ldev resource migration-init --site /<site> --key <STRUCTURE_KEY>
 Add `--templates` to include associated templates in the generated descriptor.
 The output defaults to `paths.migrations/<site>/<key>.migration.json`.
 
-Edit the descriptor to:
+Edit the descriptor to define:
 
-- Define explicit field mappings
-- Limit the scope to one site and one structure
-- Add an optional cleanup phase
+- Explicit field mappings (`introduce.mappings`)
+- Scope (see below)
+- Dependent structures (`dependentStructures`) if the migration targets fields
+  in structures that were just created
+- Whether templates are included (`templates: true`)
+- An optional cleanup phase
+
+**Descriptor fields reference:**
+
+| Field | Purpose |
+|-------|---------|
+| `"templates": true` | Include associated templates in the pipeline run |
+| `"dependentStructures": ["KEY"]` | Structures the pipeline must verify exist before running |
+| `"introduce.rootFolderIds": [id]` | Scope to a folder tree (recursive) |
+| `"introduce.folderIds": [id]` | Scope to exact folders only (non-recursive) |
+| `"introduce.articleIds": [id]` | Scope to specific content items |
+| _(no scope field)_ | Scan all content in the site (use with caution on large sites) |
+
+**Mapping syntax:**
+
+```json
+{ "source": "oldField", "target": "newField" }
+{ "source": "oldField", "target": "FieldsetName[].TargetField", "cleanupSource": true }
+```
+
+Use `FieldsetName[].TargetField` when the destination lives inside a repeatable
+fieldset in the new structure. Add `"cleanupSource": true` to remove the source
+field from the original structure after migration.
 
 When the migration introduces new fields or changes field types, use the field
-type catalog to get the correct JSON shape for each field:
+type catalog to verify JSON shapes:
 
-Reference: `references/structure-field-catalog.md`
+Reference: `../developing-liferay/references/structure-field-catalog.md`
 
 ### 3. Validate before mutating
 
@@ -98,9 +158,17 @@ ldev portal reindex tasks --json
 
 ## Guardrails
 
+- **Never run migrations against the main environment.** Always use a worktree
+  (`ldev worktree setup --name <name>` + `ldev worktree start <name>`) so the
+  portal state can be restored or discarded if the migration fails or produces
+  unexpected results.
 - Never treat a live content migration as a plain import.
 - Always keep a descriptor file under version control.
 - Always use `migration-init` to scaffold the descriptor; do not write it from scratch.
 - Always run `--check-only` before the real pipeline.
 - Do not document or automate migration-pipeline as a mandatory two-run sequence.
 - If cleanup is intended, make that choice explicit in the approved real execution plan.
+- If the migration targets fields in a new dependent structure, create and import
+  that structure from JSON first (step 0) — do not use the Liferay UI.
+- Use `../developing-liferay/references/structure-field-catalog.md` when authoring or editing structure
+  JSON directly; do not guess field shapes.

--- a/tests/unit/command-context.test.ts
+++ b/tests/unit/command-context.test.ts
@@ -4,8 +4,12 @@ import {createCommandContext} from '../../src/cli/command-context.js';
 import {createTempRepo} from '../../src/testing/temp-repo.js';
 
 describe('command-context', () => {
+  const originalArgv = [...process.argv];
+
   afterEach(() => {
     delete process.env.REPO_ROOT;
+    delete process.env.TEST_LIFERAY_SECRET;
+    process.argv = [...originalArgv];
   });
 
   test('uses REPO_ROOT as effective cwd when present', () => {
@@ -18,5 +22,95 @@ describe('command-context', () => {
     expect(context.cwd).toBe(repoRoot);
     expect(context.config.cwd).toBe(repoRoot);
     expect(context.config.repoRoot).toBe(repoRoot);
+  });
+
+  test('applies global CLI liferay overrides from argv', () => {
+    const repoRoot = createTempRepo();
+    process.env.REPO_ROOT = repoRoot;
+
+    process.argv = [
+      'node',
+      'ldev',
+      '--liferay-url',
+      'https://example.liferay.local',
+      '--liferay-client-id=client-from-cli',
+      '--liferay-client-secret',
+      'secret-from-cli',
+      '--liferay-scope-aliases',
+      'scope.a,scope.b',
+      '--liferay-timeout-seconds',
+      '99',
+    ];
+
+    const context = createCommandContext();
+
+    expect(context.config.liferay.url).toBe('https://example.liferay.local');
+    expect(context.config.liferay.oauth2ClientId).toBe('client-from-cli');
+    expect(context.config.liferay.oauth2ClientSecret).toBe('secret-from-cli');
+    expect(context.config.liferay.scopeAliases).toBe('scope.a,scope.b');
+    expect(context.config.liferay.timeoutSeconds).toBe(99);
+  });
+
+  test('resolves client secret from --liferay-client-secret-env', () => {
+    const repoRoot = createTempRepo();
+    process.env.REPO_ROOT = repoRoot;
+    process.env.TEST_LIFERAY_SECRET = 'secret-from-env-ref';
+
+    process.argv = ['node', 'ldev', '--liferay-client-secret-env', 'TEST_LIFERAY_SECRET'];
+
+    const context = createCommandContext();
+
+    expect(context.config.liferay.oauth2ClientSecret).toBe('secret-from-env-ref');
+  });
+
+  test('prefers --liferay-client-secret over --liferay-client-secret-env when both are present', () => {
+    const repoRoot = createTempRepo();
+    process.env.REPO_ROOT = repoRoot;
+    process.env.TEST_LIFERAY_SECRET = 'secret-from-env-ref';
+
+    process.argv = [
+      'node',
+      'ldev',
+      '--liferay-client-secret',
+      'secret-from-cli',
+      '--liferay-client-secret-env',
+      'TEST_LIFERAY_SECRET',
+    ];
+
+    const context = createCommandContext();
+
+    expect(context.config.liferay.oauth2ClientSecret).toBe('secret-from-cli');
+  });
+
+  test('throws when --liferay-timeout-seconds is negative', () => {
+    const repoRoot = createTempRepo();
+    process.env.REPO_ROOT = repoRoot;
+    process.argv = ['node', 'ldev', '--liferay-timeout-seconds', '-1'];
+
+    expect(() => createCommandContext()).toThrow('--liferay-timeout-seconds must be a positive integer.');
+  });
+
+  test('throws when --liferay-timeout-seconds is decimal', () => {
+    const repoRoot = createTempRepo();
+    process.env.REPO_ROOT = repoRoot;
+    process.argv = ['node', 'ldev', '--liferay-timeout-seconds', '5.5'];
+
+    expect(() => createCommandContext()).toThrow('--liferay-timeout-seconds must be a positive integer.');
+  });
+
+  test('throws when --liferay-url flag has no value', () => {
+    const repoRoot = createTempRepo();
+    process.env.REPO_ROOT = repoRoot;
+    process.argv = ['node', 'ldev', '--liferay-url', '--json'];
+
+    expect(() => createCommandContext()).toThrow('--liferay-url requires a value.');
+  });
+
+  test('throws when --liferay-url is not a valid http(s) URL', () => {
+    const repoRoot = createTempRepo();
+    process.env.REPO_ROOT = repoRoot;
+    process.argv = ['node', 'ldev', '--liferay-url', 'not-a-valid-url'];
+
+    expect(() => createCommandContext()).toThrow('--liferay-url must be a valid http(s) URL.');
   });
 });

--- a/tests/unit/core-output-printer-progress.test.ts
+++ b/tests/unit/core-output-printer-progress.test.ts
@@ -90,4 +90,23 @@ describe('withProgress', () => {
     expect(result).toBe('done');
     expect(mockStderr.write.mock.calls.length).toBeGreaterThan(0);
   });
+
+  test('clears the active progress line before logging nested info in TTY mode', async () => {
+    const printer = createPrinter('text');
+    mockStderr.isTTY = true;
+
+    const result = await withProgress(printer, 'Animating', async () => {
+      printer.info('inner message');
+      return 'done';
+    });
+
+    expect(result).toBe('done');
+
+    const writes = mockStderr.write.mock.calls.map(([value]) => String(value));
+    const innerIndex = writes.findIndex((value) => value.includes('inner message'));
+
+    expect(innerIndex).toBeGreaterThan(-1);
+    expect(writes.slice(Math.max(0, innerIndex - 3), innerIndex)).toContain('\r');
+    expect(writes.slice(Math.max(0, innerIndex - 3), innerIndex)).toContain(' '.repeat(mockStderr.columns));
+  });
 });

--- a/tests/unit/create-cli.test.ts
+++ b/tests/unit/create-cli.test.ts
@@ -1,0 +1,17 @@
+import {describe, expect, test} from 'vitest';
+
+import {createCli} from '../../src/cli/create-cli.js';
+
+describe('createCli', () => {
+  test('registers global liferay connection options', () => {
+    const cli = createCli();
+    const optionNames = cli.options.map((option) => option.long);
+
+    expect(optionNames).toContain('--liferay-url');
+    expect(optionNames).toContain('--liferay-client-id');
+    expect(optionNames).toContain('--liferay-client-secret');
+    expect(optionNames).toContain('--liferay-client-secret-env');
+    expect(optionNames).toContain('--liferay-scope-aliases');
+    expect(optionNames).toContain('--liferay-timeout-seconds');
+  });
+});

--- a/tests/unit/liferay-content-prune.test.ts
+++ b/tests/unit/liferay-content-prune.test.ts
@@ -908,7 +908,7 @@ describe('liferay-content-prune: apply mode', () => {
     expect(maxInflightDeletes).toBeGreaterThan(1);
   });
 
-  test('apply mode does not retry article deletion manually on 401', async () => {
+  test('apply mode retries article deletion once on 401 via gateway token refresh', async () => {
     let tokenFetches = 0;
     const deleteAuthHeaders: string[] = [];
 
@@ -991,8 +991,9 @@ describe('liferay-content-prune: apply mode', () => {
 
     expect(result.mode).toBe('apply');
     expect(tokenFetches).toBeGreaterThan(0);
-    expect(deleteAuthHeaders).toHaveLength(1);
+    expect(deleteAuthHeaders).toHaveLength(2);
     expect(deleteAuthHeaders[0]).toMatch(/^Bearer token-\d+$/);
+    expect(deleteAuthHeaders[1]).toMatch(/^Bearer token-\d+$/);
     expect(result.failedArticles).toEqual([
       {
         id: 1001,

--- a/tests/unit/liferay-gateway.test.ts
+++ b/tests/unit/liferay-gateway.test.ts
@@ -143,6 +143,25 @@ describe('LiferayGateway', () => {
 
       expect(result).toBeNull();
     });
+
+    test('refreshes token and retries once when first request returns 401', async () => {
+      const apiClient = createMockApiClient();
+      const tokenClient = createMockTokenClient();
+      vi.mocked(tokenClient.fetchClientCredentialsToken)
+        .mockResolvedValueOnce({...mockToken, accessToken: 'stale-token'})
+        .mockResolvedValueOnce({...mockToken, accessToken: 'fresh-token'});
+
+      vi.mocked(apiClient.get)
+        .mockResolvedValueOnce(mockHttpResponse(false, 401, null))
+        .mockResolvedValueOnce(mockHttpResponse(true, 200, {id: 1}));
+
+      const gateway = new LiferayGateway(mockConfig, apiClient, tokenClient);
+      const result = await gateway.getJson<{id: number}>('/api/test', 'fetch-test');
+
+      expect(result).toEqual({id: 1});
+      expect(apiClient.get).toHaveBeenCalledTimes(2);
+      expect(tokenClient.fetchClientCredentialsToken).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('postJson', () => {

--- a/tests/unit/liferay-resource-migration.test.ts
+++ b/tests/unit/liferay-resource-migration.test.ts
@@ -251,6 +251,9 @@ describe('liferay resource migration-run', () => {
         if (url.includes('/o/headless-delivery/v1.0/content-structures/301/structured-contents')) {
           return new Response('{"items":[],"lastPage":1}', {status: 200});
         }
+        if (url.includes('/api/jsonws/journal.journalarticle/get-latest-article')) {
+          return new Response('', {status: 404});
+        }
         throw new Error(`Unexpected URL ${url}`);
       },
     });

--- a/tests/unit/liferay-resource-migration.test.ts
+++ b/tests/unit/liferay-resource-migration.test.ts
@@ -1,6 +1,6 @@
 import fs from 'fs-extra';
 import path from 'node:path';
-import {describe, expect, test} from 'vitest';
+import {describe, expect, test, vi} from 'vitest';
 
 import {createLiferayApiClient} from '../../src/core/http/client.js';
 import {
@@ -116,6 +116,88 @@ describe('liferay resource migration-run', () => {
     expect(result.migrationApplied).toBe(true);
     expect(formatLiferayResourceMigrationRun(result)).toContain('updated\tBASIC\t301');
     expect(formatLiferayResourceMigrationRun(result)).toContain('stage=introduce');
+  });
+
+  test('marks migrationApplied=false when migration is dry-run', async () => {
+    const {config, migrationFile} = await createRepoFixture();
+    const apiClient = createLiferayApiClient({
+      fetchImpl: async (input) => {
+        const url = String(input);
+
+        if (url.includes('/by-friendly-url-path/global')) {
+          return new Response('{"id":20121,"friendlyUrlPath":"/global","name":"Global"}', {status: 200});
+        }
+        if (url.includes('/by-data-definition-key/BASIC')) {
+          return new Response(
+            JSON.stringify({
+              id: 301,
+              dataDefinitionKey: 'BASIC',
+              dataDefinitionFields: [{name: 'oldField', customProperties: {fieldReference: 'oldField'}}],
+            }),
+            {status: 200},
+          );
+        }
+        if (url.endsWith('/o/data-engine/v2.0/data-definitions/301')) {
+          return new Response('{"id":301}', {status: 200});
+        }
+        if (url.includes('/o/headless-delivery/v1.0/content-structures/301/structured-contents')) {
+          return new Response('{"items":[],"lastPage":1}', {status: 200});
+        }
+        throw new Error(`Unexpected URL ${url}`);
+      },
+    });
+
+    const result = await runLiferayResourceMigrationRun(
+      config,
+      {migrationFile, checkOnly: true, migrationDryRun: true},
+      {apiClient, tokenClient: TOKEN_CLIENT},
+    );
+
+    expect(result.status).toBe('checked');
+    expect(result.migrationApplied).toBe(false);
+  });
+
+  test('uses a running progress message instead of a preparing-only label', async () => {
+    const {config, migrationFile} = await createRepoFixture();
+    const messages: string[] = [];
+    const printer = {
+      format: 'text' as const,
+      write: vi.fn(),
+      error: vi.fn((message: string) => messages.push(message)),
+      info: vi.fn((message: string) => messages.push(message)),
+    };
+
+    const apiClient = createLiferayApiClient({
+      fetchImpl: async (input) => {
+        const url = String(input);
+
+        if (url.includes('/by-friendly-url-path/global')) {
+          return new Response('{"id":20121,"friendlyUrlPath":"/global","name":"Global"}', {status: 200});
+        }
+        if (url.includes('/by-data-definition-key/BASIC')) {
+          return new Response(
+            JSON.stringify({
+              id: 301,
+              dataDefinitionKey: 'BASIC',
+              dataDefinitionFields: [{name: 'oldField', customProperties: {fieldReference: 'oldField'}}],
+            }),
+            {status: 200},
+          );
+        }
+        if (url.endsWith('/o/data-engine/v2.0/data-definitions/301')) {
+          return new Response('{"id":301}', {status: 200});
+        }
+        if (url.includes('/o/headless-delivery/v1.0/content-structures/301/structured-contents')) {
+          return new Response('{"items":[],"lastPage":1}', {status: 200});
+        }
+        throw new Error(`Unexpected URL ${url}`);
+      },
+    });
+
+    await runLiferayResourceMigrationRun(config, {migrationFile, printer}, {apiClient, tokenClient: TOKEN_CLIENT});
+
+    expect(messages.some((message) => message.includes('Running introduce migration for structure: BASIC'))).toBe(true);
+    expect(messages.some((message) => message.includes('Preparing introduce migration'))).toBe(false);
   });
 
   test('pipeline syncs dependent structures and derives cleanup from descriptor', async () => {
@@ -326,6 +408,138 @@ describe('liferay resource migration-run', () => {
 
     expect(result.cleanupRun).toBe(true);
     expect(calls.filter((call) => call.includes('/structured-content-folders/123/structured-contents')).length).toBe(3);
+  });
+
+  test('cleanup removes deleted fields from the derived defaultDataLayout payload', async () => {
+    const {config, migrationFile} = await createRepoFixture();
+    const structureFile = path.join(
+      config.repoRoot,
+      'liferay',
+      'resources',
+      'journal',
+      'structures',
+      'global',
+      'BASIC.json',
+    );
+
+    await fs.writeJson(structureFile, {
+      dataDefinitionKey: 'BASIC',
+      dataDefinitionFields: [
+        {name: 'oldField', customProperties: {fieldReference: 'oldField'}},
+        {name: 'newField', customProperties: {fieldReference: 'newField'}},
+      ],
+      defaultDataLayout: {
+        dataLayoutPages: [
+          {
+            dataLayoutRows: [
+              {dataLayoutColumns: [{columnSize: 12, fieldNames: ['oldField']}]},
+              {dataLayoutColumns: [{columnSize: 12, fieldNames: ['newField']}]},
+            ],
+          },
+        ],
+      },
+    });
+
+    await fs.writeJson(migrationFile, {
+      site: '/global',
+      structureKey: 'BASIC',
+      templates: false,
+      introduce: {
+        mappings: [{source: 'oldField', target: 'newField', cleanupSource: true}],
+        articleIds: ['ARTICLE-001'],
+      },
+    });
+
+    let persistedFields = [
+      {name: 'oldField', contentFieldValue: {data: 'legacy'}},
+      {name: 'newField', contentFieldValue: {data: ''}},
+    ];
+    const structureUpdateBodies: Array<Record<string, unknown>> = [];
+
+    const apiClient = createLiferayApiClient({
+      fetchImpl: async (input, init) => {
+        const url = String(input);
+        const method = init?.method ?? 'GET';
+
+        if (url.includes('/by-friendly-url-path/global')) {
+          return new Response('{"id":20121,"friendlyUrlPath":"/global","name":"Global"}', {status: 200});
+        }
+        if (url.includes('/by-data-definition-key/BASIC')) {
+          return new Response(
+            JSON.stringify({
+              id: 301,
+              dataDefinitionKey: 'BASIC',
+              dataDefinitionFields: [{name: 'oldField', customProperties: {fieldReference: 'oldField'}}],
+            }),
+            {status: 200},
+          );
+        }
+        if (url.endsWith('/o/data-engine/v2.0/data-definitions/301') && method === 'GET') {
+          return new Response(
+            JSON.stringify({
+              id: 301,
+              dataDefinitionFields: [
+                {name: 'oldField', customProperties: {fieldReference: 'oldField'}},
+                {name: 'newField', customProperties: {fieldReference: 'newField'}},
+              ],
+            }),
+            {status: 200},
+          );
+        }
+        if (url.endsWith('/o/data-engine/v2.0/data-definitions/301') && method === 'PUT') {
+          structureUpdateBodies.push(JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>);
+          return new Response('{"id":301}', {status: 200});
+        }
+        if (
+          url.includes(
+            '/api/jsonws/journal.journalarticle/get-latest-article?groupId=20121&articleId=ARTICLE-001&status=0',
+          )
+        ) {
+          return new Response('{"articleId":"ARTICLE-001","resourcePrimKey":"700"}', {status: 200});
+        }
+        if (url.includes('/o/headless-delivery/v1.0/structured-contents/700?fields=')) {
+          return new Response(
+            JSON.stringify({
+              id: 700,
+              key: 'ARTICLE-001',
+              contentStructureId: '301',
+              structuredContentFolderId: 123,
+              title: 'Article',
+              contentFields: persistedFields,
+            }),
+            {status: 200},
+          );
+        }
+        if (url.endsWith('/o/headless-delivery/v1.0/structured-contents/700')) {
+          const body = JSON.parse(String(init?.body ?? '{}')) as {contentFields?: typeof persistedFields};
+          persistedFields = body.contentFields ?? persistedFields;
+          return new Response('{"id":700}', {status: 200});
+        }
+
+        throw new Error(`Unexpected URL ${url}`);
+      },
+    });
+
+    const result = await runLiferayResourceMigrationPipeline(
+      config,
+      {migrationFile, runCleanup: true, skipValidation: true},
+      {apiClient, tokenClient: TOKEN_CLIENT},
+    );
+
+    expect(result.cleanupRun).toBe(true);
+    expect(structureUpdateBodies).toHaveLength(2);
+
+    const cleanupUpdate = structureUpdateBodies[1]!;
+    expect(cleanupUpdate.dataDefinitionFields).toEqual([
+      {name: 'newField', customProperties: {fieldReference: 'newField'}},
+    ]);
+    expect(cleanupUpdate.defaultDataLayout).toEqual({
+      dataLayoutPages: [
+        {
+          dataLayoutRows: [{dataLayoutColumns: [{columnSize: 12, fieldNames: ['newField']}]}],
+        },
+      ],
+    });
   });
 
   test('cleanup fails closed when introduce returns no migrated articleIds and no scope is declared', async () => {

--- a/tests/unit/liferay-resource-sync-structure-migration.test.ts
+++ b/tests/unit/liferay-resource-sync-structure-migration.test.ts
@@ -333,6 +333,67 @@ describe('structure migration', () => {
       );
     });
 
+    test('resolves scoped articleIds directly without paginating the whole structure', async () => {
+      tempDir = createTempDir('migration-article-direct-');
+      const planPath = path.join(tempDir, 'plan.json');
+
+      await fs.writeJson(planPath, {
+        plan: {
+          mappings: [{source: 'oldField', target: 'newField', cleanupSource: false}],
+          articleIds: ['ARTICLE-001'],
+        },
+      });
+
+      const mockGateway = {
+        getJson: vi.fn(async (requestPath: string) => {
+          if (requestPath.includes('/api/jsonws/journal.journalarticle/get-latest-article')) {
+            return {
+              articleId: 'ARTICLE-001',
+              resourcePrimKey: '101',
+            };
+          }
+
+          if (requestPath.includes('/o/data-engine/v2.0/data-definitions/struct-123')) {
+            return {dataDefinitionFields: []};
+          }
+
+          if (requestPath.includes('/structured-contents/101')) {
+            return {
+              id: '101',
+              key: 'ARTICLE-001',
+              contentStructureId: 'struct-123',
+              structuredContentFolderId: 55,
+              contentFields: [{name: 'oldField', contentFieldValue: {data: 'legacy-value'}}],
+            };
+          }
+
+          if (requestPath.includes('/content-structures/')) {
+            throw new Error('full structure scan should not be used when articleIds are explicit');
+          }
+
+          return {};
+        }),
+        putJson: vi.fn(),
+      } as any;
+
+      const stats = await runStructureMigration(mockConfig, 'TEST_STRUCTURE', 20121, planPath, {
+        gateway: mockGateway,
+        dryRun: true,
+        cleanupSource: false,
+        fetchStructureByKeyFn: async () => ({id: 'struct-123', dataDefinitionKey: 'TEST_STRUCTURE'}),
+      });
+
+      expect(stats.scanned).toBe(1);
+      expect(mockGateway.getJson).toHaveBeenCalledWith(
+        expect.stringContaining('articleId=ARTICLE-001'),
+        'structure-migrate get-latest-article',
+      );
+      expect(mockGateway.getJson).not.toHaveBeenCalledWith(
+        expect.stringContaining('/content-structures/'),
+        expect.any(String),
+      );
+    });
+
     test('throws summarized failure when putJson fails for one content item', async () => {
       tempDir = createTempDir('migration-putjson-failure-');
       const planPath = path.join(tempDir, 'plan.json');
@@ -376,6 +437,218 @@ describe('structure migration', () => {
           fetchStructureByKeyFn: async () => ({id: 'struct-123', dataDefinitionKey: 'TEST_STRUCTURE'}),
         }),
       ).rejects.toThrow('Structure migration failed for 1 content item');
+    });
+
+    test("does not cleanup source when cleanupSource is string 'false'", async () => {
+      tempDir = createTempDir('migration-cleanup-string-false-');
+      const planPath = path.join(tempDir, 'plan.json');
+
+      const plan = {
+        plan: {
+          mappings: [{source: 'oldField', target: 'newField', cleanupSource: 'false'}],
+        },
+      };
+
+      await fs.writeJson(planPath, plan);
+
+      let persistedFields: Array<Record<string, unknown>> = [
+        {name: 'oldField', contentFieldValue: {data: 'legacy-value'}},
+      ];
+
+      const mockGateway = {
+        getJson: vi.fn(async (requestPath: string) => {
+          if (requestPath.includes('/content-structures/')) {
+            return {
+              items: [{id: 'content-1', key: 'article-1', contentStructureId: 'struct-123'}],
+              lastPage: 1,
+            };
+          }
+          if (requestPath.includes('/structured-contents/content-1')) {
+            return {
+              id: 'content-1',
+              key: 'article-1',
+              contentStructureId: 'struct-123',
+              contentFields: persistedFields,
+            };
+          }
+          return {};
+        }),
+        putJson: vi.fn(async (_path: string, payload: {contentFields?: Array<Record<string, unknown>>}) => {
+          persistedFields = payload.contentFields ?? [];
+          return {id: 'content-1'};
+        }),
+      } as any;
+
+      const stats = await runStructureMigration(mockConfig, 'TEST_STRUCTURE', 20121, planPath, {
+        gateway: mockGateway,
+        dryRun: false,
+        cleanupSource: false,
+        fetchStructureByKeyFn: async () => ({id: 'struct-123', dataDefinitionKey: 'TEST_STRUCTURE'}),
+      });
+
+      expect(stats.migrated).toBe(1);
+      expect(persistedFields).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({name: 'oldField', contentFieldValue: {data: 'legacy-value'}}),
+          expect.objectContaining({name: 'newField', contentFieldValue: {data: 'legacy-value'}}),
+        ]),
+      );
+    });
+
+    test('accepts persisted contentFields with equivalent data but different object key order', async () => {
+      tempDir = createTempDir('migration-persisted-order-');
+      const planPath = path.join(tempDir, 'plan.json');
+
+      await fs.writeJson(planPath, {
+        plan: {
+          mappings: [{source: 'oldField', target: 'newField', cleanupSource: false}],
+        },
+      });
+
+      let fetchCount = 0;
+      const mockGateway = {
+        getJson: vi.fn(async (requestPath: string) => {
+          if (requestPath.includes('/content-structures/')) {
+            return {
+              items: [{id: 'content-1', key: 'article-1', contentStructureId: 'struct-123'}],
+              lastPage: 1,
+            };
+          }
+
+          if (requestPath.includes('/structured-contents/content-1')) {
+            fetchCount += 1;
+
+            if (fetchCount === 1) {
+              return {
+                id: 'content-1',
+                key: 'article-1',
+                contentStructureId: 'struct-123',
+                contentFields: [{name: 'oldField', contentFieldValue: {data: 'legacy-value'}}],
+              };
+            }
+
+            return {
+              id: 'content-1',
+              key: 'article-1',
+              contentStructureId: 'struct-123',
+              contentFields: [
+                {contentFieldValue: {data: 'legacy-value'}, name: 'oldField'},
+                {contentFieldValue: {data: 'legacy-value'}, name: 'newField'},
+              ],
+            };
+          }
+
+          return {};
+        }),
+        putJson: vi.fn(async () => ({id: 'content-1'})),
+      } as any;
+
+      const stats = await runStructureMigration(mockConfig, 'TEST_STRUCTURE', 20121, planPath, {
+        gateway: mockGateway,
+        dryRun: false,
+        cleanupSource: false,
+        fetchStructureByKeyFn: async () => ({id: 'struct-123', dataDefinitionKey: 'TEST_STRUCTURE'}),
+      });
+
+      expect(stats.migrated).toBe(1);
+      expect(mockGateway.putJson).toHaveBeenCalledTimes(1);
+    });
+
+    test('uses runtime internal names when persisting repeatable fieldset targets', async () => {
+      tempDir = createTempDir('migration-fieldset-internal-names-');
+      const planPath = path.join(tempDir, 'plan.json');
+
+      await fs.writeJson(planPath, {
+        plan: {
+          mappings: [
+            {source: 'cuerpoDelTexto2', target: 'FieldsetParagrafoDestacado[].UBCuerpoTexto', cleanupSource: false},
+            {source: 'textoDestacado', target: 'FieldsetParagrafoDestacado[].UBDestacado', cleanupSource: false},
+          ],
+        },
+      });
+
+      let persistedFields: Array<Record<string, unknown>> = [
+        {name: 'cuerpoDelTexto2', contentFieldValue: {data: 'body text'}},
+        {name: 'textoDestacado', contentFieldValue: {data: 'highlight'}},
+        {
+          name: 'FieldsetParagrafoDestacado',
+          contentFieldValue: {},
+          nestedContentFields: [
+            {name: 'UBCuerpoTexto', contentFieldValue: {data: ''}},
+            {name: 'UBDestacado', contentFieldValue: {data: ''}},
+          ],
+        },
+      ];
+
+      const mockGateway = {
+        getJson: vi.fn(async (requestPath: string) => {
+          if (requestPath.includes('/o/data-engine/v2.0/data-definitions/struct-123')) {
+            return {
+              dataDefinitionFields: [
+                {
+                  name: 'Fieldset84041664',
+                  customProperties: {fieldReference: 'FieldsetParagrafoDestacado'},
+                  nestedDataDefinitionFields: [
+                    {name: 'Text75852383', customProperties: {fieldReference: 'UBCuerpoTexto'}},
+                    {name: 'Text98612061', customProperties: {fieldReference: 'UBDestacado'}},
+                  ],
+                },
+              ],
+            };
+          }
+
+          if (requestPath.includes('/content-structures/')) {
+            return {
+              items: [{id: 'content-1', key: 'article-1', contentStructureId: 'struct-123'}],
+              lastPage: 1,
+            };
+          }
+
+          if (requestPath.includes('/structured-contents/content-1')) {
+            return {
+              id: 'content-1',
+              key: 'article-1',
+              contentStructureId: 'struct-123',
+              contentFields: persistedFields,
+            };
+          }
+
+          return {};
+        }),
+        putJson: vi.fn(async (_path: string, payload: {contentFields?: Array<Record<string, unknown>>}) => {
+          const outgoingFieldset = payload.contentFields?.find((field) => field.name === 'Fieldset84041664');
+          expect(outgoingFieldset).toBeDefined();
+          expect(outgoingFieldset?.nestedContentFields).toEqual([
+            {name: 'Text75852383', contentFieldValue: {data: 'body text'}},
+            {name: 'Text98612061', contentFieldValue: {data: 'highlight'}},
+          ]);
+
+          persistedFields = [
+            {name: 'cuerpoDelTexto2', contentFieldValue: {data: 'body text'}},
+            {name: 'textoDestacado', contentFieldValue: {data: 'highlight'}},
+            {
+              name: 'FieldsetParagrafoDestacado',
+              contentFieldValue: {},
+              nestedContentFields: [
+                {name: 'UBCuerpoTexto', contentFieldValue: {data: 'body text'}},
+                {name: 'UBDestacado', contentFieldValue: {data: 'highlight'}},
+              ],
+            },
+          ];
+
+          return {id: 'content-1'};
+        }),
+      } as any;
+
+      const stats = await runStructureMigration(mockConfig, 'TEST_STRUCTURE', 20121, planPath, {
+        gateway: mockGateway,
+        dryRun: false,
+        cleanupSource: false,
+        fetchStructureByKeyFn: async () => ({id: 'struct-123', dataDefinitionKey: 'TEST_STRUCTURE'}),
+      });
+
+      expect(stats.migrated).toBe(1);
+      expect(mockGateway.putJson).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/tests/unit/liferay-resource-sync-structure-migration.test.ts
+++ b/tests/unit/liferay-resource-sync-structure-migration.test.ts
@@ -346,13 +346,6 @@ describe('structure migration', () => {
 
       const mockGateway = {
         getJson: vi.fn(async (requestPath: string) => {
-          if (requestPath.includes('/api/jsonws/journal.journalarticle/get-latest-article')) {
-            return {
-              articleId: 'ARTICLE-001',
-              resourcePrimKey: '101',
-            };
-          }
-
           if (requestPath.includes('/o/data-engine/v2.0/data-definitions/struct-123')) {
             return {dataDefinitionFields: []};
           }
@@ -373,6 +366,17 @@ describe('structure migration', () => {
 
           return {};
         }),
+        getRaw: vi.fn(async (requestPath: string) => {
+          if (requestPath.includes('/api/jsonws/journal.journalarticle/get-latest-article')) {
+            return {
+              ok: true,
+              status: 200,
+              data: {articleId: 'ARTICLE-001', resourcePrimKey: '101'},
+            };
+          }
+
+          return {ok: false, status: 404, data: null};
+        }),
         putJson: vi.fn(),
       } as any;
 
@@ -384,10 +388,7 @@ describe('structure migration', () => {
       });
 
       expect(stats.scanned).toBe(1);
-      expect(mockGateway.getJson).toHaveBeenCalledWith(
-        expect.stringContaining('articleId=ARTICLE-001'),
-        'structure-migrate get-latest-article',
-      );
+      expect(mockGateway.getRaw).toHaveBeenCalledWith(expect.stringContaining('articleId=ARTICLE-001'));
       expect(mockGateway.getJson).not.toHaveBeenCalledWith(
         expect.stringContaining('/content-structures/'),
         expect.any(String),

--- a/tests/unit/liferay-resource-sync-structure.test.ts
+++ b/tests/unit/liferay-resource-sync-structure.test.ts
@@ -225,6 +225,13 @@ describe('liferay resource structure-sync', () => {
       failed: 0,
       dryRun: false,
       articleKeys: ['ARTICLE-001'],
+      reasonBreakdown: {
+        copiedToNewField: 1,
+        alreadyHadTargetValue: 0,
+        sourceEmpty: 0,
+        noEffectiveChange: 0,
+        sourceCleaned: 1,
+      },
     });
     expect(formatLiferayResourceSyncStructure(result)).toContain('migration scanned=1 migrated=1');
     expect(calls).toEqual(
@@ -531,6 +538,13 @@ describe('liferay resource structure-sync', () => {
       failed: 0,
       dryRun: false,
       articleKeys: ['ARTICLE-001'],
+      reasonBreakdown: {
+        copiedToNewField: 1,
+        alreadyHadTargetValue: 0,
+        sourceEmpty: 0,
+        noEffectiveChange: 0,
+        sourceCleaned: 0,
+      },
     });
     expect(localizedFields.get('ca-ES')).toEqual([
       {name: 'oldField', contentFieldValue: {data: 'valor cat'}},


### PR DESCRIPTION
## Summary
This PR delivers a broader migration hardening pass for resource/structure workflows, combining feature improvements and fixes in migration progress visibility, command wiring, and structure sync behavior.

## What changed
- Improved migration progress UX and messaging in command output.
- Hardened structure-sync and structure-migration flows.
- Refined resource command wiring for migration-related paths.
- Updated gateway and migration internals to support clearer progress and safer execution handling.
- Updated docs and AI migration skill guidance to reflect the latest migration workflow and guardrails.
- Extended unit tests around printer progress output, gateway behavior, content prune interactions, and migration/structure migration execution paths.

## Files touched (high level)
- Commands and CLI wiring:
  - `src/commands/liferay/resource.command.ts`
  - `src/commands/resource/resource-command-builder.ts`
  - `src/commands/resource/resource.command.ts`
- Core output:
  - `src/core/output/printer.ts`
- Liferay resource/migration internals:
  - `src/features/liferay/liferay-gateway.ts`
  - `src/features/liferay/resource/liferay-resource-migration.ts`
  - `src/features/liferay/resource/liferay-resource-sync-structure-migration.ts`
  - `src/features/liferay/resource/liferay-resource-sync-structure.ts`
  - `src/features/liferay/resource/sync-strategies/structure-sync-strategy.ts`
- Docs and skill:
  - `docs/commands/resources.md`
  - `templates/ai/skills/migrating-journal-structures/SKILL.md`
- Tests:
  - `tests/unit/core-output-printer-progress.test.ts`
  - `tests/unit/liferay-content-prune.test.ts`
  - `tests/unit/liferay-gateway.test.ts`
  - `tests/unit/liferay-resource-migration.test.ts`
  - `tests/unit/liferay-resource-sync-structure-migration.test.ts`

## Notes
- This branch includes many additional fixes/features beyond a single isolated change and is intended as a consolidated migration-progress hardening update.
