### PR TITLE
refactor(cli): scope Liferay overrides to portal and resource namespaces

### DIFF
--- a/docs/commands/discovery.md
+++ b/docs/commands/discovery.md
@@ -5,10 +5,10 @@ description: Minimal reference for understanding portal and runtime state.
 
 # Discovery Commands
 
-Global connection overrides are available for remote execution and **must be passed before subcommands**:
+Namespace-scoped connection overrides are available for remote execution on `ldev portal` and `ldev resource`:
 
 ```bash
-ldev --liferay-url https://portal.example.com portal inventory sites --json
+ldev portal --liferay-url https://portal.example.com inventory sites --json
 ```
 
 ## `ldev context`

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -45,9 +45,12 @@ Namespaces:
 - `ldev project` — project scaffold
 - `ldev ai` — reusable AI assets and skills
 
-Global Liferay connection overrides (must appear **before** the subcommand):
+Liferay connection overrides are available on `ldev portal` and `ldev resource`:
 
 ```bash
+ldev portal [options] <subcommand>
+ldev resource [options] <subcommand>
+
 --liferay-url <url>
 --liferay-client-id <clientId>
 --liferay-client-secret <clientSecret>

--- a/docs/core-concepts/oauth.md
+++ b/docs/core-concepts/oauth.md
@@ -114,24 +114,24 @@ export LIFERAY_REMOTE_CLIENT_ID=ldev-remote-ops
 export LIFERAY_REMOTE_CLIENT_SECRET='***'
 ```
 
-### 4. Run `ldev` using global overrides
+### 4. Run `ldev` using namespace overrides
 
-Global connection options must be placed before subcommands:
+Attach the connection options to `ldev portal` or `ldev resource` before the concrete subcommand:
 
 ```bash
-ldev \
+ldev portal \
 	--liferay-url "$LIFERAY_REMOTE_URL" \
 	--liferay-client-id "$LIFERAY_REMOTE_CLIENT_ID" \
 	--liferay-client-secret-env LIFERAY_REMOTE_CLIENT_SECRET \
-	portal check --json
+	check --json
 ```
 
 ```bash
-ldev \
+ldev portal \
 	--liferay-url "$LIFERAY_REMOTE_URL" \
 	--liferay-client-id "$LIFERAY_REMOTE_CLIENT_ID" \
 	--liferay-client-secret-env LIFERAY_REMOTE_CLIENT_SECRET \
-	portal inventory sites --json
+	inventory sites --json
 ```
 
 ### 5. Validate before running write operations
@@ -139,8 +139,8 @@ ldev \
 Run this sequence first:
 
 ```bash
-ldev --liferay-url "$LIFERAY_REMOTE_URL" --liferay-client-id "$LIFERAY_REMOTE_CLIENT_ID" --liferay-client-secret-env LIFERAY_REMOTE_CLIENT_SECRET portal check --json
-ldev --liferay-url "$LIFERAY_REMOTE_URL" --liferay-client-id "$LIFERAY_REMOTE_CLIENT_ID" --liferay-client-secret-env LIFERAY_REMOTE_CLIENT_SECRET portal inventory sites --json
+ldev portal --liferay-url "$LIFERAY_REMOTE_URL" --liferay-client-id "$LIFERAY_REMOTE_CLIENT_ID" --liferay-client-secret-env LIFERAY_REMOTE_CLIENT_SECRET check --json
+ldev portal --liferay-url "$LIFERAY_REMOTE_URL" --liferay-client-id "$LIFERAY_REMOTE_CLIENT_ID" --liferay-client-secret-env LIFERAY_REMOTE_CLIENT_SECRET inventory sites --json
 ```
 
 If those commands fail with auth/scope errors, update the OAuth app scopes and retry.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -58,7 +58,7 @@ export REPO_ROOT=/path/to/project
 
 When you run `ldev` from automation hosts, CI jobs, or jumpboxes, you can override Liferay connection values per command instead of changing project files.
 
-Supported global options:
+These are namespace options on `ldev portal` and `ldev resource`, not root options:
 
 - `--liferay-url <url>`
 - `--liferay-client-id <clientId>`
@@ -67,22 +67,22 @@ Supported global options:
 - `--liferay-scope-aliases <aliases>`
 - `--liferay-timeout-seconds <seconds>`
 
-Important: these are root options. Place them before the command group/subcommand.
+Place them on the namespace before the concrete subcommand.
 
 ```bash
-ldev --liferay-url https://portal.example.com portal check --json
-ldev --liferay-url https://portal.example.com portal inventory sites --json
+ldev portal --liferay-url https://portal.example.com check --json
+ldev portal --liferay-url https://portal.example.com inventory sites --json
 ```
 
 For secrets, prefer environment-variable indirection:
 
 ```bash
 export LIFERAY_REMOTE_SECRET='***'
-ldev \
+ldev portal \
 	--liferay-url https://portal.example.com \
 	--liferay-client-id remote-client \
 	--liferay-client-secret-env LIFERAY_REMOTE_SECRET \
-	portal inventory page --url /home --json
+	inventory page --url /home --json
 ```
 
 If both `--liferay-client-secret` and `--liferay-client-secret-env` are provided, `--liferay-client-secret` wins.

--- a/src/cli/create-cli.ts
+++ b/src/cli/create-cli.ts
@@ -42,25 +42,8 @@ export function createCli(cwd = process.cwd(), groups: CommandGroup[] = COMMAND_
     .name('ldev')
     .version(version)
     .description('Liferay local development CLI')
-    .option('--liferay-url <url>', 'Override Liferay base URL for this command')
-    .option('--liferay-client-id <clientId>', 'Override Liferay OAuth2 client id for this command')
-    .option(
-      '--liferay-client-secret <clientSecret>',
-      'Override Liferay OAuth2 client secret for this command (less secure; prefer --liferay-client-secret-env)',
-    )
-    .option(
-      '--liferay-client-secret-env <envVar>',
-      'Read Liferay OAuth2 client secret from an environment variable (recommended)',
-    )
-    .option('--liferay-scope-aliases <aliases>', 'Override OAuth2 scope aliases (comma-separated) for this command')
-    .option('--liferay-timeout-seconds <seconds>', 'Override Liferay HTTP timeout in seconds for this command')
     .enablePositionalOptions()
     .showHelpAfterError()
-    .addHelpText(
-      'after',
-      '\nOverride precedence: --liferay-client-secret has priority over --liferay-client-secret-env.\n' +
-        'Security tip: prefer --liferay-client-secret-env in local shells and CI to avoid exposing secrets in process args/history.\n',
-    )
     .addHelpText('after', () => `\n${buildContextualRootHelp(cwd)}`);
 
   for (const group of groups) {

--- a/src/commands/liferay/liferay.command.ts
+++ b/src/commands/liferay/liferay.command.ts
@@ -30,6 +30,9 @@ export function createPortalCommand(): Command {
     .addHelpText(
       'after',
       `
+Override precedence: --liferay-client-secret has priority over --liferay-client-secret-env.
+Security tip: prefer --liferay-client-secret-env in local shells and CI to avoid exposing secrets in process args/history.
+
 Use this namespace for portal inspection and API operations against a running Liferay instance.
 For resource export, import and migration workflows, use the top-level 'resource' namespace.
 

--- a/src/commands/liferay/liferay.command.ts
+++ b/src/commands/liferay/liferay.command.ts
@@ -13,9 +13,23 @@ import {createLiferayThemeCheckCommand} from './liferay-theme-check.command.js';
 export function createPortalCommand(): Command {
   const command = new Command('portal').alias('liferay');
 
-  command.description('Portal inspection, config, inventory and API').addHelpText(
-    'after',
-    `
+  command
+    .description('Portal inspection, config, inventory and API')
+    .option('--liferay-url <url>', 'Override Liferay base URL for this command')
+    .option('--liferay-client-id <clientId>', 'Override Liferay OAuth2 client id for this command')
+    .option(
+      '--liferay-client-secret <clientSecret>',
+      'Override Liferay OAuth2 client secret for this command (less secure; prefer --liferay-client-secret-env)',
+    )
+    .option(
+      '--liferay-client-secret-env <envVar>',
+      'Read Liferay OAuth2 client secret from an environment variable (recommended)',
+    )
+    .option('--liferay-scope-aliases <aliases>', 'Override OAuth2 scope aliases (comma-separated) for this command')
+    .option('--liferay-timeout-seconds <seconds>', 'Override Liferay HTTP timeout in seconds for this command')
+    .addHelpText(
+      'after',
+      `
 Use this namespace for portal inspection and API operations against a running Liferay instance.
 For resource export, import and migration workflows, use the top-level 'resource' namespace.
 
@@ -39,7 +53,7 @@ Main groups:
   reindex      Reindex observation and temporary tuning
   content      Journal/web content management (prune for local environments)
 `,
-  );
+    );
 
   createAuthCommands(command);
   command.addCommand(createLiferayConfigCommand().helpGroup('Portal diagnostics:'));

--- a/src/commands/resource/resource-command-builder.ts
+++ b/src/commands/resource/resource-command-builder.ts
@@ -95,6 +95,18 @@ export type ResourceCommandOptions = {
 export function buildResourceCommand(options: ResourceCommandOptions): Command {
   const resource = new Command('resource')
     .description(options.description)
+    .option('--liferay-url <url>', 'Override Liferay base URL for this command')
+    .option('--liferay-client-id <clientId>', 'Override Liferay OAuth2 client id for this command')
+    .option(
+      '--liferay-client-secret <clientSecret>',
+      'Override Liferay OAuth2 client secret for this command (less secure; prefer --liferay-client-secret-env)',
+    )
+    .option(
+      '--liferay-client-secret-env <envVar>',
+      'Read Liferay OAuth2 client secret from an environment variable (recommended)',
+    )
+    .option('--liferay-scope-aliases <aliases>', 'Override OAuth2 scope aliases (comma-separated) for this command')
+    .option('--liferay-timeout-seconds <seconds>', 'Override Liferay HTTP timeout in seconds for this command')
     .option('--preflight', 'Run API surface preflight before executing resource subcommands')
     .addHelpText('after', options.helpText);
 

--- a/src/commands/resource/resource-command-builder.ts
+++ b/src/commands/resource/resource-command-builder.ts
@@ -108,7 +108,12 @@ export function buildResourceCommand(options: ResourceCommandOptions): Command {
     .option('--liferay-scope-aliases <aliases>', 'Override OAuth2 scope aliases (comma-separated) for this command')
     .option('--liferay-timeout-seconds <seconds>', 'Override Liferay HTTP timeout in seconds for this command')
     .option('--preflight', 'Run API surface preflight before executing resource subcommands')
-    .addHelpText('after', options.helpText);
+    .addHelpText(
+      'after',
+      'Override precedence: --liferay-client-secret has priority over --liferay-client-secret-env.\n' +
+        'Security tip: prefer --liferay-client-secret-env in local shells and CI to avoid exposing secrets in process args/history.\n\n' +
+        options.helpText,
+    );
 
   if (options.helpGroup) {
     resource.helpGroup(options.helpGroup);

--- a/src/features/liferay/inventory/liferay-inventory-page-fetch-fragments.ts
+++ b/src/features/liferay/inventory/liferay-inventory-page-fetch-fragments.ts
@@ -5,7 +5,7 @@ import type {HttpApiClient} from '../../../core/http/client.js';
 import {type PageFragmentEntry} from './liferay-inventory-page-assemble.js';
 import type {LiferayGateway} from '../liferay-gateway.js';
 import {buildResourceSiteChain} from '../resource/liferay-resource-shared.js';
-import {resolveFragmentsBaseDir, resolveSiteToken} from '../resource/liferay-resource-paths.js';
+import {resolveSiteToken, tryResolveFragmentsBaseDir} from '../resource/liferay-resource-paths.js';
 import {safeGatewayGet} from './liferay-inventory-page-fetch-http.js';
 
 export async function tryFetchFragmentEntryLinks(
@@ -77,8 +77,9 @@ async function findFragmentExportPath(
 }
 
 async function resolveFragmentSearchBaseDirs(config: AppConfig): Promise<string[]> {
-  const configured = resolveFragmentsBaseDir(config);
-  const candidates = [configured];
+  const configured = tryResolveFragmentsBaseDir(config);
+  const candidates = configured ? [configured] : [];
+
   if (config.liferayDir && (await fs.pathExists(config.liferayDir))) {
     const entries = await fs.readdir(config.liferayDir, {withFileTypes: true});
     for (const entry of entries) {

--- a/src/features/liferay/inventory/liferay-inventory-page-fetch-journal.ts
+++ b/src/features/liferay/inventory/liferay-inventory-page-fetch-journal.ts
@@ -22,7 +22,7 @@ import {
   resolveResourceSite,
 } from '../resource/liferay-resource-shared.js';
 import {matchesDdmTemplate} from '../liferay-identifiers.js';
-import {resolveArtifactSiteDir, resolveSiteToken} from '../resource/liferay-resource-paths.js';
+import {resolveSiteToken, tryResolveArtifactSiteDir} from '../resource/liferay-resource-paths.js';
 import {
   type ArticleRef,
   fetchContentStructureById,
@@ -141,11 +141,14 @@ export async function buildJournalArticleSummary(
     );
     if (structureSite) {
       summary.ddmStructureSiteFriendlyUrl = structureSite.siteFriendlyUrl;
-      summary.structureExportPath = buildStructureExportPath(
+      const structureExportPath = buildStructureExportPath(
         config,
         structureSite.siteFriendlyUrl,
         summary.ddmStructureKey,
       );
+      if (structureExportPath) {
+        summary.structureExportPath = structureExportPath;
+      }
     }
   }
 
@@ -156,7 +159,10 @@ export async function buildJournalArticleSummary(
     });
     if (templateSite) {
       summary.ddmTemplateSiteFriendlyUrl = templateSite;
-      summary.templateExportPath = buildTemplateExportPath(config, templateSite, ddmTemplateKey);
+      const templateExportPath = buildTemplateExportPath(config, templateSite, ddmTemplateKey);
+      if (templateExportPath) {
+        summary.templateExportPath = templateExportPath;
+      }
     }
   }
 
@@ -188,12 +194,13 @@ export async function collectLayoutContentStructures(
     }
     const key = inferContentStructureKey(response.data) || article.ddmStructureKey;
     const siteFriendlyUrl = article.ddmStructureSiteFriendlyUrl ?? article.siteFriendlyUrl;
+    const exportPath = siteFriendlyUrl && key ? buildStructureExportPath(config, siteFriendlyUrl, key) : undefined;
     result.push({
       contentStructureId,
       ...(key ? {key} : {}),
       name: String(response.data?.name ?? ''),
       ...(siteFriendlyUrl ? {siteFriendlyUrl} : {}),
-      ...(siteFriendlyUrl && key ? {exportPath: buildStructureExportPath(config, siteFriendlyUrl, key)} : {}),
+      ...(exportPath ? {exportPath} : {}),
     });
   }
 
@@ -316,19 +323,13 @@ async function resolveTemplateSiteByKey(
 }
 
 function buildStructureExportPath(config: AppConfig, siteFriendlyUrl: string, key: string): string | undefined {
-  try {
-    return path.join(resolveArtifactSiteDir(config, 'structure', resolveSiteToken(siteFriendlyUrl)), `${key}.json`);
-  } catch {
-    return undefined;
-  }
+  const siteDir = tryResolveArtifactSiteDir(config, 'structure', resolveSiteToken(siteFriendlyUrl));
+  return siteDir ? path.join(siteDir, `${key}.json`) : undefined;
 }
 
 function buildTemplateExportPath(config: AppConfig, siteFriendlyUrl: string, key: string): string | undefined {
-  try {
-    return path.join(resolveArtifactSiteDir(config, 'template', resolveSiteToken(siteFriendlyUrl)), `${key}.ftl`);
-  } catch {
-    return undefined;
-  }
+  const siteDir = tryResolveArtifactSiteDir(config, 'template', resolveSiteToken(siteFriendlyUrl));
+  return siteDir ? path.join(siteDir, `${key}.ftl`) : undefined;
 }
 
 function inferContentStructureKey(value: Record<string, unknown> | null | undefined): string {

--- a/src/features/liferay/resource/artifact-paths.ts
+++ b/src/features/liferay/resource/artifact-paths.ts
@@ -34,6 +34,14 @@ export function resolveRepoPath(config: AppConfig, relativePath: string): string
   return path.resolve(requireRepoRoot(config), relativePath);
 }
 
+export function tryResolveRepoPath(config: AppConfig, relativePath: string): string | undefined {
+  if (!config.repoRoot) {
+    return undefined;
+  }
+
+  return path.resolve(config.repoRoot, relativePath);
+}
+
 export function resolveStructuresBaseDir(config: AppConfig): string {
   return resolveRepoPath(config, config.paths?.structures ?? 'liferay/resources/journal/structures');
 }
@@ -48,6 +56,10 @@ export function resolveAdtsBaseDir(config: AppConfig): string {
 
 export function resolveFragmentsBaseDir(config: AppConfig): string {
   return resolveRepoPath(config, config.paths?.fragments ?? 'liferay/fragments');
+}
+
+export function tryResolveFragmentsBaseDir(config: AppConfig): string | undefined {
+  return tryResolveRepoPath(config, config.paths?.fragments ?? 'liferay/fragments');
 }
 
 export function resolveMigrationsBaseDir(config: AppConfig): string {
@@ -119,6 +131,27 @@ export function resolveArtifactBaseDir(config: AppConfig, type: ArtifactType, di
   }
 }
 
+export function tryResolveArtifactBaseDir(
+  config: AppConfig,
+  type: ArtifactType,
+  dirOverride?: string,
+): string | undefined {
+  if (dirOverride?.trim()) {
+    return tryResolveRepoPath(config, dirOverride);
+  }
+
+  switch (type) {
+    case 'template':
+      return tryResolveRepoPath(config, config.paths?.templates ?? 'liferay/resources/journal/templates');
+    case 'structure':
+      return tryResolveRepoPath(config, config.paths?.structures ?? 'liferay/resources/journal/structures');
+    case 'adt':
+      return tryResolveRepoPath(config, config.paths?.adts ?? 'liferay/resources/templates/application_display');
+    case 'fragment':
+      return tryResolveFragmentsBaseDir(config);
+  }
+}
+
 export async function resolveArtifactFile(config: AppConfig, options: ResolveArtifactFileOptions): Promise<string> {
   if (options.fileOverride) {
     return resolveExistingArtifactFile(config, options.fileOverride);
@@ -155,6 +188,25 @@ export function resolveArtifactSiteDir(
     return path.join(resolveFragmentsBaseDir(config), 'sites', siteToken);
   }
   return path.join(resolveArtifactBaseDir(config, type, dirOverride), siteToken);
+}
+
+export function tryResolveArtifactSiteDir(
+  config: AppConfig,
+  type: ArtifactType,
+  siteToken: string,
+  dirOverride?: string,
+): string | undefined {
+  if (type === 'fragment') {
+    if (dirOverride?.trim()) {
+      return tryResolveRepoPath(config, dirOverride);
+    }
+
+    const fragmentsBaseDir = tryResolveFragmentsBaseDir(config);
+    return fragmentsBaseDir ? path.join(fragmentsBaseDir, 'sites', siteToken) : undefined;
+  }
+
+  const baseDir = tryResolveArtifactBaseDir(config, type, dirOverride);
+  return baseDir ? path.join(baseDir, siteToken) : undefined;
 }
 
 export function resolveFragmentProjectDir(config: AppConfig, siteToken: string, dirOverride?: string): string {

--- a/src/features/liferay/resource/liferay-resource-paths.ts
+++ b/src/features/liferay/resource/liferay-resource-paths.ts
@@ -13,6 +13,10 @@ export {
   resolveStructuresBaseDir,
   resolveTemplatesBaseDir,
   siteTokenToFriendlyUrl,
+  tryResolveArtifactBaseDir,
+  tryResolveArtifactSiteDir,
+  tryResolveFragmentsBaseDir,
+  tryResolveRepoPath,
 } from './artifact-paths.js';
 
 import {resolveArtifactFile} from './artifact-paths.js';

--- a/tests/unit/command-context.test.ts
+++ b/tests/unit/command-context.test.ts
@@ -1,3 +1,7 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
 import {afterEach, describe, expect, test} from 'vitest';
 
 import {createCommandContext} from '../../src/cli/command-context.js';
@@ -24,13 +28,14 @@ describe('command-context', () => {
     expect(context.config.repoRoot).toBe(repoRoot);
   });
 
-  test('applies global CLI liferay overrides from argv', () => {
+  test('applies portal namespace liferay overrides from argv', () => {
     const repoRoot = createTempRepo();
     process.env.REPO_ROOT = repoRoot;
 
     process.argv = [
       'node',
       'ldev',
+      'portal',
       '--liferay-url',
       'https://example.liferay.local',
       '--liferay-client-id=client-from-cli',
@@ -40,6 +45,7 @@ describe('command-context', () => {
       'scope.a,scope.b',
       '--liferay-timeout-seconds',
       '99',
+      'check',
     ];
 
     const context = createCommandContext();
@@ -56,7 +62,7 @@ describe('command-context', () => {
     process.env.REPO_ROOT = repoRoot;
     process.env.TEST_LIFERAY_SECRET = 'secret-from-env-ref';
 
-    process.argv = ['node', 'ldev', '--liferay-client-secret-env', 'TEST_LIFERAY_SECRET'];
+    process.argv = ['node', 'ldev', 'portal', '--liferay-client-secret-env', 'TEST_LIFERAY_SECRET', 'check'];
 
     const context = createCommandContext();
 
@@ -71,10 +77,12 @@ describe('command-context', () => {
     process.argv = [
       'node',
       'ldev',
+      'portal',
       '--liferay-client-secret',
       'secret-from-cli',
       '--liferay-client-secret-env',
       'TEST_LIFERAY_SECRET',
+      'check',
     ];
 
     const context = createCommandContext();
@@ -85,7 +93,7 @@ describe('command-context', () => {
   test('throws when --liferay-timeout-seconds is negative', () => {
     const repoRoot = createTempRepo();
     process.env.REPO_ROOT = repoRoot;
-    process.argv = ['node', 'ldev', '--liferay-timeout-seconds', '-1'];
+    process.argv = ['node', 'ldev', 'portal', '--liferay-timeout-seconds', '-1', 'check'];
 
     expect(() => createCommandContext()).toThrow('--liferay-timeout-seconds must be a positive integer.');
   });
@@ -93,7 +101,7 @@ describe('command-context', () => {
   test('throws when --liferay-timeout-seconds is decimal', () => {
     const repoRoot = createTempRepo();
     process.env.REPO_ROOT = repoRoot;
-    process.argv = ['node', 'ldev', '--liferay-timeout-seconds', '5.5'];
+    process.argv = ['node', 'ldev', 'portal', '--liferay-timeout-seconds', '5.5', 'check'];
 
     expect(() => createCommandContext()).toThrow('--liferay-timeout-seconds must be a positive integer.');
   });
@@ -101,7 +109,7 @@ describe('command-context', () => {
   test('throws when --liferay-url flag has no value', () => {
     const repoRoot = createTempRepo();
     process.env.REPO_ROOT = repoRoot;
-    process.argv = ['node', 'ldev', '--liferay-url', '--json'];
+    process.argv = ['node', 'ldev', 'portal', '--liferay-url', '--json', 'check'];
 
     expect(() => createCommandContext()).toThrow('--liferay-url requires a value.');
   });
@@ -109,8 +117,34 @@ describe('command-context', () => {
   test('throws when --liferay-url is not a valid http(s) URL', () => {
     const repoRoot = createTempRepo();
     process.env.REPO_ROOT = repoRoot;
-    process.argv = ['node', 'ldev', '--liferay-url', 'not-a-valid-url'];
+    process.argv = ['node', 'ldev', 'portal', '--liferay-url', 'not-a-valid-url', 'check'];
 
     expect(() => createCommandContext()).toThrow('--liferay-url must be a valid http(s) URL.');
+  });
+
+  test('supports remote-only command context outside a detected repo', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ldev-remote-only-'));
+    process.env.TEST_LIFERAY_SECRET = 'secret-from-env-ref';
+    process.argv = [
+      'node',
+      'ldev',
+      'portal',
+      '--liferay-url',
+      'https://portal.example.com',
+      '--liferay-client-id',
+      'remote-client',
+      '--liferay-client-secret-env',
+      'TEST_LIFERAY_SECRET',
+      'check',
+    ];
+
+    const context = createCommandContext({cwd: tempDir});
+
+    expect(context.project.repo.inRepo).toBe(false);
+    expect(context.project.projectType).toBe('unknown');
+    expect(context.config.repoRoot).toBeNull();
+    expect(context.config.liferay.url).toBe('https://portal.example.com');
+    expect(context.config.liferay.oauth2ClientId).toBe('remote-client');
+    expect(context.config.liferay.oauth2ClientSecret).toBe('secret-from-env-ref');
   });
 });

--- a/tests/unit/create-cli.test.ts
+++ b/tests/unit/create-cli.test.ts
@@ -3,15 +3,41 @@ import {describe, expect, test} from 'vitest';
 import {createCli} from '../../src/cli/create-cli.js';
 
 describe('createCli', () => {
-  test('registers global liferay connection options', () => {
+  test('does not register liferay connection options on the root command', () => {
     const cli = createCli();
     const optionNames = cli.options.map((option) => option.long);
 
-    expect(optionNames).toContain('--liferay-url');
-    expect(optionNames).toContain('--liferay-client-id');
-    expect(optionNames).toContain('--liferay-client-secret');
-    expect(optionNames).toContain('--liferay-client-secret-env');
-    expect(optionNames).toContain('--liferay-scope-aliases');
-    expect(optionNames).toContain('--liferay-timeout-seconds');
+    expect(optionNames).not.toContain('--liferay-url');
+    expect(optionNames).not.toContain('--liferay-client-id');
+    expect(optionNames).not.toContain('--liferay-client-secret');
+    expect(optionNames).not.toContain('--liferay-client-secret-env');
+    expect(optionNames).not.toContain('--liferay-scope-aliases');
+    expect(optionNames).not.toContain('--liferay-timeout-seconds');
+  });
+
+  test('registers liferay connection options on portal and resource namespaces', () => {
+    const cli = createCli();
+    const portal = cli.commands.find((command) => command.name() === 'portal');
+    const resource = cli.commands.find((command) => command.name() === 'resource');
+
+    expect(portal).toBeDefined();
+    expect(resource).toBeDefined();
+
+    const expectedOptions = [
+      '--liferay-url',
+      '--liferay-client-id',
+      '--liferay-client-secret',
+      '--liferay-client-secret-env',
+      '--liferay-scope-aliases',
+      '--liferay-timeout-seconds',
+    ];
+
+    const portalOptionNames = portal?.options.map((option) => option.long) ?? [];
+    const resourceOptionNames = resource?.options.map((option) => option.long) ?? [];
+
+    for (const optionName of expectedOptions) {
+      expect(portalOptionNames).toContain(optionName);
+      expect(resourceOptionNames).toContain(optionName);
+    }
   });
 });

--- a/tests/unit/liferay-artifact-paths.test.ts
+++ b/tests/unit/liferay-artifact-paths.test.ts
@@ -10,6 +10,9 @@ import {
   sanitizeArtifactToken,
   resolveSiteToken,
   siteTokenToFriendlyUrl,
+  tryResolveArtifactBaseDir,
+  tryResolveArtifactSiteDir,
+  tryResolveFragmentsBaseDir,
   type ArtifactType,
 } from '../../src/features/liferay/resource/artifact-paths.js';
 import {createTempDir} from '../../src/testing/temp-repo.js';
@@ -294,6 +297,46 @@ describe('resolveArtifactBaseDir – fallback default paths', () => {
 
   test('fragment falls back to liferay/fragments', () => {
     expect(resolveArtifactBaseDir(cfgNoPathsKey, 'fragment')).toBe(path.join(REPO_ROOT, 'liferay/fragments'));
+  });
+});
+
+describe('tryResolveArtifact* helpers', () => {
+  const cfg = makeConfig();
+  const cfgWithoutRepoRoot = {
+    ...makeConfig(),
+    repoRoot: null,
+  } as Parameters<typeof tryResolveArtifactBaseDir>[0];
+
+  test('tryResolveFragmentsBaseDir returns configured path when repoRoot exists', () => {
+    expect(tryResolveFragmentsBaseDir(cfg)).toBe(path.join(REPO_ROOT, 'liferay/fragments'));
+  });
+
+  test('tryResolveArtifactBaseDir returns configured path when repoRoot exists', () => {
+    expect(tryResolveArtifactBaseDir(cfg, 'structure')).toBe(
+      path.join(REPO_ROOT, 'liferay/resources/journal/structures'),
+    );
+  });
+
+  test('tryResolveArtifactSiteDir returns configured fragment site path when repoRoot exists', () => {
+    expect(tryResolveArtifactSiteDir(cfg, 'fragment', 'guest')).toBe(
+      path.join(REPO_ROOT, 'liferay/fragments', 'sites', 'guest'),
+    );
+  });
+
+  test('tryResolveFragmentsBaseDir returns undefined without repoRoot', () => {
+    expect(tryResolveFragmentsBaseDir(cfgWithoutRepoRoot)).toBeUndefined();
+  });
+
+  test('tryResolveArtifactBaseDir returns undefined without repoRoot', () => {
+    expect(tryResolveArtifactBaseDir(cfgWithoutRepoRoot, 'template')).toBeUndefined();
+  });
+
+  test('tryResolveArtifactSiteDir returns undefined without repoRoot', () => {
+    expect(tryResolveArtifactSiteDir(cfgWithoutRepoRoot, 'structure', 'guest')).toBeUndefined();
+  });
+
+  test('tryResolveArtifactSiteDir keeps strict repo semantics for dirOverride and returns undefined without repoRoot', () => {
+    expect(tryResolveArtifactSiteDir(cfgWithoutRepoRoot, 'template', 'guest', 'custom/templates')).toBeUndefined();
   });
 });
 

--- a/tests/unit/liferay-inventory-page.test.ts
+++ b/tests/unit/liferay-inventory-page.test.ts
@@ -27,6 +27,18 @@ const CONFIG = {
   },
 };
 
+const REMOTE_ONLY_CONFIG = {
+  ...CONFIG,
+  cwd: '/tmp',
+  repoRoot: null,
+  dockerDir: null,
+  liferayDir: null,
+  files: {
+    dockerEnv: null,
+    liferayProfile: null,
+  },
+};
+
 const EXPECTED_GUEST_STRUCTURE_EXPORT_PATH = path.resolve(
   CONFIG.repoRoot,
   'liferay/resources/journal/structures',
@@ -380,6 +392,79 @@ describe('liferay inventory page', () => {
     ]);
     expect(formatLiferayInventoryPage(result)).toContain('REGULAR PAGE');
     expect(formatLiferayInventoryPage(result)).toContain('contentField Headline=Hello');
+  });
+
+  test('skips local fragment export path enrichment outside a repo', async () => {
+    const apiClient = createLiferayApiClient({
+      fetchImpl: async (input) => {
+        const url = String(input);
+
+        if (url.includes('/by-friendly-url-path/guest')) {
+          return new Response('{"id":20121,"friendlyUrlPath":"/guest","name":"Guest"}', {status: 200});
+        }
+
+        if (url.includes('parentLayoutId=0')) {
+          return new Response(
+            '[{"layoutId":11,"plid":1011,"type":"content","nameCurrentValue":"Home","friendlyURL":"/home","hidden":false}]',
+            {status: 200},
+          );
+        }
+
+        if (url.includes('parentLayoutId=11')) {
+          return new Response('[]', {status: 200});
+        }
+
+        if (url.includes('/site-pages/home?fields=pageDefinition')) {
+          return new Response(
+            JSON.stringify({
+              pageDefinition: {
+                pageElement: {
+                  type: 'Root',
+                  pageElements: [
+                    {
+                      type: 'Fragment',
+                      definition: {
+                        fragment: {key: 'banner'},
+                      },
+                    },
+                  ],
+                },
+              },
+            }),
+            {status: 200},
+          );
+        }
+
+        if (url.includes('/fragment.fragmententrylink/get-fragment-entry-links')) {
+          return new Response('[]', {status: 200});
+        }
+
+        if (url.includes('/api/jsonws/classname/fetch-class-name?value=com.liferay.portal.kernel.model.Layout')) {
+          return new Response('{"classNameId":20006}', {status: 200});
+        }
+
+        throw new Error(`Unexpected URL ${url}`);
+      },
+    });
+
+    const result = await runLiferayInventoryPage(
+      REMOTE_ONLY_CONFIG,
+      {url: '/web/guest/home'},
+      {apiClient, tokenClient: TOKEN_CLIENT},
+    );
+
+    expect(() => validateLiferayInventoryPageResultV2(result)).not.toThrow();
+    if (result.pageType !== 'regularPage') {
+      throw new Error('Expected regular page');
+    }
+
+    expect(result.fragmentEntryLinks).toEqual([{type: 'fragment', fragmentKey: 'banner'}]);
+    const [fragmentEntry] = result.fragmentEntryLinks ?? [];
+    if (!fragmentEntry) {
+      throw new Error('Expected fragment entry');
+    }
+    expect(fragmentEntry).not.toHaveProperty('fragmentExportPath');
+    expect(fragmentEntry).not.toHaveProperty('fragmentSiteFriendlyUrl');
   });
 
   test('returns classic portlet layout composition from type settings', async () => {
@@ -980,6 +1065,122 @@ describe('liferay inventory page', () => {
     expect('articleProperties' in result).toBe(false);
     expect(formatLiferayInventoryPage(result)).toContain('DISPLAY PAGE');
     expect(formatLiferayInventoryPage(result)).toContain('contentField Headline=News title');
+  });
+
+  test('skips local structure and template export path enrichment outside a repo', async () => {
+    const apiClient = createLiferayApiClient({
+      fetchImpl: async (input) => {
+        const url = String(input);
+
+        if (url.includes('/by-friendly-url-path/guest')) {
+          return new Response('{"id":20121,"friendlyUrlPath":"/guest","name":"Guest"}', {status: 200});
+        }
+
+        if (url.includes('/structured-contents?')) {
+          return new Response(
+            '{"items":[{"id":41001,"key":"ART-001","title":"News article","friendlyUrlPath":"news-article","contentStructureId":301}],"lastPage":1}',
+            {status: 200},
+          );
+        }
+
+        if (url.includes('/journal.journalarticle/get-article-by-url-title')) {
+          return new Response(
+            JSON.stringify({
+              id: 41001,
+              resourcePrimKey: 41001,
+              articleId: 'ART-001',
+              titleCurrentValue: 'News article',
+              ddmStructureKey: 'NEWS',
+              ddmTemplateKey: 'NEWS_TEMPLATE',
+              contentStructureId: 301,
+            }),
+            {status: 200},
+          );
+        }
+
+        if (url.includes('/api/jsonws/group/get-group?groupId=20121')) {
+          return new Response(
+            '{"companyId":10157,"parentGroupId":0,"friendlyURL":"/guest","nameCurrentValue":"Guest"}',
+            {status: 200},
+          );
+        }
+
+        if (url.includes('/by-friendly-url-path/global')) {
+          return new Response('{"id":20122,"friendlyUrlPath":"/global","name":"Global"}', {status: 200});
+        }
+
+        if (
+          url.includes(
+            '/o/data-engine/v2.0/sites/20121/data-definitions/by-content-type/journal/by-data-definition-key/NEWS',
+          )
+        ) {
+          return new Response('{"id":301,"dataDefinitionKey":"NEWS","name":{"en_US":"News"}}', {status: 200});
+        }
+
+        if (url.includes('/api/jsonws/ddm.ddmtemplate/get-templates?companyId=10157&groupId=20121')) {
+          return new Response(
+            '[{"templateId":"40801","templateKey":"NEWS_TEMPLATE","externalReferenceCode":"NEWS_TEMPLATE","nameCurrentValue":"News Template","classPK":301,"script":"<#-- ftl -->"}]',
+            {status: 200},
+          );
+        }
+
+        if (url.endsWith('/o/headless-delivery/v1.0/structured-contents/41001')) {
+          return new Response(
+            JSON.stringify({
+              id: 41001,
+              contentStructureId: 301,
+              priority: 0,
+              contentFields: [
+                {
+                  label: 'Headline',
+                  name: 'headline',
+                  dataType: 'string',
+                  contentFieldValue: {data: 'News title'},
+                },
+              ],
+            }),
+            {status: 200},
+          );
+        }
+
+        if (url.endsWith('/o/headless-delivery/v1.0/content-structures/301')) {
+          return new Response('{"id":301,"dataDefinitionKey":"NEWS","name":"News"}', {status: 200});
+        }
+
+        if (url.includes('/api/jsonws/classname/fetch-class-name?value=com.liferay.journal.model.JournalArticle')) {
+          return new Response('{"classNameId":1002}', {status: 200});
+        }
+
+        throw new Error(`Unexpected URL ${url}`);
+      },
+    });
+
+    const result = await runLiferayInventoryPage(
+      REMOTE_ONLY_CONFIG,
+      {site: 'guest', friendlyUrl: '/w/news-article'},
+      {apiClient, tokenClient: TOKEN_CLIENT},
+    );
+
+    expect(() => validateLiferayInventoryPageResultV2(result)).not.toThrow();
+    if (result.pageType !== 'displayPage') {
+      throw new Error('Expected display page');
+    }
+
+    expect(result.journalArticles?.[0]).toMatchObject({
+      articleId: 'ART-001',
+      ddmStructureKey: 'NEWS',
+      ddmTemplateKey: 'NEWS_TEMPLATE',
+      ddmStructureSiteFriendlyUrl: '/guest',
+      ddmTemplateSiteFriendlyUrl: '/guest',
+    });
+    expect(result.journalArticles?.[0]).not.toHaveProperty('structureExportPath');
+    expect(result.journalArticles?.[0]).not.toHaveProperty('templateExportPath');
+    expect(result.contentStructures?.[0]).toMatchObject({
+      contentStructureId: 301,
+      key: 'NEWS',
+      siteFriendlyUrl: '/guest',
+    });
+    expect(result.contentStructures?.[0]).not.toHaveProperty('exportPath');
   });
 
   test('fails clearly when layout cannot be resolved', async () => {


### PR DESCRIPTION
## Summary
- Removes the Liferay connection override flags from the root `ldev` command.
- Keeps those overrides only on the `portal` and `resource` namespaces, which is where they actually apply.
- Updates the docs and tests so the CLI contract is consistent and no longer documents two competing syntaxes.

## What Changed
- Updated `src/cli/create-cli.ts`:
  - removed root-level `--liferay-url`
  - removed root-level OAuth client/secret override flags
  - removed root-level scope alias and timeout override flags
  - removed the root help text that described those overrides
- Kept the namespace-scoped overrides on:
  - `src/commands/liferay/liferay.command.ts`
  - `src/commands/resource/resource-command-builder.ts`
- Updated tests:
  - `tests/unit/create-cli.test.ts`
  - `tests/unit/command-context.test.ts`
- Updated docs to document only the namespace form:
  - `docs/reference/configuration.md`
  - `docs/core-concepts/oauth.md`
  - `docs/commands/discovery.md`
  - `docs/commands/index.md`

## New Contract
Use:

```bash
ldev portal --liferay-url https://portal.example.com --liferay-client-id <id> --liferay-client-secret-env LIFERAY_SECRET check --json
ldev resource --liferay-url https://portal.example.com --liferay-client-id <id> --liferay-client-secret-env LIFERAY_SECRET structure --site /global --key TEST
```

Do not use the old root-scoped form anymore:

```bash
ldev --liferay-url https://portal.example.com portal check
```

That syntax now fails intentionally with `unknown option '--liferay-url'`.

## Why
The previous state was confusing:
- the root command advertised the overrides as global options
- `portal` and `resource` also exposed them locally
- docs still described them as root-only or global in some places

This change makes the CLI easier to explain and easier to use:
- root command stays focused on global CLI concerns
- remote connection overrides live only on the namespaces that consume them
- docs and help output now match the actual intended usage

## Validation
- `npm run test:unit -- tests/unit/create-cli.test.ts tests/unit/command-context.test.ts`
- `npm run build`
- Manual verification:
  - `node dist/index.js --help`
  - `node dist/index.js portal --help`
  - `node dist/index.js resource --help`
  - confirmed old root-scoped syntax is rejected
  - confirmed namespace-scoped syntax is accepted

## Breaking Change
Yes, intentionally:
- root-scoped Liferay connection overrides were removed
- callers must move those flags onto `ldev portal` or `ldev resource`
