### PR TITLE
Scope ai install force to explicit project flags

### DIFF
--- a/src/commands/ai/ai.command.ts
+++ b/src/commands/ai/ai.command.ts
@@ -20,7 +20,10 @@ export function createAiCommand(): Command {
       .command('install')
       .description('Install the standard reusable AI assets into a project')
       .requiredOption('--target <target>', 'Project root')
-      .option('--force', 'Overwrite AGENTS.md if it already exists')
+      .option(
+        '--force',
+        'Overwrite AGENTS.md and requested project AI files if they already exist; project-context requires explicit --project-context',
+      )
       .option(
         '--local',
         'Keep AI tooling local by adding generated agent/editor files to .gitignore while leaving docs/ai versionable',
@@ -73,7 +76,8 @@ Safe defaults:
 Potentially mutating:
   install              Install vendor skills + AGENTS.md bootstrap
   install --skill ...  Install only selected vendor skills (like tsdown --skill patterns)
-  install --force      Overwrite AGENTS.md when bootstrapping a project
+  install --force      Overwrite AGENTS.md and requested project AI files when bootstrapping a project
+                       project-context files are only overwritten when --project-context is explicitly passed
   install --local      Add generated agent/editor files to .gitignore, but keep docs/ai versionable
   install --project-context
                       Also install project-owned context scaffolding.

--- a/src/features/ai/ai-install-project.ts
+++ b/src/features/ai/ai-install-project.ts
@@ -166,19 +166,24 @@ export async function collectExistingProjectSkills(skillsDestinationDir: string)
     .sort();
 }
 
-export async function installProjectFile(targetDir: string, assets: AiAssets, relativePath: string): Promise<boolean> {
+export async function installProjectFile(
+  targetDir: string,
+  assets: AiAssets,
+  relativePath: string,
+  options?: {overwrite?: boolean},
+): Promise<boolean> {
   const source = path.join(assets.projectDir, relativePath);
   if (!(await fs.pathExists(source))) {
     return false;
   }
 
   const destination = path.join(targetDir, relativePath);
-  if (await fs.pathExists(destination)) {
+  if ((await fs.pathExists(destination)) && !options?.overwrite) {
     return false;
   }
 
   await fs.ensureDir(path.dirname(destination));
-  await copyAiTemplatePath(source, destination);
+  await copyAiTemplatePath(source, destination, {overwrite: options?.overwrite ?? true});
   return true;
 }
 

--- a/src/features/ai/ai-install.ts
+++ b/src/features/ai/ai-install.ts
@@ -266,32 +266,52 @@ async function applyAiInstall(options: {
       })
     : 'skipped';
 
+  const overwriteProjectFiles = options.force;
+  const overwriteProjectContextFiles = options.force && options.projectContext;
+
   const claudeInstalled = !options.skillsOnly
     ? options.projectType === 'blade-workspace'
       ? false
-      : await installProjectFile(options.targetDir, options.assets, 'CLAUDE.md')
+      : await installProjectFile(options.targetDir, options.assets, 'CLAUDE.md', {
+          overwrite: overwriteProjectFiles,
+        })
     : false;
 
   const installProjectContext = !options.skillsOnly && (options.project || options.projectContext);
 
   const projectContextInstalled = installProjectContext
-    ? await installProjectFile(options.targetDir, options.assets, path.join('docs', 'ai', 'project-context.md'))
+    ? await installProjectFile(options.targetDir, options.assets, path.join('docs', 'ai', 'project-context.md'), {
+        overwrite: overwriteProjectContextFiles,
+      })
     : false;
 
   const projectContextSampleInstalled = installProjectContext
-    ? await installProjectFile(options.targetDir, options.assets, path.join('docs', 'ai', 'project-context.md.sample'))
+    ? await installProjectFile(
+        options.targetDir,
+        options.assets,
+        path.join('docs', 'ai', 'project-context.md.sample'),
+        {
+          overwrite: overwriteProjectContextFiles,
+        },
+      )
     : false;
 
   const copilotInstalled = !options.skillsOnly
-    ? await installProjectFile(options.targetDir, options.assets, path.join('.github', 'copilot-instructions.md'))
+    ? await installProjectFile(options.targetDir, options.assets, path.join('.github', 'copilot-instructions.md'), {
+        overwrite: overwriteProjectFiles,
+      })
     : false;
 
   const geminiInstalled = !options.skillsOnly
-    ? await installProjectFile(options.targetDir, options.assets, path.join('.gemini', 'GEMINI.md'))
+    ? await installProjectFile(options.targetDir, options.assets, path.join('.gemini', 'GEMINI.md'), {
+        overwrite: overwriteProjectFiles,
+      })
     : false;
 
   const cursorrulesInstalled = !options.skillsOnly
-    ? await installProjectFile(options.targetDir, options.assets, '.cursorrules')
+    ? await installProjectFile(options.targetDir, options.assets, '.cursorrules', {
+        overwrite: overwriteProjectFiles,
+      })
     : false;
 
   const gitignoreEntriesAdded =

--- a/src/features/ai/ai-install.ts
+++ b/src/features/ai/ai-install.ts
@@ -120,12 +120,12 @@ export function formatAiResult(result: AiCommandResult): string {
   } else {
     lines.push(`Installed skills: ${result.updatedSkills.length}`);
     lines.push(`AGENTS.md: ${result.agents}`);
-    if (result.claudeInstalled) lines.push('CLAUDE.md: installed');
-    if (result.projectContextInstalled) lines.push('docs/ai/project-context.md: installed');
-    if (result.projectContextSampleInstalled) lines.push('docs/ai/project-context.md.sample: installed');
-    if (result.copilotInstalled) lines.push('.github/copilot-instructions.md: installed');
-    if (result.geminiInstalled) lines.push('.gemini/GEMINI.md: installed');
-    if (result.cursorrulesInstalled) lines.push('.cursorrules: installed');
+    if (result.claudeInstalled) lines.push('CLAUDE.md: applied');
+    if (result.projectContextInstalled) lines.push('docs/ai/project-context.md: applied');
+    if (result.projectContextSampleInstalled) lines.push('docs/ai/project-context.md.sample: applied');
+    if (result.copilotInstalled) lines.push('.github/copilot-instructions.md: applied');
+    if (result.geminiInstalled) lines.push('.gemini/GEMINI.md: applied');
+    if (result.cursorrulesInstalled) lines.push('.cursorrules: applied');
     if (result.gitignoreEntriesAdded.length > 0) {
       lines.push(`AI/tooling paths added to .gitignore: ${result.gitignoreEntriesAdded.length}`);
     }
@@ -297,9 +297,11 @@ async function applyAiInstall(options: {
     : false;
 
   const copilotInstalled = !options.skillsOnly
-    ? await installProjectFile(options.targetDir, options.assets, path.join('.github', 'copilot-instructions.md'), {
-        overwrite: overwriteProjectFiles,
-      })
+    ? options.projectType === 'blade-workspace'
+      ? false
+      : await installProjectFile(options.targetDir, options.assets, path.join('.github', 'copilot-instructions.md'), {
+          overwrite: overwriteProjectFiles,
+        })
     : false;
 
   const geminiInstalled = !options.skillsOnly

--- a/tests/integration/ai.integration.test.ts
+++ b/tests/integration/ai.integration.test.ts
@@ -603,6 +603,22 @@ describe('ai integration', () => {
     }
   }, 40000);
 
+  test('install --force in blade-workspace does not overwrite official copilot instructions', async () => {
+    const targetDir = createTempWorkspace();
+
+    await fs.ensureDir(path.join(targetDir, '.github'));
+    await fs.writeFile(path.join(targetDir, '.github', 'copilot-instructions.md'), 'official copilot\n');
+
+    const result = await runCli(['ai', 'install', '--target', targetDir, '--force'], {
+      cwd: CLI_CWD,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(await fs.readFile(path.join(targetDir, '.github', 'copilot-instructions.md'), 'utf8')).toBe(
+      'official copilot\n',
+    );
+  }, 40000);
+
   test('install in ldev-native adds common and native-specific rules but not workspace-specific rules', async () => {
     const targetDir = createTempDir('dev-cli-ai-native-rules-');
     await fs.ensureDir(path.join(targetDir, 'docker'));

--- a/tests/integration/ai.integration.test.ts
+++ b/tests/integration/ai.integration.test.ts
@@ -449,6 +449,67 @@ describe('ai integration', () => {
     );
   }, 40000);
 
+  test('install --force overwrites existing project AI files including gemini and cursor entrypoints', async () => {
+    const targetDir = createTempDir('dev-cli-ai-project-files-force-');
+
+    const firstInstall = await runCli(['ai', 'install', '--target', targetDir, '--project-context'], {
+      cwd: CLI_CWD,
+    });
+    expect(firstInstall.exitCode).toBe(0);
+
+    await fs.writeFile(path.join(targetDir, 'CLAUDE.md'), 'custom claude\n');
+    await fs.ensureDir(path.join(targetDir, 'docs', 'ai'));
+    await fs.writeFile(path.join(targetDir, 'docs', 'ai', 'project-context.md'), 'custom context\n');
+    await fs.writeFile(path.join(targetDir, 'docs', 'ai', 'project-context.md.sample'), 'custom sample\n');
+    await fs.writeFile(path.join(targetDir, '.github', 'copilot-instructions.md'), 'custom copilot\n');
+    await fs.ensureDir(path.join(targetDir, '.gemini'));
+    await fs.writeFile(path.join(targetDir, '.gemini', 'GEMINI.md'), 'custom gemini\n');
+    await fs.writeFile(path.join(targetDir, '.cursorrules'), 'custom cursor\n');
+
+    const secondInstall = await runCli(['ai', 'install', '--target', targetDir, '--project-context', '--force'], {
+      cwd: CLI_CWD,
+    });
+    expect(secondInstall.exitCode).toBe(0);
+
+    expect(await fs.readFile(path.join(targetDir, 'CLAUDE.md'), 'utf8')).not.toBe('custom claude\n');
+    expect(await fs.readFile(path.join(targetDir, 'docs', 'ai', 'project-context.md'), 'utf8')).not.toBe(
+      'custom context\n',
+    );
+    expect(await fs.readFile(path.join(targetDir, 'docs', 'ai', 'project-context.md.sample'), 'utf8')).not.toBe(
+      'custom sample\n',
+    );
+    expect(await fs.readFile(path.join(targetDir, '.github', 'copilot-instructions.md'), 'utf8')).not.toBe(
+      'custom copilot\n',
+    );
+    expect(await fs.readFile(path.join(targetDir, '.gemini', 'GEMINI.md'), 'utf8')).not.toBe('custom gemini\n');
+    expect(await fs.readFile(path.join(targetDir, '.cursorrules'), 'utf8')).not.toBe('custom cursor\n');
+  }, 40000);
+
+  test('install --project --force does not overwrite project-context files unless --project-context is explicit', async () => {
+    const targetDir = createTempDir('dev-cli-ai-project-force-scope-');
+
+    const firstInstall = await runCli(['ai', 'install', '--target', targetDir, '--project'], {
+      cwd: CLI_CWD,
+    });
+    expect(firstInstall.exitCode).toBe(0);
+
+    await fs.ensureDir(path.join(targetDir, 'docs', 'ai'));
+    await fs.writeFile(path.join(targetDir, 'docs', 'ai', 'project-context.md'), 'custom context\n');
+    await fs.writeFile(path.join(targetDir, 'docs', 'ai', 'project-context.md.sample'), 'custom sample\n');
+
+    const secondInstall = await runCli(['ai', 'install', '--target', targetDir, '--project', '--force'], {
+      cwd: CLI_CWD,
+    });
+    expect(secondInstall.exitCode).toBe(0);
+
+    expect(await fs.readFile(path.join(targetDir, 'docs', 'ai', 'project-context.md'), 'utf8')).toBe(
+      'custom context\n',
+    );
+    expect(await fs.readFile(path.join(targetDir, 'docs', 'ai', 'project-context.md.sample'), 'utf8')).toBe(
+      'custom sample\n',
+    );
+  }, 40000);
+
   test('install in blade-workspace preserves official AI files and adds ldev workspace augmentation files', async () => {
     const targetDir = createTempWorkspace();
 


### PR DESCRIPTION
## Summary

This PR narrows the scope of `ldev ai install --force` so overwrite behavior follows the flags that were explicitly requested.

Changes included:
- allow project AI files to be overwritten when `--force` is used
- overwrite `docs/ai/project-context.md` and `docs/ai/project-context.md.sample` only when `--project-context` is explicitly passed
- keep `--project --force` from overwriting project context scaffolding on its own
- clarify the CLI help text for `--force`
- add integration coverage for both overwrite paths

## Behavior

- `ldev ai install --force --project`
  - overwrites requested project AI files such as `CLAUDE.md`, `.github/copilot-instructions.md`, `.gemini/GEMINI.md`, and `.cursorrules`
  - does not overwrite project context files
- `ldev ai install --force --project-context`
  - overwrites project context files as well
- `ldev ai install --skills-only`
  - remains vendor-only

## Validation

- `npm run build`
- `npm exec vitest -- run --config vitest.integration.config.ts tests/integration/ai.integration.test.ts -t "install --project --force does not overwrite project-context files unless --project-context is explicit|install --force overwrites existing project AI files including gemini and cursor entrypoints"`