### PR TITLE
Refine issue-engineering workflow: distinguish trivial vs non-trivial tasks

### DIFF
--- a/templates/ai/install/AGENTS.md
+++ b/templates/ai/install/AGENTS.md
@@ -43,8 +43,8 @@ These rules apply to every task, regardless of the skill in use:
 8. If a command fails, diagnose first (`ldev logs diagnose --json` or `ldev doctor --json`) before retrying.
 9. Never guess IDs, keys, or site names. Use `ldev portal inventory ...` to resolve them.
 10. Never assume the portal URL. Read `context.liferay.portalUrl` from bootstrap output.
-11. For `ldev-native`, any task that mutates code/resources/runtime must execute this gate order without exceptions: `Red-1` reproduction in current runtime → isolated worktree setup and root lock → `Red-2` reproduction in worktree runtime → import/deploy verification with runtime evidence → `Red -> Green` visual validation.
-12. Invalid skip reasons include: no formal GitHub issue, task is small, already on a feature branch, runtime already running, or user did not explicitly request validation/worktree steps.
+11. For `ldev-native`, the recommended default for any task that mutates code/resources/runtime is: `Red-1` reproduction in current runtime → isolated worktree setup and root lock → `Red-2` reproduction in worktree runtime → import/deploy verification with runtime evidence → `Red → Green` visual validation. Before imposing the full gate sequence, briefly assess the task scope: for bug fixes, migrations, and significant feature work, apply the full gate. For clearly trivial changes (single-field config update, copy fix, isolated template tweak the developer explicitly scoped), ask the developer whether they want the full isolation workflow or prefer to proceed in the current checkout.
+12. Safety checks that apply to every task regardless of scope: `--check-only` before any resource import, read-after-write verification after mutations, ID and URL resolution via `ldev portal inventory` (never guess), and diagnosis before speculative fixes. These are not negotiable. Workflow steps (worktree isolation, Red-1/Red-2 cycle, browser validation) are the recommended default; for clearly trivial tasks, confirm with the developer before imposing them.
 
 ## ldev Command Resolution
 

--- a/templates/ai/install/AGENTS.md
+++ b/templates/ai/install/AGENTS.md
@@ -22,8 +22,11 @@ Before changing code or runtime state:
 4. Read `CLAUDE.md`.
 5. Read the task-specific skill under `.agents/skills/` if one applies.
 6. If `.agents/skills/project-issue-engineering/SKILL.md` exists and the task
-  mutates code, resources, or runtime state, read it first regardless of
-  whether the request came from GitHub, chat, or an ad-hoc instruction.
+   mutates code, resources, or runtime state, read it first for non-trivial work
+   such as bug fixes, features, migrations, or anything with reproduction risk.
+   For clearly trivial ad-hoc requests where the developer has explicitly scoped
+   the exact change, confirm whether they want the full issue workflow or prefer
+   to proceed directly.
 
 Use `ldev --help` as the source of truth for the public CLI surface.
 

--- a/templates/ai/install/AGENTS.workspace.md
+++ b/templates/ai/install/AGENTS.workspace.md
@@ -156,9 +156,12 @@ Recommended locations:
 - repository docs that describe team-specific architecture or workflows
 
 If `.agents/skills/project-issue-engineering/` exists and the task is driven by
-code/resource/runtime mutation, read that skill for repository process after
-bootstrap regardless of whether the request came from GitHub, chat, or ad-hoc
-instructions. Use vendor skills for the technical execution itself.
+code/resource/runtime mutation, read that skill for non-trivial repository
+process after bootstrap: bug fixes, features, migrations, or anything with
+reproduction risk. For clearly trivial ad-hoc requests where the developer has
+explicitly scoped the exact change, confirm whether they want the full issue
+workflow or prefer to proceed directly. Use vendor skills for the technical
+execution itself.
 
 ## Installed Skills
 

--- a/templates/ai/project/CLAUDE.md
+++ b/templates/ai/project/CLAUDE.md
@@ -17,12 +17,10 @@ short. Put long-lived project knowledge in [docs/ai/project-context.md](docs/ai/
 ## Task Routing
 
 **Any task that changes code, resources, or runtime state (GitHub issue, chat request, or ad-hoc request):**
-Read `.agents/skills/project-issue-engineering/SKILL.md` **before doing anything else**.
-It defines the project issue workflow: intake → technical routing → validation → PR.
-If the repository has `ldev-native` capabilities available, follow its
-isolated worktree guidance as a mandatory gate before mutating runtime state.
-Use `.agents/skills/isolating-worktrees/SKILL.md` for the canonical setup and
-edit-root lock flow when worktree isolation is required.
+If `.agents/skills/project-issue-engineering/SKILL.md` exists, read it first for non-trivial work (bug fixes, features, migrations, anything with reproduction risk). For clearly trivial ad-hoc requests where the developer has explicitly scoped the exact change they want, confirm with them whether to follow the full issue engineering workflow or proceed directly — then act per their answer.
+
+If the repository has `ldev-native` capabilities available, worktree isolation is the recommended default for significant changes. For trivial changes, ask the developer before creating a worktree — they may prefer to work directly in the current checkout.
+Use `.agents/skills/isolating-worktrees/SKILL.md` for the canonical setup and edit-root lock flow when worktree isolation is used.
 
 **Liferay technical execution after issue workflow intake/reproduction gates:**
 Use `.agents/skills/liferay-expert/SKILL.md` to route to the right specialist skill.

--- a/templates/ai/project/skills/issue-engineering/SKILL.md
+++ b/templates/ai/project/skills/issue-engineering/SKILL.md
@@ -170,7 +170,7 @@ Route by task:
 - browser-based verification or visual evidence:
   - use `automating-browser-tests`
 
-## 5. Validate Red -> Green before handoff
+## 5. Validate before handoff
 
 For runtime-backed resources (ADTs, templates, structures, fragments), browser
 validation with Playwright is strongly recommended before handoff.
@@ -187,7 +187,8 @@ When reviewers need visual evidence directly in a GitHub issue or PR comment
 without committing branch artifacts, read
 `references/github-visual-evidence.md` before posting anything.
 
-Validation must follow a visible `Red -> Green` loop:
+For bug fixes, visual regressions, layout changes, and other user-facing runtime
+changes, validation should follow a visible `Red -> Green` loop:
 
 - `Red`: capture the failing local state before the fix
 - `Green`: verify the exact symptom checklist from the issue is now satisfied on
@@ -199,21 +200,22 @@ the symptom is gone.
 
 **DOM counters (element counts, selector presence) are supplementary evidence
 only.** A counter that returns `1` proves an element exists; it does not prove
-the page looks correct. Visual validation is required in addition to any
-scripted assertions.
+the page looks correct. For visual/user-facing changes, prefer visual validation
+in addition to any scripted assertions.
 
-**Side-by-side comparison is required before declaring Green:**
+**Side-by-side comparison is the recommended default before declaring Green:**
 
 - Open `before.png` (captured at Red) and the new `after.png` side by side.
 - Confirm every symptom from the issue description is no longer visible.
 - Confirm no new visual regressions appear (unexpected layout shifts, overlapping
   elements, missing sections).
 
-**Human confirmation is required before declaring Green:**
+**Human confirmation is the recommended default before closing a visual Red loop:**
 
-Do not self-declare the issue as fixed. Present the side-by-side evidence to the
-user and wait for explicit confirmation. The phrase "looks good" or "visually
-correct" from the user is the only valid gate to close the Red loop.
+For visual fixes, present the side-by-side evidence to the user and ask whether it
+looks correct before closing the Red loop. If the developer explicitly chooses a
+lighter validation path for a trivial or tightly scoped change, document that
+choice in the handoff and proceed per their instruction.
 
 **Revert-first on regression:** If a symptom appears in `after.png` (or in
 the running page) that was **not present in Red**, do not patch over it.

--- a/templates/ai/project/skills/issue-engineering/SKILL.md
+++ b/templates/ai/project/skills/issue-engineering/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: issue-engineering
-description: 'Use for any task that can mutate code, resources, or runtime state in this project (GitHub issue, chat request, or ad-hoc), to enforce intake/reproduction gates, evidence, and human handoff.'
+description: 'Use for non-trivial tasks that mutate code, resources, or runtime state (GitHub issue, feature, bug fix, migration). For clearly trivial ad-hoc changes, confirm with the developer whether the full workflow applies before starting.'
 ---
 
 # Issue Engineering
@@ -23,22 +23,29 @@ For technical execution, always route to vendor skills:
 - `migrating-journal-structures`
 - `automating-browser-tests`
 
-For `ldev-native`, this skill is mandatory before technical execution whenever
-the task mutates code, resources, or runtime state, even without a formal
-GitHub issue.
+For `ldev-native`, this skill is the recommended default before technical execution
+for non-trivial tasks (bug fixes, features, migrations) regardless of whether a
+formal GitHub issue exists. For clearly trivial ad-hoc tasks where the developer
+has explicitly scoped the change, confirm with them first — they may prefer to
+skip intake and proceed directly.
 
 For scope boundaries and invalid shortcuts, read
 `references/boundary-rules.md` only when needed.
 
-## Hard gates
+## Recommended gate order
 
-For `ldev-native` mutating tasks, execute this order without skipping:
+For `ldev-native` non-trivial tasks (bugs, features, migrations), follow this order:
 
 1. `Red-1` reproduction in the current runtime
 2. isolated worktree setup and active edit-root lock
 3. `Red-2` reproduction in the worktree runtime
 4. import/deploy verification with runtime evidence
 5. `Red -> Green` visual validation on the same local URL
+
+For clearly trivial tasks where the developer has explicitly defined the exact scope,
+confirm with them whether the full gate applies or whether they prefer to proceed
+directly. Never omit safety invariants (--check-only, read-after-write, ID resolution)
+regardless of which path is chosen.
 
 For `blade-workspace`, keep the same intake and validation discipline but do
 not invent a fake worktree phase.
@@ -94,11 +101,11 @@ issue; local reproduction defines the bug you are actually fixing.
 
 ## 3. Isolate the edit root
 
-**For `ldev-native` projects this step is mandatory, not optional.**
-If the project defines agent invariants in `docs/ai/project-context.md`, those
-invariants require a worktree before any code change or runtime mutation.
-Do not skip this step regardless of whether the user asks to skip commits or
-work in a lightweight mode.
+**For `ldev-native` projects, worktree isolation is the strongly recommended default.**
+For non-trivial tasks (bug fixes, features, migrations), apply this step without
+negotiation. For clearly trivial tasks where the developer explicitly requests
+lightweight mode, surface the recommendation, explain the risk of working in the
+main checkout, and ask for their explicit go-ahead. Proceed per their answer.
 
 If isolated worktrees are available:
 
@@ -166,14 +173,15 @@ Route by task:
 ## 5. Validate Red -> Green before handoff
 
 For runtime-backed resources (ADTs, templates, structures, fragments), browser
-validation with Playwright is required before handoff regardless of whether
-the user asks to skip commits or work in a lightweight mode.
+validation with Playwright is strongly recommended before handoff.
 
 "No commit" only affects the final git step. It does not waive:
 
 - import: `ldev resource import-*` for the changed resource
 - runtime verification: `ldev portal check --json`, `ldev logs diagnose --json`
-- browser validation: Playwright against the affected URL
+- browser validation: Playwright against the affected URL (recommended; if the
+  developer explicitly opts out for a clearly trivial visual change they've already
+  confirmed, note the skip and proceed per their instruction)
 
 When reviewers need visual evidence directly in a GitHub issue or PR comment
 without committing branch artifacts, read

--- a/templates/ai/project/skills/issue-engineering/references/validation.md
+++ b/templates/ai/project/skills/issue-engineering/references/validation.md
@@ -32,10 +32,14 @@ ldev resource structure --site /<site> --key <STRUCTURE_KEY>
 ldev resource template --site /<site> --id <TEMPLATE_ID>
 ```
 
-If the change affects a template, ADT, structure, or fragment, visual validation
-is **required**, not optional. Import success alone is not sufficient evidence.
+If the change affects visible output from a template, ADT, structure, or fragment,
+visual validation is the recommended default. Import success alone is not
+sufficient evidence for visual/user-facing changes. For trivial or non-visual
+changes, the developer may choose a lighter validation path; record that decision
+in the handoff.
 
-`before.png` must already exist from the reproduction step in intake. Do not
+When the chosen validation path uses a Red -> Green screenshot loop,
+`before.png` should already exist from the reproduction step in intake. Do not
 re-capture it here; that would overwrite the baseline taken before the fix.
 
 ```bash
@@ -56,8 +60,9 @@ For example:
 - results column width stays stable
 - empty-state message is visible in the results area
 
-Do not mark the issue as fixed until each expected behavior is checked on the
-final local page state.
+For bug fixes and visual changes, do not mark the issue as fixed until each
+expected behavior is checked on the final local page state. For explicitly scoped
+trivial work, record the lighter validation chosen by the developer.
 
 If browser routing is wrong for the target virtual host, do not count an unrelated
 screenshot as evidence. Record visual validation as blocked and use:

--- a/templates/ai/skills/automating-browser-tests/REFERENCE.md
+++ b/templates/ai/skills/automating-browser-tests/REFERENCE.md
@@ -13,7 +13,7 @@ Quick rules:
 
 - Use `--filename`, not `--output`, for screenshots.
 - Do not pass `--viewport-width` / `--viewport-height` to `screenshot`; set viewport on an open page with `run-code`.
-- Use full-page screenshots as mandatory evidence with `run-code` + `page.screenshot({ fullPage: true })`.
+- Use full-page screenshots as the recommended default for visual/user-facing evidence with `run-code` + `page.screenshot({ fullPage: true })`.
 - Install official skills with `playwright-cli install --skills` before guessing command syntax.
 - Do not start with `snapshot` on pages that still redirect or re-render heavily.
 - Build `run-code` snippets into a shell variable with a shell-native multiline

--- a/templates/ai/skills/automating-browser-tests/SKILL.md
+++ b/templates/ai/skills/automating-browser-tests/SKILL.md
@@ -117,7 +117,7 @@ to the browser host before opening. Full page layout mutation pattern is in `REF
 
 - Use semantic session names (`issue-NUM`, `page-editor-NUM`), not generic ones.
 - Store evidence under `.tmp/<issue>/` before uploading anywhere.
-- Capture full-page screenshots via `run-code` (`page.screenshot({ fullPage: true })`) as mandatory evidence.
+- Capture full-page screenshots via `run-code` (`page.screenshot({ fullPage: true })`) as the recommended default for visual/user-facing evidence.
 - For flaky failures, use `tracing-start`/`tracing-stop` before guessing.
 - Never validate against production; always reproduce locally first.
 - Inspect the loaded local page with `snapshot` plus `ldev portal inventory page --url`

--- a/templates/ai/workspace-rules/ldev-native-agent-workflow.md
+++ b/templates/ai/workspace-rules/ldev-native-agent-workflow.md
@@ -11,12 +11,15 @@ alwaysApply: true
 - Treat `AGENTS.md` as the bootstrap entrypoint.
 - `ldev` owns the full runtime contract in this project type.
 - If `.agents/skills/project-issue-engineering/SKILL.md` exists and the task
-  mutates code, resources, or runtime state, run that workflow first regardless
-  of whether the request came from GitHub, chat, or an ad-hoc instruction.
-- For these mutating tasks, enforce this gate order without exceptions:
-  `Red-1` reproduction -> worktree isolation/root lock -> `Red-2` reproduction ->
-  import/deploy verification -> `Red -> Green` visual validation.
-- When that isolation needs a runtime-backed worktree, ask the user whether the main environment needs to run in parallel with the worktree. Default is `ldev worktree setup --name <worktree-name> --with-env --stop-main-for-clone` (main stays stopped to conserve resources). Add `--restart-main-after-clone` only if the user confirms they need main running alongside the worktree.
+  mutates code, resources, or runtime state, run that workflow first for non-trivial
+  work (bugs, features, migrations). For clearly trivial ad-hoc requests, confirm
+  with the developer whether to follow the full intake or proceed directly.
+- For non-trivial mutating tasks, the recommended default gate order is:
+  `Red-1` reproduction → worktree isolation/root lock → `Red-2` reproduction →
+  import/deploy verification → `Red → Green` visual validation.
+  For clearly trivial changes, assess the scope and ask the developer whether they
+  want the full workflow or prefer to work directly in the current checkout.
+- When isolation needs a runtime-backed worktree, ask the user whether the main environment needs to run in parallel. Default is `ldev worktree setup --name <worktree-name> --with-env --stop-main-for-clone` (main stays stopped to conserve resources). Add `--restart-main-after-clone` only if the user confirms they need main running alongside the worktree.
 
 Preferred task-shaped entry points after bootstrap:
 


### PR DESCRIPTION
## Summary
This PR refines the issue-engineering skill and related agent workflow documentation to distinguish between non-trivial tasks (bug fixes, features, migrations) and clearly trivial ad-hoc changes. The changes shift from mandatory enforcement of all gates to a recommended-default approach with explicit developer confirmation for trivial work.

## Key Changes

- **Issue-engineering skill description**: Updated to clarify that the workflow applies to "non-trivial tasks" and advises confirming with developers before starting for clearly trivial ad-hoc changes.

- **Gate enforcement language**: Changed from "mandatory" and "hard gates" to "recommended gate order" and "strongly recommended default" throughout the skill documentation. The gate sequence (Red-1 → worktree → Red-2 → import/deploy → Red→Green validation) remains the default but now includes explicit guidance to assess scope and ask developers first for trivial changes.

- **Worktree isolation guidance**: Updated to recommend worktree isolation as the default for non-trivial tasks while allowing developers to opt out for clearly trivial changes after explicit confirmation of the risk.

- **Validation step flexibility**: Browser validation with Playwright is now "strongly recommended" rather than required, with a note that developers can opt out for clearly trivial visual changes they've already confirmed.

- **Agent workflow rules**: Refined `ldev-native-agent-workflow.md` to recommend the full intake workflow for non-trivial work while allowing direct execution for clearly trivial requests after developer confirmation.

- **CLAUDE.md task routing**: Simplified guidance to read issue-engineering for non-trivial work, with explicit instruction to confirm with developers on trivial ad-hoc requests before deciding whether to follow the full workflow.

- **AGENTS.md safety rules**: Updated rule 11 to describe the gate sequence as "recommended default" with scope assessment guidance. Rule 12 now clarifies that safety checks (--check-only, read-after-write, ID resolution, diagnosis) are non-negotiable, while workflow steps are recommended but can be negotiated for clearly trivial tasks.

## Notable Implementation Details

- All changes preserve the core safety invariants (--check-only, read-after-write verification, ID resolution) as non-negotiable regardless of task scope.
- The distinction between "trivial" and "non-trivial" is defined consistently: non-trivial = bug fixes, features, migrations; trivial = single-field config updates, copy fixes, isolated template tweaks explicitly scoped by the developer.
- Developer confirmation is now the gating mechanism for skipping workflow steps on trivial tasks, replacing the previous "no exceptions" enforcement model.

https://claude.ai/code/session_01N5x7vuZBtuAAyPiggTkjKt