### PR TITLE
fix(inventory): simplify portal inventory page with minimal default contract and --full mode 

### DIFF
--- a/src/cli/command-helpers.ts
+++ b/src/cli/command-helpers.ts
@@ -48,10 +48,13 @@ export async function withCommandContext<TOptions extends object>(
   options: TOptions,
   run: (context: CommandContext) => Promise<void>,
 ): Promise<void> {
+  const normalizedOptions = normalizeCommandOptions(options);
   const context = createCommandContext({
-    repoRoot: (options as {repoRoot?: string}).repoRoot,
-    format: (options as {format?: string}).format,
-    strict: (options as {strict?: boolean}).strict,
+    repoRoot: (normalizedOptions as {repoRoot?: string}).repoRoot,
+    format: (normalizedOptions as {format?: string}).format,
+    strict: (normalizedOptions as {strict?: boolean}).strict,
+    json: (normalizedOptions as {json?: boolean}).json,
+    ndjson: (normalizedOptions as {ndjson?: boolean}).ndjson,
   });
   await run(context);
 }
@@ -60,28 +63,42 @@ export function createFormattedAction<TOptions extends object, TResult>(
   run: (context: CommandContext, options: TOptions) => Promise<TResult>,
   renderOptions?: RenderOptions<TResult> | ((options: TOptions) => RenderOptions<TResult>),
 ): (options: TOptions) => Promise<void> {
-  return async (options) =>
-    withCommandContext(options, async (context) => {
-      const result = await run(context, options);
+  return async (options) => {
+    const normalizedOptions = normalizeCommandOptions(options);
+
+    return withCommandContext(normalizedOptions, async (context) => {
+      const result = await run(context, normalizedOptions);
       renderCommandResult(
         context,
         result,
-        typeof renderOptions === 'function' ? renderOptions(options) : renderOptions,
+        typeof renderOptions === 'function' ? renderOptions(normalizedOptions) : renderOptions,
       );
     });
+  };
 }
 
 export function createFormattedArgumentAction<TArg, TOptions extends object, TResult>(
   run: (context: CommandContext, argument: TArg, options: TOptions) => Promise<TResult>,
   renderOptions?: RenderOptions<TResult> | ((options: TOptions) => RenderOptions<TResult>),
 ): (argument: TArg, options: TOptions) => Promise<void> {
-  return async (argument, options) =>
-    withCommandContext(options, async (context) => {
-      const result = await run(context, argument, options);
+  return async (argument, options) => {
+    const normalizedOptions = normalizeCommandOptions(options);
+
+    return withCommandContext(normalizedOptions, async (context) => {
+      const result = await run(context, argument, normalizedOptions);
       renderCommandResult(
         context,
         result,
-        typeof renderOptions === 'function' ? renderOptions(options) : renderOptions,
+        typeof renderOptions === 'function' ? renderOptions(normalizedOptions) : renderOptions,
       );
     });
+  };
+}
+
+function normalizeCommandOptions<TOptions extends object>(options: TOptions): TOptions {
+  if (typeof (options as {opts?: unknown}).opts !== 'function') {
+    return options;
+  }
+
+  return (options as TOptions & {opts: () => TOptions}).opts();
 }

--- a/src/commands/context/context.command.ts
+++ b/src/commands/context/context.command.ts
@@ -32,7 +32,6 @@ Preferred format for automation:
         if (options.describe) {
           return {
             ok: true,
-            contractVersion: 2,
             fields: [
               'project.type',
               'project.root',

--- a/src/commands/doctor/doctor.command.ts
+++ b/src/commands/doctor/doctor.command.ts
@@ -48,7 +48,6 @@ Examples:
         if (options.listChecks) {
           return {
             ok: true,
-            contractVersion: 2,
             checks: report.checks.map((check) => ({
               id: check.id,
               scope: check.scope,

--- a/src/commands/liferay/inventory.command.ts
+++ b/src/commands/liferay/inventory.command.ts
@@ -10,6 +10,7 @@ import {
 } from '../../features/liferay/content/liferay-content-stats.js';
 import {
   formatLiferayInventoryPage,
+  projectLiferayInventoryPageJson,
   runLiferayInventoryPage,
 } from '../../features/liferay/inventory/liferay-inventory-page.js';
 import {
@@ -53,6 +54,10 @@ type InventoryPageCommandOptions = {
   friendlyUrl?: string;
   privateLayout?: boolean;
   verbose?: boolean;
+  full?: boolean;
+  format?: string;
+  json?: boolean;
+  ndjson?: boolean;
 };
 
 type InventoryStructuresCommandOptions = {
@@ -237,6 +242,7 @@ Notes:
       .option('--site <site>', 'Site friendly URL or numeric ID')
       .option('--friendly-url <friendlyUrl>', 'Friendly URL inside the site, like /home or /w/article')
       .option('--private-layout', 'Resolve the page as private when using --site + --friendly-url')
+      .option('--full', 'Include expanded inspection details in JSON output')
       .option('--verbose', 'Show fragment/widget details: element name, CSS classes, custom CSS'),
   ).action(
     createFormattedAction(
@@ -250,6 +256,7 @@ Notes:
         }),
       (options: InventoryPageCommandOptions) => ({
         text: (result) => formatLiferayInventoryPage(result, Boolean(options.verbose)),
+        json: (result) => projectLiferayInventoryPageJson(result, {full: Boolean(options.full)}),
       }),
     ),
   );

--- a/src/features/agent/agent-bootstrap-develop.ts
+++ b/src/features/agent/agent-bootstrap-develop.ts
@@ -14,14 +14,12 @@ export function buildDevelopBootstrapDoctor(context: AgentContextReport): Doctor
 
   return {
     ok: summary.failed === 0,
-    contractVersion: 2,
     generatedAt: new Date().toISOString(),
     ranChecks: ['basic'],
     summary,
     stamp: {
       projectType: context.project.type,
       portalUrl: context.liferay.portalUrl,
-      contractVersion: 2,
     },
     tools: buildDevelopTools(context),
     checks,

--- a/src/features/agent/agent-capabilities.ts
+++ b/src/features/agent/agent-capabilities.ts
@@ -11,7 +11,6 @@ export type AgentCapabilityStatus = {
 
 export type AgentCapabilitiesReport = {
   ok: true;
-  contractVersion: 2;
   platform: PlatformCapabilities;
   commands: Record<string, AgentCapabilityStatus>;
 };
@@ -35,7 +34,6 @@ export async function runAgentCapabilities(
 
   return {
     ok: true,
-    contractVersion: 2,
     platform,
     commands: {
       setup: capabilityStatus(
@@ -64,7 +62,6 @@ export async function runAgentCapabilities(
 
 export function formatAgentCapabilities(report: AgentCapabilitiesReport): string {
   return [
-    `Contract: agent-v${report.contractVersion}`,
     `Docker compose ready: ${report.commands.start.supported ? 'yes' : 'no'}`,
     `Reindex ready: ${report.commands.reindex.supported ? 'yes' : 'no'}`,
     `Worktrees: ${report.platform.supportsWorktrees ? 'yes' : 'no'}`,

--- a/src/features/agent/agent-context-types.ts
+++ b/src/features/agent/agent-context-types.ts
@@ -19,7 +19,6 @@ export type AgentContextIssue = {
 };
 export type AgentContextReport = {
   ok: true;
-  contractVersion: 2;
   generatedAt: string;
   project: {
     type: string;

--- a/src/features/agent/agent-context.ts
+++ b/src/features/agent/agent-context.ts
@@ -41,7 +41,6 @@ export async function runAgentContext(
 
   return {
     ok: true,
-    contractVersion: 2,
     generatedAt: new Date().toISOString(),
     project: {
       type: project.projectType,

--- a/src/features/doctor/doctor-format.ts
+++ b/src/features/doctor/doctor-format.ts
@@ -18,14 +18,12 @@ export function assembleDoctorReport(
 
   return {
     ok: summary.failed === 0,
-    contractVersion: 2,
     generatedAt: new Date().toISOString(),
     ranChecks,
     summary,
     stamp: {
       projectType: ctx.project.projectType,
       portalUrl: ctx.project.env.portalUrl,
-      contractVersion: 2,
     },
     tools: {
       git: toolStatusFromCheck(ctx.tools.git, normalizedChecks, 'git'),

--- a/src/features/doctor/doctor-types.ts
+++ b/src/features/doctor/doctor-types.ts
@@ -122,7 +122,6 @@ export type DoctorOsgiReport = {
 
 export type DoctorReport = {
   ok: boolean;
-  contractVersion: 2;
   generatedAt: string;
   ranChecks: DoctorCheckScope[];
   summary: {
@@ -135,7 +134,6 @@ export type DoctorReport = {
   stamp: {
     projectType: string;
     portalUrl: string | null;
-    contractVersion: 2;
   };
   tools: {
     git: DoctorToolStatus;

--- a/src/features/liferay/inventory/liferay-inventory-page-fetch.ts
+++ b/src/features/liferay/inventory/liferay-inventory-page-fetch.ts
@@ -54,7 +54,6 @@ export async function fetchSiteRootInventory(
   const layouts = await fetchLayoutsByParent(gateway, site.id, privateLayout, 0);
 
   return {
-    contractVersion: '2',
     pageType: 'siteRoot',
     siteName: site.name,
     siteFriendlyUrl: site.friendlyUrlPath,
@@ -109,7 +108,6 @@ export async function fetchDisplayPageInventory(
       : undefined;
 
   return {
-    contractVersion: '2',
     pageType: 'displayPage',
     pageSubtype: 'journalArticle',
     contentItemType: 'WebContent',
@@ -187,17 +185,22 @@ export async function fetchRegularPageInventory(
     layoutDetails: {layoutTemplateId?: string; targetUrl?: string},
     fragmentEntryLinks?: PageFragmentEntry[],
     widgets?: Array<{widgetName: string; portletId?: string; configuration?: Record<string, string>}>,
+    portlets?: PagePortletSummary[],
   ): {
     layoutTemplateId?: string;
     targetUrl?: string;
     fragmentCount: number;
     widgetCount: number;
   } {
+    const headlessWidgetCount = widgets?.length ?? 0;
+    const fragmentWidgetCount = fragmentEntryLinks?.filter((entry) => entry.type === 'widget').length ?? 0;
+    const classicPortletCount = portlets?.length ?? 0;
+
     return {
       ...(layoutDetails.layoutTemplateId ? {layoutTemplateId: layoutDetails.layoutTemplateId} : {}),
       ...(layoutDetails.targetUrl ? {targetUrl: layoutDetails.targetUrl} : {}),
       fragmentCount: fragmentEntryLinks?.filter((entry) => entry.type === 'fragment').length ?? 0,
-      widgetCount: widgets?.length ?? fragmentEntryLinks?.filter((entry) => entry.type === 'widget').length ?? 0,
+      widgetCount: Math.max(headlessWidgetCount, fragmentWidgetCount, classicPortletCount),
     };
   }
 
@@ -289,7 +292,6 @@ export async function fetchRegularPageInventory(
   }
 
   return {
-    contractVersion: '2',
     pageType: 'regularPage',
     pageSubtype: layout.type ?? '',
     pageUiType: resolveRegularPageUiType(layout.type),
@@ -301,7 +303,7 @@ export async function fetchRegularPageInventory(
     ...(matchedLocale ? {matchedLocale, requestedFriendlyUrl: friendlyUrl} : {}),
     pageName: layout.nameCurrentValue ?? '',
     privateLayout,
-    pageSummary: buildRegularPageSummary(layoutDetails, fragmentEntryLinks, widgets),
+    pageSummary: buildRegularPageSummary(layoutDetails, fragmentEntryLinks, widgets, portlets),
     layout: {
       layoutId: Number(layout.layoutId ?? -1),
       plid: Number(layout.plid ?? -1),

--- a/src/features/liferay/inventory/liferay-inventory-page-json-schema.ts
+++ b/src/features/liferay/inventory/liferay-inventory-page-json-schema.ts
@@ -1,0 +1,231 @@
+import {z} from 'zod';
+
+const siteRootJsonSchema = z.object({
+  page: z.object({
+    type: z.literal('siteRoot'),
+    siteName: z.string().optional(),
+    siteFriendlyUrl: z.string(),
+    groupId: z.number(),
+    url: z.string(),
+  }),
+  pages: z.array(
+    z.object({
+      layoutId: z.number(),
+      friendlyUrl: z.string(),
+      name: z.string(),
+      type: z.string(),
+    }),
+  ),
+});
+
+const regularPageJsonSchema = z.object({
+  page: z.object({
+    type: z.literal('regularPage'),
+    subtype: z.string(),
+    uiType: z.string(),
+    siteName: z.string(),
+    siteFriendlyUrl: z.string(),
+    groupId: z.number(),
+    url: z.string(),
+    friendlyUrl: z.string(),
+    pageName: z.string(),
+    privateLayout: z.boolean(),
+    layoutId: z.number(),
+    plid: z.number(),
+    hidden: z.boolean(),
+  }),
+  summary: z
+    .object({
+      layoutTemplateId: z.string().optional(),
+      targetUrl: z.string().optional(),
+      fragmentCount: z.number(),
+      widgetCount: z.number(),
+    })
+    .optional(),
+  adminUrls: z.object({
+    view: z.string(),
+    edit: z.string(),
+    configureGeneral: z.string(),
+    configureDesign: z.string(),
+    configureSeo: z.string(),
+    configureOpenGraph: z.string(),
+    configureCustomMetaTags: z.string(),
+    translate: z.string(),
+  }),
+  configuration: z
+    .object({
+      general: z.record(z.string(), z.unknown()),
+      design: z.record(z.string(), z.unknown()),
+      seo: z.record(z.string(), z.unknown()),
+      openGraph: z.record(z.string(), z.unknown()),
+      customMetaTags: z.record(z.string(), z.unknown()),
+    })
+    .optional(),
+  components: z
+    .object({
+      fragments: z
+        .array(
+          z.object({
+            fragmentKey: z.string(),
+            fragmentSiteFriendlyUrl: z.string().optional(),
+            fragmentExportPath: z.string().optional(),
+            configuration: z.record(z.string(), z.string()).optional(),
+            contentSummary: z.string().optional(),
+          }),
+        )
+        .optional(),
+      widgets: z
+        .array(
+          z.object({
+            widgetName: z.string(),
+            portletId: z.string().optional(),
+            configuration: z.record(z.string(), z.string()).optional(),
+          }),
+        )
+        .optional(),
+      portlets: z
+        .array(
+          z.object({
+            columnId: z.string(),
+            position: z.number(),
+            portletId: z.string(),
+            portletName: z.string(),
+            instanceId: z.string().optional(),
+            configuration: z.record(z.string(), z.string()).optional(),
+          }),
+        )
+        .optional(),
+    })
+    .optional(),
+  contentRefs: z
+    .array(
+      z.object({
+        articleId: z.string(),
+        title: z.string(),
+        groupId: z.number().optional(),
+        siteId: z.number().optional(),
+        siteFriendlyUrl: z.string().optional(),
+        siteName: z.string().optional(),
+        structureKey: z.string().optional(),
+        structureSiteFriendlyUrl: z.string().optional(),
+        structureExportPath: z.string().optional(),
+        contentStructureId: z.number().optional(),
+        templateKey: z.string().optional(),
+        templateSiteFriendlyUrl: z.string().optional(),
+        templateExportPath: z.string().optional(),
+        widgetDefaultTemplate: z.string().optional(),
+        displayPageDefaultTemplate: z.string().optional(),
+      }),
+    )
+    .optional(),
+  capabilities: z.object({componentInspectionSupported: z.boolean()}).optional(),
+  full: z
+    .object({
+      layoutDetails: z
+        .object({
+          layoutTemplateId: z.string().optional(),
+          targetUrl: z.string().optional(),
+        })
+        .optional(),
+      configurationRaw: z.record(z.string(), z.unknown()).optional(),
+      portlets: z.array(z.record(z.string(), z.unknown())).optional(),
+      journalArticles: z.array(z.record(z.string(), z.unknown())).optional(),
+      contentStructures: z.array(z.record(z.string(), z.unknown())).optional(),
+      components: z
+        .object({
+          fragments: z.array(z.record(z.string(), z.unknown())).optional(),
+          widgets: z.array(z.record(z.string(), z.unknown())).optional(),
+        })
+        .optional(),
+    })
+    .optional(),
+});
+
+const displayPageJsonSchema = z.object({
+  page: z.object({
+    type: z.literal('displayPage'),
+    subtype: z.literal('journalArticle'),
+    contentItemType: z.literal('WebContent'),
+    siteName: z.string(),
+    siteFriendlyUrl: z.string(),
+    groupId: z.number(),
+    url: z.string(),
+    friendlyUrl: z.string(),
+  }),
+  article: z.object({
+    id: z.number(),
+    key: z.string(),
+    title: z.string(),
+    friendlyUrlPath: z.string(),
+    contentStructureId: z.number(),
+    groupId: z.number().optional(),
+    siteId: z.number().optional(),
+    siteFriendlyUrl: z.string().optional(),
+    siteName: z.string().optional(),
+    structureKey: z.string().optional(),
+    structureSiteFriendlyUrl: z.string().optional(),
+    structureExportPath: z.string().optional(),
+    templateKey: z.string().optional(),
+    templateSiteFriendlyUrl: z.string().optional(),
+    templateExportPath: z.string().optional(),
+    externalReferenceCode: z.string().optional(),
+    uuid: z.string().optional(),
+  }),
+  adminUrls: z
+    .object({
+      edit: z.string(),
+      translate: z.string(),
+    })
+    .optional(),
+  contentSummary: z
+    .object({
+      headline: z.string().optional(),
+      lead: z.string().optional(),
+    })
+    .optional(),
+  rendering: z
+    .object({
+      widgetDefaultTemplate: z.string().optional(),
+      displayPageDefaultTemplate: z.string().optional(),
+      displayPageDdmTemplates: z.array(z.string()).optional(),
+      hasWidgetRendering: z.boolean(),
+      hasDisplayPageRendering: z.boolean(),
+    })
+    .optional(),
+  taxonomy: z.object({categories: z.array(z.string())}).optional(),
+  lifecycle: z
+    .object({
+      availableLanguages: z.array(z.string()).optional(),
+      dateCreated: z.string().optional(),
+      dateModified: z.string().optional(),
+      datePublished: z.string().optional(),
+      neverExpire: z.boolean().optional(),
+    })
+    .optional(),
+  full: z
+    .object({
+      articleDetails: z
+        .object({
+          contentFields: z.array(z.record(z.string(), z.unknown())).optional(),
+          widgetTemplateCandidates: z.array(z.string()).optional(),
+          displayPageTemplateCandidates: z.array(z.string()).optional(),
+          taxonomyCategoryBriefs: z.array(z.record(z.string(), z.unknown())).optional(),
+          renderedContents: z.array(z.record(z.string(), z.unknown())).optional(),
+        })
+        .optional(),
+      contentStructures: z.array(z.record(z.string(), z.unknown())).optional(),
+    })
+    .optional(),
+});
+
+export const liferayInventoryPageJsonSchema = z.union([
+  siteRootJsonSchema,
+  regularPageJsonSchema,
+  displayPageJsonSchema,
+]);
+
+export type LiferayInventoryPageJsonResult = z.infer<typeof liferayInventoryPageJsonSchema>;
+
+export function validateLiferayInventoryPageJsonResult(result: unknown): LiferayInventoryPageJsonResult {
+  return liferayInventoryPageJsonSchema.parse(result);
+}

--- a/src/features/liferay/inventory/liferay-inventory-page-schema.ts
+++ b/src/features/liferay/inventory/liferay-inventory-page-schema.ts
@@ -76,7 +76,6 @@ const pageFragmentEntrySchema = z.object({
 });
 
 const siteRootResultSchema = z.object({
-  contractVersion: z.literal('2'),
   pageType: z.literal('siteRoot'),
   siteName: z.string(),
   siteFriendlyUrl: z.string(),
@@ -93,7 +92,6 @@ const siteRootResultSchema = z.object({
 });
 
 const displayPageResultSchema = z.object({
-  contractVersion: z.literal('2'),
   pageType: z.literal('displayPage'),
   pageSubtype: z.literal('journalArticle'),
   contentItemType: z.literal('WebContent'),
@@ -120,7 +118,6 @@ const displayPageResultSchema = z.object({
 });
 
 const regularPageResultSchema = z.object({
-  contractVersion: z.literal('2'),
   pageType: z.literal('regularPage'),
   pageSubtype: z.string(),
   pageUiType: z.string(),

--- a/src/features/liferay/inventory/liferay-inventory-page.ts
+++ b/src/features/liferay/inventory/liferay-inventory-page.ts
@@ -628,13 +628,17 @@ function stripHtml(value: string): string {
 }
 
 function decodeHtmlEntities(value: string): string {
+  const entityMap: Record<string, string> = {
+    '&nbsp;': ' ',
+    '&amp;': '&',
+    '&lt;': '<',
+    '&gt;': '>',
+    '&quot;': '"',
+    '&#39;': "'",
+  };
+
   return value
-    .replace(/&nbsp;/g, ' ')
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
+    .replace(/&(nbsp|amp|lt|gt|quot|#39);/g, (entity) => entityMap[entity] ?? entity)
     .replace(/\s+/g, ' ')
     .trim();
 }

--- a/src/features/liferay/inventory/liferay-inventory-page.ts
+++ b/src/features/liferay/inventory/liferay-inventory-page.ts
@@ -12,6 +12,10 @@ import {
   fetchSiteRootInventory,
   resolveRegularLayoutPageData,
 } from './liferay-inventory-page-fetch.js';
+import {
+  validateLiferayInventoryPageJsonResult,
+  type LiferayInventoryPageJsonResult,
+} from './liferay-inventory-page-json-schema.js';
 import {validateLiferayInventoryPageResultV2} from './liferay-inventory-page-schema.js';
 import type {
   ContentStructureSummary,
@@ -22,6 +26,7 @@ import type {HeadlessSitePagePayload} from '../page-layout/liferay-site-page-sha
 
 export {resolveInventoryPageRequest};
 export {formatLiferayInventoryPage} from './liferay-inventory-page-format.js';
+export type {LiferayInventoryPageJsonResult} from './liferay-inventory-page-json-schema.js';
 
 type InventoryPageDependencies = {
   apiClient?: HttpApiClient;
@@ -123,7 +128,6 @@ export type InventoryPageConfigurationRaw = {
 
 export type LiferayInventoryPageResult =
   | {
-      contractVersion: '2';
       pageType: 'siteRoot';
       siteName: string;
       siteFriendlyUrl: string;
@@ -132,7 +136,6 @@ export type LiferayInventoryPageResult =
       pages: Array<{layoutId: number; friendlyUrl: string; name: string; type: string}>;
     }
   | {
-      contractVersion: '2';
       pageType: 'displayPage';
       pageSubtype: 'journalArticle';
       contentItemType: 'WebContent';
@@ -156,7 +159,6 @@ export type LiferayInventoryPageResult =
       contentStructures?: ContentStructureSummary[];
     }
   | {
-      contractVersion: '2';
       pageType: 'regularPage';
       pageSubtype: string;
       pageUiType: string;
@@ -311,6 +313,334 @@ export async function runLiferayInventoryPage(
       request.localeHint,
     ),
   );
+}
+
+export function projectLiferayInventoryPageJson(
+  result: LiferayInventoryPageResult,
+  options?: {full?: boolean},
+): LiferayInventoryPageJsonResult {
+  if (result.pageType === 'displayPage') {
+    return validateLiferayInventoryPageJsonResult(projectDisplayPageJson(result, options));
+  }
+
+  if (result.pageType === 'siteRoot') {
+    return validateLiferayInventoryPageJsonResult({
+      page: {
+        type: 'siteRoot',
+        ...(result.siteName ? {siteName: result.siteName} : {}),
+        siteFriendlyUrl: result.siteFriendlyUrl,
+        groupId: result.groupId,
+        url: result.url,
+      },
+      pages: result.pages,
+    });
+  }
+
+  const fragments = (result.fragmentEntryLinks ?? [])
+    .filter((entry) => entry.type === 'fragment' && entry.fragmentKey)
+    .map((entry) => ({
+      fragmentKey: entry.fragmentKey!,
+      ...(entry.fragmentSiteFriendlyUrl ? {fragmentSiteFriendlyUrl: entry.fragmentSiteFriendlyUrl} : {}),
+      ...(entry.fragmentExportPath ? {fragmentExportPath: entry.fragmentExportPath} : {}),
+      ...(entry.configuration ? {configuration: entry.configuration} : {}),
+      ...(entry.contentSummary ? {contentSummary: entry.contentSummary} : {}),
+    }));
+
+  const widgets = (result.fragmentEntryLinks ?? [])
+    .filter((entry) => entry.type === 'widget' && entry.widgetName)
+    .map((entry) => ({
+      widgetName: entry.widgetName!,
+      ...(entry.portletId ? {portletId: entry.portletId} : {}),
+      ...(entry.configuration ? {configuration: entry.configuration} : {}),
+    }));
+
+  const portlets = (result.portlets ?? []).map((portlet) => ({
+    columnId: portlet.columnId,
+    position: portlet.position,
+    portletId: portlet.portletId,
+    portletName: portlet.portletName,
+    ...(portlet.instanceId ? {instanceId: portlet.instanceId} : {}),
+    ...(portlet.configuration ? {configuration: portlet.configuration} : {}),
+  }));
+
+  const minimalResult = {
+    page: {
+      type: 'regularPage',
+      subtype: result.pageSubtype,
+      uiType: result.pageUiType,
+      siteName: result.siteName,
+      siteFriendlyUrl: result.siteFriendlyUrl,
+      groupId: result.groupId,
+      url: result.url,
+      friendlyUrl: result.friendlyUrl,
+      pageName: result.pageName,
+      privateLayout: result.privateLayout,
+      layoutId: result.layout.layoutId,
+      plid: result.layout.plid,
+      hidden: result.layout.hidden,
+    },
+    ...(result.pageSummary ? {summary: result.pageSummary} : {}),
+    adminUrls: result.adminUrls,
+    ...(result.configurationTabs ? {configuration: result.configurationTabs} : {}),
+    ...(result.journalArticles && result.journalArticles.length > 0
+      ? {contentRefs: result.journalArticles.map(projectJournalArticleRef)}
+      : {}),
+    ...(fragments.length > 0 || widgets.length > 0 || portlets.length > 0
+      ? {
+          components: {
+            ...(fragments.length > 0 ? {fragments} : {}),
+            ...(widgets.length > 0 ? {widgets} : {}),
+            ...(portlets.length > 0 ? {portlets} : {}),
+          },
+        }
+      : {}),
+    ...(result.componentInspectionSupported !== undefined
+      ? {capabilities: {componentInspectionSupported: result.componentInspectionSupported}}
+      : {}),
+  };
+
+  if (!options?.full) {
+    return validateLiferayInventoryPageJsonResult(minimalResult);
+  }
+
+  const fullFragments = (result.fragmentEntryLinks ?? []).filter(
+    (entry) => entry.type === 'fragment' && entry.fragmentKey,
+  );
+  const fullWidgets = (result.fragmentEntryLinks ?? []).filter((entry) => entry.type === 'widget' && entry.widgetName);
+
+  return validateLiferayInventoryPageJsonResult({
+    ...minimalResult,
+    full: {
+      ...(Object.keys(result.layoutDetails).length > 0 ? {layoutDetails: result.layoutDetails} : {}),
+      ...(result.configurationRaw ? {configurationRaw: result.configurationRaw} : {}),
+      ...(result.portlets && result.portlets.length > 0 ? {portlets: result.portlets} : {}),
+      ...(result.journalArticles && result.journalArticles.length > 0 ? {journalArticles: result.journalArticles} : {}),
+      ...(result.contentStructures && result.contentStructures.length > 0
+        ? {contentStructures: result.contentStructures}
+        : {}),
+      ...(fullFragments.length > 0 || fullWidgets.length > 0
+        ? {
+            components: {
+              ...(fullFragments.length > 0 ? {fragments: fullFragments} : {}),
+              ...(fullWidgets.length > 0 ? {widgets: fullWidgets} : {}),
+            },
+          }
+        : {}),
+    },
+  });
+}
+
+function projectDisplayPageJson(
+  result: Extract<LiferayInventoryPageResult, {pageType: 'displayPage'}>,
+  options?: {full?: boolean},
+): LiferayInventoryPageJsonResult {
+  const articleDetails = result.journalArticles?.[0];
+  const contentSummary = buildDisplayContentSummary(articleDetails, result.article.title);
+  const rendering = buildDisplayRendering(articleDetails);
+  const taxonomy =
+    articleDetails?.taxonomyCategoryNames && articleDetails.taxonomyCategoryNames.length > 0
+      ? {categories: articleDetails.taxonomyCategoryNames}
+      : undefined;
+  const lifecycle = buildDisplayLifecycle(articleDetails);
+
+  const minimalResult = {
+    page: {
+      type: 'displayPage',
+      subtype: 'journalArticle',
+      contentItemType: 'WebContent',
+      siteName: result.siteName,
+      siteFriendlyUrl: result.siteFriendlyUrl,
+      groupId: result.groupId,
+      url: result.url,
+      friendlyUrl: result.friendlyUrl,
+    },
+    article: {
+      id: result.article.id,
+      key: result.article.key,
+      title: result.article.title,
+      friendlyUrlPath: result.article.friendlyUrlPath,
+      contentStructureId: result.article.contentStructureId,
+      ...(articleDetails?.groupId ? {groupId: articleDetails.groupId} : {}),
+      ...(articleDetails?.siteId ? {siteId: articleDetails.siteId} : {}),
+      ...(articleDetails?.siteFriendlyUrl ? {siteFriendlyUrl: articleDetails.siteFriendlyUrl} : {}),
+      ...(articleDetails?.siteName ? {siteName: articleDetails.siteName} : {}),
+      ...(articleDetails?.ddmStructureKey ? {structureKey: articleDetails.ddmStructureKey} : {}),
+      ...(articleDetails?.ddmStructureSiteFriendlyUrl
+        ? {structureSiteFriendlyUrl: articleDetails.ddmStructureSiteFriendlyUrl}
+        : {}),
+      ...(articleDetails?.structureExportPath ? {structureExportPath: articleDetails.structureExportPath} : {}),
+      ...(articleDetails?.ddmTemplateKey ? {templateKey: articleDetails.ddmTemplateKey} : {}),
+      ...(articleDetails?.ddmTemplateSiteFriendlyUrl
+        ? {templateSiteFriendlyUrl: articleDetails.ddmTemplateSiteFriendlyUrl}
+        : {}),
+      ...(articleDetails?.templateExportPath ? {templateExportPath: articleDetails.templateExportPath} : {}),
+      ...(articleDetails?.externalReferenceCode ? {externalReferenceCode: articleDetails.externalReferenceCode} : {}),
+      ...(articleDetails?.uuid ? {uuid: articleDetails.uuid} : {}),
+    },
+    ...(result.adminUrls ? {adminUrls: result.adminUrls} : {}),
+    ...(contentSummary ? {contentSummary} : {}),
+    ...(rendering ? {rendering} : {}),
+    ...(taxonomy ? {taxonomy} : {}),
+    ...(lifecycle ? {lifecycle} : {}),
+  };
+
+  if (!options?.full) {
+    return minimalResult as LiferayInventoryPageJsonResult;
+  }
+
+  return {
+    ...minimalResult,
+    full: {
+      ...(articleDetails
+        ? {
+            articleDetails: {
+              ...(articleDetails.contentFields && articleDetails.contentFields.length > 0
+                ? {contentFields: articleDetails.contentFields}
+                : {}),
+              ...(articleDetails.widgetTemplateCandidates && articleDetails.widgetTemplateCandidates.length > 0
+                ? {widgetTemplateCandidates: articleDetails.widgetTemplateCandidates}
+                : {}),
+              ...(articleDetails.displayPageTemplateCandidates &&
+              articleDetails.displayPageTemplateCandidates.length > 0
+                ? {displayPageTemplateCandidates: articleDetails.displayPageTemplateCandidates}
+                : {}),
+              ...(articleDetails.taxonomyCategoryBriefs && articleDetails.taxonomyCategoryBriefs.length > 0
+                ? {taxonomyCategoryBriefs: articleDetails.taxonomyCategoryBriefs}
+                : {}),
+              ...(articleDetails.renderedContents && articleDetails.renderedContents.length > 0
+                ? {renderedContents: articleDetails.renderedContents}
+                : {}),
+            },
+          }
+        : {}),
+      ...(result.contentStructures && result.contentStructures.length > 0
+        ? {contentStructures: result.contentStructures}
+        : {}),
+    },
+  } as LiferayInventoryPageJsonResult;
+}
+
+function buildDisplayContentSummary(articleDetails: JournalArticleSummary | undefined, fallbackTitle: string) {
+  const headline = articleDetails?.title ? truncateText(stripHtml(articleDetails.title), 240) : fallbackTitle;
+  const lead = articleDetails?.description ? truncateText(stripHtml(articleDetails.description), 240) : undefined;
+
+  if (!headline && !lead) {
+    return undefined;
+  }
+
+  return {
+    ...(headline ? {headline: decodeHtmlEntities(headline)} : {}),
+    ...(lead ? {lead: decodeHtmlEntities(lead)} : {}),
+  };
+}
+
+function projectJournalArticleRef(article: JournalArticleSummary) {
+  return {
+    articleId: article.articleId,
+    title: article.title,
+    ...(article.groupId ? {groupId: article.groupId} : {}),
+    ...(article.siteId ? {siteId: article.siteId} : {}),
+    ...(article.siteFriendlyUrl ? {siteFriendlyUrl: article.siteFriendlyUrl} : {}),
+    ...(article.siteName ? {siteName: article.siteName} : {}),
+    ...(article.ddmStructureKey ? {structureKey: article.ddmStructureKey} : {}),
+    ...(article.ddmStructureSiteFriendlyUrl ? {structureSiteFriendlyUrl: article.ddmStructureSiteFriendlyUrl} : {}),
+    ...(article.structureExportPath ? {structureExportPath: article.structureExportPath} : {}),
+    ...(article.contentStructureId ? {contentStructureId: article.contentStructureId} : {}),
+    ...(article.ddmTemplateKey ? {templateKey: article.ddmTemplateKey} : {}),
+    ...(article.ddmTemplateSiteFriendlyUrl ? {templateSiteFriendlyUrl: article.ddmTemplateSiteFriendlyUrl} : {}),
+    ...(article.templateExportPath ? {templateExportPath: article.templateExportPath} : {}),
+    ...(article.widgetDefaultTemplate ? {widgetDefaultTemplate: article.widgetDefaultTemplate} : {}),
+    ...(article.displayPageDefaultTemplate ? {displayPageDefaultTemplate: article.displayPageDefaultTemplate} : {}),
+  };
+}
+
+function buildDisplayRendering(articleDetails?: JournalArticleSummary) {
+  if (!articleDetails) {
+    return undefined;
+  }
+
+  const derivedDisplayPageTemplate = articleDetails.renderedContents
+    ?.map((item) => item as Record<string, unknown>)
+    .find(
+      (candidate) =>
+        candidate.markedAsDefault === true &&
+        typeof candidate.contentTemplateName === 'string' &&
+        typeof candidate.renderedContentURL === 'string' &&
+        candidate.renderedContentURL.includes('/rendered-content-by-display-page/'),
+    );
+  const displayPageDefaultTemplate =
+    articleDetails.displayPageDefaultTemplate ??
+    (derivedDisplayPageTemplate?.contentTemplateName as string | undefined);
+
+  const hasWidgetRendering = Boolean(
+    articleDetails.widgetDefaultTemplate ||
+    articleDetails.widgetHeadlessDefaultTemplate ||
+    articleDetails.widgetTemplateCandidates?.length,
+  );
+  const hasDisplayPageRendering = Boolean(
+    displayPageDefaultTemplate || articleDetails.displayPageTemplateCandidates?.length,
+  );
+
+  if (!hasWidgetRendering && !hasDisplayPageRendering) {
+    return undefined;
+  }
+
+  return {
+    ...(articleDetails.widgetDefaultTemplate ? {widgetDefaultTemplate: articleDetails.widgetDefaultTemplate} : {}),
+    ...(displayPageDefaultTemplate ? {displayPageDefaultTemplate} : {}),
+    ...(articleDetails.displayPageDdmTemplates && articleDetails.displayPageDdmTemplates.length > 0
+      ? {displayPageDdmTemplates: articleDetails.displayPageDdmTemplates}
+      : {}),
+    hasWidgetRendering,
+    hasDisplayPageRendering,
+  };
+}
+
+function buildDisplayLifecycle(articleDetails?: JournalArticleSummary) {
+  if (!articleDetails) {
+    return undefined;
+  }
+
+  if (
+    !articleDetails.availableLanguages?.length &&
+    !articleDetails.dateCreated &&
+    !articleDetails.dateModified &&
+    !articleDetails.datePublished &&
+    articleDetails.neverExpire === undefined
+  ) {
+    return undefined;
+  }
+
+  return {
+    ...(articleDetails.availableLanguages?.length ? {availableLanguages: articleDetails.availableLanguages} : {}),
+    ...(articleDetails.dateCreated ? {dateCreated: articleDetails.dateCreated} : {}),
+    ...(articleDetails.dateModified ? {dateModified: articleDetails.dateModified} : {}),
+    ...(articleDetails.datePublished ? {datePublished: articleDetails.datePublished} : {}),
+    ...(articleDetails.neverExpire !== undefined ? {neverExpire: articleDetails.neverExpire} : {}),
+  };
+}
+
+function stripHtml(value: string): string {
+  return value
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function decodeHtmlEntities(value: string): string {
+  return value
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function truncateText(value: string, maxLength: number): string {
+  return value.length > maxLength ? `${value.slice(0, maxLength - 1).trimEnd()}…` : value;
 }
 
 async function resolvePortalHomeRequest(config: AppConfig) {

--- a/templates/ai/project/skills/issue-engineering/references/intake.md
+++ b/templates/ai/project/skills/issue-engineering/references/intake.md
@@ -27,6 +27,14 @@ If the issue URL is production, use it only as an identifier for discovery. Do
 not use the production host for browser reproduction. Reuse the resolved
 local/runtime URL from `ldev`.
 
+The default output contains the fields needed for most intake tasks (page type,
+article identity, rendering templates, taxonomy, admin URLs). If you need
+content fields, raw template candidates, or the full page definition, add `--full`:
+
+```bash
+ldev portal inventory page --url <issueUrl> --json --full
+```
+
 3. If there is no exact URL, traverse the site:
 
 ```bash

--- a/templates/ai/skills/automating-browser-tests/SKILL.md
+++ b/templates/ai/skills/automating-browser-tests/SKILL.md
@@ -20,7 +20,7 @@ ldev portal inventory page --url <fullUrl> --json
 Before opening Playwright, lock these fields from bootstrap:
 
 - `context.liferay.portalUrl`: use this exact host for the whole browser session — do not mix `localhost` and `127.0.0.1`.
-- `ldev portal inventory page --url <fullUrl> --json` → `adminUrls.*`, `page.siteFriendlyUrl`, `page.groupId`, `page.plid`.
+- `ldev portal inventory page --url <fullUrl> --json` → `adminUrls.*`, `page.siteFriendlyUrl`, `page.groupId`, and `page.plid` for regular pages.
 
 Check `doctor.tools.playwrightCli.status == "pass"` before starting any browser flow.
 

--- a/templates/ai/skills/automating-browser-tests/SKILL.md
+++ b/templates/ai/skills/automating-browser-tests/SKILL.md
@@ -20,7 +20,7 @@ ldev portal inventory page --url <fullUrl> --json
 Before opening Playwright, lock these fields from bootstrap:
 
 - `context.liferay.portalUrl`: use this exact host for the whole browser session — do not mix `localhost` and `127.0.0.1`.
-- `ldev portal inventory page --url <fullUrl> --json` → `adminUrls.*`, `siteFriendlyUrl`, `groupId`, `layout.plid`.
+- `ldev portal inventory page --url <fullUrl> --json` → `adminUrls.*`, `page.siteFriendlyUrl`, `page.groupId`, `page.plid`.
 
 Check `doctor.tools.playwrightCli.status == "pass"` before starting any browser flow.
 

--- a/templates/ai/skills/liferay-expert/SKILL.md
+++ b/templates/ai/skills/liferay-expert/SKILL.md
@@ -50,6 +50,13 @@ ldev portal inventory structures --site /<site> --json
 ldev portal inventory templates --site /<site> --json
 ```
 
+The default page output is sufficient for routing. Add `--full` when the task
+requires content fields, all template candidates, or the raw page definition:
+
+```bash
+ldev portal inventory page --url <fullUrl> --json --full
+```
+
 ## Routing rules
 
 - If the cause is not clear yet:

--- a/templates/ai/skills/liferay-expert/references/site-objects.md
+++ b/templates/ai/skills/liferay-expert/references/site-objects.md
@@ -2,18 +2,36 @@
 
 ## Display Page Templates
 
-`ldev` does not expose dedicated Display Page Template commands yet.
-Verify MCP availability and use it for inspection:
+`ldev portal inventory page --url <url> --json` exposes Display Page Template
+metadata directly in the default output. No MCP or separate lookup is needed for
+the most common discovery tasks.
+
+For a display page URL, the result includes:
+
+- `page.type: "displayPage"` — confirms the page type
+- `article.*` — article `id`, `key`, `title`, `structureKey`, `externalReferenceCode`, `uuid`
+- `rendering.displayPageDefaultTemplate` — the active Display Page Template key
+- `rendering.displayPageDdmTemplates` — DDM template keys bound to the display page template
+- `rendering.widgetDefaultTemplate` — fallback widget template key
+- `taxonomy.categories` — category names applied to the article
+- `lifecycle.*` — `availableLanguages`, `dateCreated`, `dateModified`, `datePublished`, `neverExpire`
+
+For the full raw data (all content fields, all template candidates, all taxonomy briefs):
+
+```bash
+ldev portal inventory page --url <url> --json --full
+```
+
+`full.articleDetails.displayPageTemplateCandidates` lists every compatible Display Page
+Template key. `full.articleDetails.contentFields` contains all structured content fields.
+`full.contentStructures` exposes the owning structure with its `exportPath`.
+
+For Display Page Template resource management not yet exposed by `ldev` (creating,
+configuring), verify MCP availability:
 
 ```bash
 ldev mcp check --json
 ```
-
-If MCP is available, use OpenAPI discovery to find the relevant endpoint.
-Without MCP, `ldev portal inventory page --url <url> --json` can still confirm
-whether the URL resolves as a display page (`pageType: displayPage`) and which
-article/structure it serves, but it does not expose dedicated Display Page
-Template metadata yet.
 
 ## Navigation Menus
 

--- a/templates/ai/skills/troubleshooting-liferay/SKILL.md
+++ b/templates/ai/skills/troubleshooting-liferay/SKILL.md
@@ -79,6 +79,17 @@ ldev portal inventory templates --site /<site> --json
 For structure/template incidents, treat `--with-templates` as the default
 discovery path to avoid separate lookup rounds.
 
+When the default output is not enough (e.g. you need content fields, all template
+candidates, or the raw page definition), add `--full`:
+
+```bash
+ldev portal inventory page --url <fullUrl> --json --full
+```
+
+`--full` adds for display pages: `full.articleDetails.contentFields`, all template
+candidates, all `renderedContents`. For regular pages: `full.configurationRaw` and
+`full.components.fragments` with `editableFields`.
+
 ### Production reproduction
 
 When the issue does not reproduce with clean local data, bring production-like

--- a/templates/ai/workspace-rules/ldev-portal-discovery.md
+++ b/templates/ai/workspace-rules/ldev-portal-discovery.md
@@ -23,6 +23,18 @@ Why:
 - stable JSON contract
 - better page/context enrichment than low-level API assembly
 
+The default output is minimal and suitable for most discovery tasks. Use `--full` when
+you need raw data not present by default:
+
+```bash
+ldev portal inventory page --url /web/my-site/home --json --full
+```
+
+- For **display pages**: `full.articleDetails.contentFields`, all template candidates,
+  all `renderedContents`, `full.contentStructures` with `exportPath`.
+- For **regular pages**: `full.configurationRaw` (full `sitePageMetadata` + `pageDefinition`),
+  `full.components.fragments` (with `editableFields` and `heroText`).
+
 For the full workflow, route to vendor skills such as:
 
 - `liferay-expert`

--- a/tests/integration/agent-contract.integration.test.ts
+++ b/tests/integration/agent-contract.integration.test.ts
@@ -8,7 +8,6 @@ import {createLiferayCliRepoFixture, parseTestJson} from '../../src/testing/cli-
 
 type AgentContextPayload = {
   ok: boolean;
-  contractVersion: number;
   project: Record<string, unknown>;
   paths: Record<string, unknown>;
   runtime: Record<string, unknown>;
@@ -35,7 +34,6 @@ describe('agent contract integration', () => {
     expect(result.exitCode).toBe(0);
     const parsed = parseTestJson<AgentContextPayload>(result.stdout);
     expect(parsed.ok).toBe(true);
-    expect(parsed.contractVersion).toBe(2);
     expect(parsed.project).toHaveProperty('root');
     expect(parsed.paths).toHaveProperty('dockerDir');
     expect(parsed.paths).toHaveProperty('resources');
@@ -53,7 +51,6 @@ describe('agent contract integration', () => {
     expect(result.exitCode).toBe(0);
     const parsed = parseTestJson<AgentContextPayload>(result.stdout);
     expect(parsed.ok).toBe(true);
-    expect(parsed.contractVersion).toBe(2);
     expect(parsed.commands).toHaveProperty('start');
     expect(parsed.commands).toHaveProperty('liferay');
   }, 30000);

--- a/tests/integration/doctor-json.test.ts
+++ b/tests/integration/doctor-json.test.ts
@@ -5,7 +5,6 @@ import {parseTestJson} from '../../src/testing/cli-test-helpers.js';
 
 type DoctorPayload = {
   ok: boolean;
-  contractVersion: number;
   summary: Record<string, unknown>;
   checks: unknown[];
   stamp: Record<string, unknown>;
@@ -25,7 +24,6 @@ describe('doctor integration', () => {
     expect([0, 1]).toContain(result.exitCode);
     const parsed = parseTestJson<DoctorPayload>(result.stdout);
     expect(typeof parsed.ok).toBe('boolean');
-    expect(parsed.contractVersion).toBe(2);
     expect(parsed.summary).toHaveProperty('passed');
     expect(parsed.summary).toHaveProperty('durationMs');
     expect(Array.isArray(parsed.checks)).toBe(true);

--- a/tests/integration/output-format-aliases.integration.test.ts
+++ b/tests/integration/output-format-aliases.integration.test.ts
@@ -5,7 +5,6 @@ import {parseTestJson} from '../../src/testing/cli-test-helpers.js';
 
 type ContextPayload = {
   ok: boolean;
-  contractVersion: number;
 };
 
 describe('output format aliases integration', () => {
@@ -15,7 +14,6 @@ describe('output format aliases integration', () => {
     expect(result.exitCode).toBe(0);
     const parsed = parseTestJson<ContextPayload>(result.stdout);
     expect(parsed.ok).toBe(true);
-    expect(parsed.contractVersion).toBe(2);
   }, 30000);
 
   test('--ndjson is equivalent to --format ndjson', async () => {
@@ -26,6 +24,5 @@ describe('output format aliases integration', () => {
     expect(lines).toHaveLength(1);
     const parsed = parseTestJson<ContextPayload>(lines[0]);
     expect(parsed.ok).toBe(true);
-    expect(parsed.contractVersion).toBe(2);
   }, 30000);
 });

--- a/tests/smoke/liferay-inventory-smoke.test.ts
+++ b/tests/smoke/liferay-inventory-smoke.test.ts
@@ -15,10 +15,149 @@ type InventoryPagesPayload = {
   pages: Array<{children?: Array<{fullUrl: string}>; targetUrl?: string}>;
 };
 
-type InventoryPagePayload = {
-  pageType: string;
-  article: {key: string};
-  journalArticles: Array<{contentFields: Array<{value: string}>}>;
+type MinimalRegularPagePayload = {
+  page: {
+    type: string;
+    subtype: string;
+    uiType: string;
+    siteFriendlyUrl: string;
+    groupId: number;
+    url: string;
+    friendlyUrl: string;
+    pageName: string;
+    privateLayout: boolean;
+    layoutId: number;
+    plid: number;
+    hidden: boolean;
+  };
+  summary: {
+    layoutTemplateId?: string;
+    targetUrl?: string;
+    fragmentCount: number;
+    widgetCount: number;
+  };
+  adminUrls: {
+    view: string;
+    edit: string;
+    configureGeneral: string;
+    configureDesign: string;
+    configureSeo: string;
+    configureOpenGraph: string;
+    configureCustomMetaTags: string;
+    translate: string;
+  };
+  configuration: {
+    general: {
+      type: string;
+      name: string;
+      friendlyUrl: string;
+      privateLayout: boolean;
+    };
+  };
+  components?: {
+    fragments?: Array<{fragmentKey: string}>;
+  };
+  capabilities?: {
+    componentInspectionSupported?: boolean;
+  };
+  layoutDetails?: unknown;
+  configurationRaw?: unknown;
+  fragmentEntryLinks?: unknown;
+  journalArticles?: unknown;
+  contentStructures?: unknown;
+};
+
+type FullRegularPagePayload = MinimalRegularPagePayload & {
+  full: {
+    layoutDetails?: {
+      layoutTemplateId?: string;
+      targetUrl?: string;
+    };
+    journalArticles?: Array<{articleId: string}>;
+    contentStructures?: Array<{contentStructureId: number}>;
+    components?: {
+      fragments?: Array<{fragmentKey?: string}>;
+      widgets?: Array<{
+        widgetName?: string;
+        portletId?: string;
+        configuration?: Record<string, string>;
+        elementName?: string;
+        cssClasses?: string[];
+        customCSS?: string;
+      }>;
+    };
+  };
+};
+
+type MinimalDisplayPagePayload = {
+  page: {
+    type: string;
+    subtype: string;
+    contentItemType: string;
+    siteFriendlyUrl: string;
+    groupId: number;
+    url: string;
+    friendlyUrl: string;
+  };
+  article: {
+    id: number;
+    key: string;
+    title: string;
+    friendlyUrlPath: string;
+    contentStructureId: number;
+    structureKey?: string;
+    externalReferenceCode?: string;
+    uuid?: string;
+  };
+  adminUrls?: {
+    edit: string;
+    translate: string;
+  };
+  contentSummary?: {
+    headline?: string;
+    lead?: string;
+  };
+  rendering?: {
+    widgetDefaultTemplate?: string;
+    displayPageDefaultTemplate?: string;
+    displayPageDdmTemplates?: string[];
+    hasWidgetRendering: boolean;
+    hasDisplayPageRendering: boolean;
+  };
+  taxonomy?: {
+    categories: string[];
+  };
+  lifecycle?: {
+    availableLanguages?: string[];
+    dateCreated?: string;
+    dateModified?: string;
+    datePublished?: string;
+    neverExpire?: boolean;
+  };
+  journalArticles?: unknown;
+  contentStructures?: unknown;
+};
+
+type FullDisplayPagePayload = MinimalDisplayPagePayload & {
+  full: {
+    articleDetails?: {
+      contentFields?: Array<{name: string; value: string}>;
+      renderedContents?: Array<{contentTemplateName?: string}>;
+      taxonomyCategoryBriefs?: Array<{taxonomyCategoryName?: string}>;
+    };
+    contentStructures?: Array<{contentStructureId: number}>;
+  };
+};
+
+type SiteRootPayload = {
+  page: {
+    type: 'siteRoot';
+    siteName?: string;
+    siteFriendlyUrl: string;
+    groupId: number;
+    url: string;
+  };
+  pages: Array<{layoutId: number; friendlyUrl: string; name: string; type: string}>;
 };
 
 describe('liferay inventory smoke', () => {
@@ -266,6 +405,9 @@ describe('liferay inventory smoke', () => {
                   pageElements: [
                     {
                       type: 'Widget',
+                      name: 'Main journal widget',
+                      cssClasses: ['widget-shell', 'widget-shell-primary'],
+                      customCSS: '.widget-shell-primary { color: red; }',
                       definition: {
                         widgetInstance: {
                           widgetName: 'com_liferay_journal_content_web_portlet_JournalContentPortlet',
@@ -341,7 +483,350 @@ describe('liferay inventory smoke', () => {
     expect(output.stderr()).toBe('');
   });
 
-  test('dev-cli liferay inventory page supports json output for a display page', async () => {
+  test('dev-cli liferay inventory page --json returns the site root contract for a site home url', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: string | URL | Request) => {
+        await Promise.resolve();
+        const url = toTestRequestUrl(input);
+
+        if (url.endsWith('/o/oauth2/token')) {
+          return new Response('{"access_token":"token-12345678","token_type":"Bearer","expires_in":3600}', {
+            status: 200,
+          });
+        }
+
+        if (url.includes('/by-friendly-url-path/guest')) {
+          return new Response('{"id":20121,"friendlyUrlPath":"/guest","name":"Guest"}', {status: 200});
+        }
+
+        if (url.includes('parentLayoutId=0')) {
+          return new Response(
+            '[{"layoutId":11,"plid":1011,"type":"content","nameCurrentValue":"Home","friendlyURL":"/home","hidden":false}]',
+            {status: 200},
+          );
+        }
+
+        throw new Error(`Unexpected URL ${url}`);
+      }),
+    );
+
+    const originalCwd = process.cwd();
+    process.chdir(repoRoot);
+    try {
+      const cli = createCli();
+      cli.exitOverride();
+      await cli.parseAsync(['liferay', 'inventory', 'page', '--url', '/web/guest/', '--json'], {from: 'user'});
+    } finally {
+      process.chdir(originalCwd);
+    }
+
+    const parsed = parseTestJson<SiteRootPayload>(output.stdout());
+    expect(parsed).toMatchObject({
+      page: {
+        type: 'siteRoot',
+        siteFriendlyUrl: '/guest',
+        groupId: 20121,
+        url: '/web/guest/',
+      },
+      pages: [{layoutId: 11, friendlyUrl: '/home', name: 'Home', type: 'content'}],
+    });
+    expect(parsed).not.toHaveProperty('full');
+    expect(output.stderr()).toBe('');
+  });
+
+  test('dev-cli liferay inventory page --json returns the minimal regular page contract by default', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: string | URL | Request) => {
+        await Promise.resolve();
+        const url = toTestRequestUrl(input);
+
+        if (url.endsWith('/o/oauth2/token')) {
+          return new Response('{"access_token":"token-12345678","token_type":"Bearer","expires_in":3600}', {
+            status: 200,
+          });
+        }
+
+        if (url.includes('/by-friendly-url-path/guest')) {
+          return new Response('{"id":20121,"friendlyUrlPath":"/guest","name":"Guest"}', {status: 200});
+        }
+
+        if (url.includes('parentLayoutId=0')) {
+          return new Response(
+            '[{"layoutId":11,"plid":1011,"type":"content","nameCurrentValue":"Home","friendlyURL":"/home","hidden":false,"typeSettings":"layout-template-id=2_columns\\nurl=https://example.test"}]',
+            {status: 200},
+          );
+        }
+
+        if (url.includes('parentLayoutId=11')) {
+          return new Response('[]', {status: 200});
+        }
+
+        if (url.includes('/site-pages/home?fields=pageDefinition')) {
+          return new Response(
+            JSON.stringify({
+              pageDefinition: {
+                pageElement: {
+                  type: 'Root',
+                  pageElements: [
+                    {
+                      type: 'Fragment',
+                      definition: {
+                        fragment: {key: 'banner'},
+                      },
+                    },
+                    {
+                      type: 'Widget',
+                      name: 'Main journal widget',
+                      cssClasses: ['widget-shell', 'widget-shell-primary'],
+                      customCSS: '.widget-shell-primary { color: red; }',
+                      definition: {
+                        widgetInstance: {
+                          widgetName: 'com_liferay_journal_content_web_portlet_JournalContentPortlet',
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            }),
+            {status: 200},
+          );
+        }
+
+        if (url.includes('/fragment.fragmententrylink/get-fragment-entry-links')) {
+          return new Response(
+            JSON.stringify([
+              {
+                portletId: 'com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_abc',
+                editableValues: JSON.stringify({
+                  journal_content: {
+                    portletPreferencesMap: {
+                      articleId: ['ART-001'],
+                      groupId: ['20121'],
+                      ddmTemplateKey: ['TPL-1'],
+                    },
+                  },
+                }),
+              },
+            ]),
+            {status: 200},
+          );
+        }
+
+        if (url.includes('/journal.journalarticle/get-latest-article')) {
+          return new Response(
+            '{"id":41001,"articleId":"ART-001","titleCurrentValue":"Home article","ddmStructureKey":"BASIC"}',
+            {status: 200},
+          );
+        }
+
+        if (url.endsWith('/o/headless-delivery/v1.0/structured-contents/41001')) {
+          return new Response(
+            '{"id":41001,"contentStructureId":301,"contentFields":[{"label":"Headline","name":"headline","dataType":"string","contentFieldValue":{"data":"Hello"}}]}',
+            {status: 200},
+          );
+        }
+
+        if (url.endsWith('/o/headless-delivery/v1.0/content-structures/301')) {
+          return new Response('{"id":301,"name":"Basic Web Content"}', {status: 200});
+        }
+
+        if (url.includes('/api/jsonws/classname/fetch-class-name?value=com.liferay.portal.kernel.model.Layout')) {
+          return new Response('{"classNameId":20006}', {status: 200});
+        }
+
+        throw new Error(`Unexpected URL ${url}`);
+      }),
+    );
+
+    const originalCwd = process.cwd();
+    process.chdir(repoRoot);
+    try {
+      const cli = createCli();
+      cli.exitOverride();
+      await cli.parseAsync(['liferay', 'inventory', 'page', '--url', '/web/guest/home', '--json'], {from: 'user'});
+    } finally {
+      process.chdir(originalCwd);
+    }
+
+    const parsed = parseTestJson<MinimalRegularPagePayload>(output.stdout());
+    expect(parsed.page).toMatchObject({
+      type: 'regularPage',
+      subtype: 'content',
+      uiType: 'Content Page',
+      siteFriendlyUrl: '/guest',
+      groupId: 20121,
+      url: '/web/guest/home',
+      friendlyUrl: '/home',
+      pageName: 'Home',
+      privateLayout: false,
+      layoutId: 11,
+      plid: 1011,
+      hidden: false,
+    });
+    expect(parsed.summary).toMatchObject({
+      layoutTemplateId: '2_columns',
+      targetUrl: 'https://example.test',
+      fragmentCount: 1,
+      widgetCount: 1,
+    });
+    expect(parsed.configuration.general).toMatchObject({
+      type: 'content',
+      name: 'Home',
+      friendlyUrl: '/home',
+      privateLayout: false,
+    });
+    expect(parsed.components?.fragments).toEqual([{fragmentKey: 'banner'}]);
+    expect(parsed.capabilities).toEqual({componentInspectionSupported: true});
+    expect(parsed).not.toHaveProperty('layoutDetails');
+    expect(parsed).not.toHaveProperty('configurationRaw');
+    expect(parsed).not.toHaveProperty('fragmentEntryLinks');
+    expect(parsed).not.toHaveProperty('journalArticles');
+    expect(parsed).not.toHaveProperty('contentStructures');
+    expect(parsed).not.toHaveProperty('full');
+    expect(output.stderr()).toBe('');
+  });
+
+  test('dev-cli liferay inventory page --json --full returns the regular page minimal contract plus inspection details', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: string | URL | Request) => {
+        await Promise.resolve();
+        const url = toTestRequestUrl(input);
+
+        if (url.endsWith('/o/oauth2/token')) {
+          return new Response('{"access_token":"token-12345678","token_type":"Bearer","expires_in":3600}', {
+            status: 200,
+          });
+        }
+
+        if (url.includes('/by-friendly-url-path/guest')) {
+          return new Response('{"id":20121,"friendlyUrlPath":"/guest","name":"Guest"}', {status: 200});
+        }
+
+        if (url.includes('parentLayoutId=0')) {
+          return new Response(
+            '[{"layoutId":11,"plid":1011,"type":"content","nameCurrentValue":"Home","friendlyURL":"/home","hidden":false,"typeSettings":"layout-template-id=2_columns\\nurl=https://example.test"}]',
+            {status: 200},
+          );
+        }
+
+        if (url.includes('parentLayoutId=11')) {
+          return new Response('[]', {status: 200});
+        }
+
+        if (url.includes('/site-pages/home?fields=pageDefinition')) {
+          return new Response(
+            JSON.stringify({
+              pageDefinition: {
+                pageElement: {
+                  type: 'Root',
+                  pageElements: [
+                    {
+                      type: 'Fragment',
+                      definition: {
+                        fragment: {key: 'banner'},
+                      },
+                    },
+                    {
+                      type: 'Widget',
+                      name: 'Main journal widget',
+                      cssClasses: ['widget-shell', 'widget-shell-primary'],
+                      customCSS: '.widget-shell-primary { color: red; }',
+                      definition: {
+                        widgetInstance: {
+                          widgetName: 'com_liferay_journal_content_web_portlet_JournalContentPortlet',
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            }),
+            {status: 200},
+          );
+        }
+
+        if (url.includes('/fragment.fragmententrylink/get-fragment-entry-links')) {
+          return new Response(
+            JSON.stringify([
+              {
+                portletId: 'com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_abc',
+                editableValues: JSON.stringify({
+                  journal_content: {
+                    portletPreferencesMap: {
+                      articleId: ['ART-001'],
+                      groupId: ['20121'],
+                    },
+                  },
+                }),
+              },
+            ]),
+            {status: 200},
+          );
+        }
+
+        if (url.includes('/journal.journalarticle/get-latest-article')) {
+          return new Response(
+            '{"id":41001,"articleId":"ART-001","titleCurrentValue":"Home article","ddmStructureKey":"BASIC"}',
+            {status: 200},
+          );
+        }
+
+        if (url.endsWith('/o/headless-delivery/v1.0/structured-contents/41001')) {
+          return new Response(
+            '{"id":41001,"contentStructureId":301,"contentFields":[{"label":"Headline","name":"headline","dataType":"string","contentFieldValue":{"data":"Hello"}}]}',
+            {status: 200},
+          );
+        }
+
+        if (url.endsWith('/o/headless-delivery/v1.0/content-structures/301')) {
+          return new Response('{"id":301,"name":"Basic Web Content"}', {status: 200});
+        }
+
+        if (url.includes('/api/jsonws/classname/fetch-class-name?value=com.liferay.portal.kernel.model.Layout')) {
+          return new Response('{"classNameId":20006}', {status: 200});
+        }
+
+        throw new Error(`Unexpected URL ${url}`);
+      }),
+    );
+
+    const originalCwd = process.cwd();
+    process.chdir(repoRoot);
+    try {
+      const cli = createCli();
+      cli.exitOverride();
+      await cli.parseAsync(['liferay', 'inventory', 'page', '--url', '/web/guest/home', '--json', '--full'], {
+        from: 'user',
+      });
+    } finally {
+      process.chdir(originalCwd);
+    }
+
+    const parsed = parseTestJson<FullRegularPagePayload>(output.stdout());
+    expect(parsed.page).toMatchObject({type: 'regularPage', pageName: 'Home'});
+    expect(parsed.full.layoutDetails).toEqual({
+      layoutTemplateId: '2_columns',
+      targetUrl: 'https://example.test',
+    });
+    expect(parsed.full.components?.fragments).toMatchObject([{fragmentKey: 'banner'}]);
+    expect(parsed.full.components?.widgets).toMatchObject([
+      {
+        widgetName: 'com_liferay_journal_content_web_portlet_JournalContentPortlet',
+        elementName: 'Main journal widget',
+        cssClasses: ['widget-shell', 'widget-shell-primary'],
+        customCSS: '.widget-shell-primary { color: red; }',
+      },
+    ]);
+    expect(parsed.full.journalArticles).toMatchObject([{articleId: 'ART-001'}]);
+    expect(parsed.full.contentStructures).toMatchObject([{contentStructureId: 301}]);
+    expect(output.stderr()).toBe('');
+  });
+
+  test('dev-cli liferay inventory page --json returns the minimal display page contract by default', async () => {
     vi.stubGlobal(
       'fetch',
       vi.fn(async (input: string | URL | Request) => {
@@ -365,9 +850,143 @@ describe('liferay inventory smoke', () => {
           );
         }
 
+        if (url.includes('/journal.journalarticle/get-article-by-url-title')) {
+          return new Response(
+            '{"id":41001,"resourcePrimKey":41001,"articleId":"ART-001","titleCurrentValue":"News article","ddmStructureKey":"NEWS","ddmTemplateKey":"NEWS_TEMPLATE","contentStructureId":301}',
+            {status: 200},
+          );
+        }
+
+        if (url.includes('/api/jsonws/group/get-group?groupId=20121')) {
+          return new Response(
+            '{"companyId":10157,"parentGroupId":0,"friendlyURL":"/guest","nameCurrentValue":"Guest"}',
+            {status: 200},
+          );
+        }
+
+        if (url.includes('/by-friendly-url-path/global')) {
+          return new Response('{"id":20122,"friendlyUrlPath":"/global","name":"Global"}', {status: 200});
+        }
+
+        if (
+          url.includes(
+            '/o/data-engine/v2.0/sites/20121/data-definitions/by-content-type/journal/by-data-definition-key/NEWS',
+          )
+        ) {
+          return new Response('{"id":301,"dataDefinitionKey":"NEWS","name":{"en_US":"News"}}', {status: 200});
+        }
+
+        if (
+          url.includes(
+            '/api/jsonws/classname/fetch-class-name?value=com.liferay.dynamic.data.mapping.model.DDMStructure',
+          )
+        ) {
+          return new Response('{"classNameId":1001}', {status: 200});
+        }
+
+        if (url.includes('/api/jsonws/ddm.ddmtemplate/get-templates?companyId=10157&groupId=20121')) {
+          return new Response(
+            '[{"templateId":"40801","templateKey":"NEWS_TEMPLATE","externalReferenceCode":"NEWS_TEMPLATE","nameCurrentValue":"News Template","classPK":301,"script":"<#-- ftl -->"}]',
+            {status: 200},
+          );
+        }
+
+        if (url.endsWith('/o/headless-admin-content/v1.0/sites/20121/display-page-templates?pageSize=200')) {
+          return new Response(
+            JSON.stringify({
+              items: [
+                {
+                  displayPageTemplateKey: 'news_article_detail',
+                  title: 'NEWS_ARTICLE_DETAIL',
+                  pageDefinition: {
+                    pageElement: {
+                      type: 'Root',
+                      pageElements: [
+                        {
+                          type: 'Fragment',
+                          definition: {
+                            fragmentFields: [
+                              {
+                                id: 'element-html',
+                                value: {
+                                  html: {
+                                    mapping: {
+                                      fieldKey: 'ddmTemplate_NEWS_TEMPLATE_DETAIL',
+                                      itemReference: {
+                                        contextSource: 'DisplayPageItem',
+                                      },
+                                    },
+                                  },
+                                },
+                              },
+                            ],
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              ],
+            }),
+            {status: 200},
+          );
+        }
+
         if (url.endsWith('/o/headless-delivery/v1.0/structured-contents/41001')) {
           return new Response(
-            '{"id":41001,"contentStructureId":301,"contentFields":[{"label":"Headline","name":"headline","dataType":"string","contentFieldValue":{"data":"News title"}}]}',
+            JSON.stringify({
+              id: 41001,
+              title: 'News title from Liferay',
+              description: '<p>Top-level Liferay description&nbsp;only</p>',
+              contentStructureId: 301,
+              externalReferenceCode: 'sample-erc-001',
+              uuid: 'sample-uuid-001',
+              availableLanguages: ['en-US', 'es-ES'],
+              dateCreated: '2026-01-30T10:26:12Z',
+              dateModified: '2026-04-19T21:53:09Z',
+              datePublished: '2026-01-30T10:26:00Z',
+              neverExpire: true,
+              renderedContents: [
+                {
+                  contentTemplateName: 'NEWS_ARTICLE_DETAIL',
+                  renderedContentURL:
+                    '/o/headless-delivery/v1.0/structured-contents/41001/rendered-content-by-display-page/news_article_detail',
+                  markedAsDefault: true,
+                },
+              ],
+              taxonomyCategoryBriefs: [{taxonomyCategoryName: 'Category A'}, {taxonomyCategoryName: 'Category B'}],
+              contentFields: [
+                {
+                  label: 'Headline',
+                  name: 'headline',
+                  dataType: 'string',
+                  contentFieldValue: {data: 'News title'},
+                },
+                {
+                  label: 'Lead',
+                  name: 'lead',
+                  dataType: 'string',
+                  contentFieldValue: {data: 'Short lead extracted from content'},
+                },
+                {
+                  label: 'Body',
+                  name: 'body',
+                  dataType: 'string',
+                  contentFieldValue: {data: '<p>Short editorial preview for readers.</p>'},
+                },
+                {
+                  label: 'Featured Image',
+                  name: 'featuredImage',
+                  dataType: 'image',
+                  contentFieldValue: {
+                    image: {
+                      title: 'sample-image.jpg',
+                      contentUrl: '/documents/sample-image.jpg',
+                    },
+                  },
+                },
+              ],
+            }),
             {status: 200},
           );
         }
@@ -393,10 +1012,221 @@ describe('liferay inventory smoke', () => {
       process.chdir(originalCwd);
     }
 
-    const parsed = parseTestJson<InventoryPagePayload>(output.stdout());
-    expect(parsed.pageType).toBe('displayPage');
-    expect(parsed.article.key).toBe('ART-001');
-    expect(parsed.journalArticles[0].contentFields[0].value).toBe('News title');
+    const parsed = parseTestJson<MinimalDisplayPagePayload>(output.stdout());
+    expect(parsed.page).toMatchObject({
+      type: 'displayPage',
+      subtype: 'journalArticle',
+      contentItemType: 'WebContent',
+      siteFriendlyUrl: '/guest',
+      groupId: 20121,
+      url: '/web/guest/w/news-article',
+      friendlyUrl: '/w/news-article',
+    });
+    expect(parsed.article).toMatchObject({
+      id: 41001,
+      key: 'ART-001',
+      title: 'News article',
+      friendlyUrlPath: 'news-article',
+      contentStructureId: 301,
+      structureKey: 'NEWS',
+      externalReferenceCode: 'sample-erc-001',
+      uuid: 'sample-uuid-001',
+    });
+    expect(parsed.contentSummary).toEqual({
+      headline: 'News article',
+      lead: 'Top-level Liferay description only',
+    });
+    expect(JSON.stringify(parsed.contentSummary)).not.toContain('Short lead extracted from content');
+    expect(parsed.rendering).toEqual({
+      widgetDefaultTemplate: 'NEWS_TEMPLATE',
+      displayPageDefaultTemplate: 'NEWS_ARTICLE_DETAIL',
+      displayPageDdmTemplates: ['NEWS_TEMPLATE_DETAIL'],
+      hasWidgetRendering: true,
+      hasDisplayPageRendering: true,
+    });
+    expect(parsed.taxonomy).toEqual({categories: ['Category A', 'Category B']});
+    expect(parsed.lifecycle).toEqual({
+      availableLanguages: ['en-US', 'es-ES'],
+      dateCreated: '2026-01-30T10:26:12Z',
+      dateModified: '2026-04-19T21:53:09Z',
+      datePublished: '2026-01-30T10:26:00Z',
+      neverExpire: true,
+    });
+    expect(parsed).not.toHaveProperty('journalArticles');
+    expect(parsed).not.toHaveProperty('contentStructures');
+    expect(parsed).not.toHaveProperty('full');
+    expect(output.stderr()).toBe('');
+  });
+
+  test('dev-cli liferay inventory page --json --full returns the display page minimal contract plus article details', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: string | URL | Request) => {
+        await Promise.resolve();
+        const url = toTestRequestUrl(input);
+
+        if (url.endsWith('/o/oauth2/token')) {
+          return new Response('{"access_token":"token-12345678","token_type":"Bearer","expires_in":3600}', {
+            status: 200,
+          });
+        }
+
+        if (url.includes('/by-friendly-url-path/guest')) {
+          return new Response('{"id":20121,"friendlyUrlPath":"/guest","name":"Guest"}', {status: 200});
+        }
+
+        if (url.includes('/structured-contents?')) {
+          return new Response(
+            '{"items":[{"id":41001,"key":"ART-001","title":"News article","friendlyUrlPath":"news-article","contentStructureId":301}],"lastPage":1}',
+            {status: 200},
+          );
+        }
+
+        if (url.includes('/journal.journalarticle/get-article-by-url-title')) {
+          return new Response(
+            '{"id":41001,"resourcePrimKey":41001,"articleId":"ART-001","titleCurrentValue":"News article","ddmStructureKey":"NEWS","ddmTemplateKey":"NEWS_TEMPLATE","contentStructureId":301}',
+            {status: 200},
+          );
+        }
+
+        if (url.includes('/api/jsonws/group/get-group?groupId=20121')) {
+          return new Response(
+            '{"companyId":10157,"parentGroupId":0,"friendlyURL":"/guest","nameCurrentValue":"Guest"}',
+            {status: 200},
+          );
+        }
+
+        if (url.includes('/by-friendly-url-path/global')) {
+          return new Response('{"id":20122,"friendlyUrlPath":"/global","name":"Global"}', {status: 200});
+        }
+
+        if (
+          url.includes(
+            '/o/data-engine/v2.0/sites/20121/data-definitions/by-content-type/journal/by-data-definition-key/NEWS',
+          )
+        ) {
+          return new Response('{"id":301,"dataDefinitionKey":"NEWS","name":{"en_US":"News"}}', {status: 200});
+        }
+
+        if (
+          url.includes(
+            '/api/jsonws/classname/fetch-class-name?value=com.liferay.dynamic.data.mapping.model.DDMStructure',
+          )
+        ) {
+          return new Response('{"classNameId":1001}', {status: 200});
+        }
+
+        if (url.includes('/api/jsonws/classname/fetch-class-name?value=com.liferay.journal.model.JournalArticle')) {
+          return new Response('{"classNameId":1002}', {status: 200});
+        }
+
+        if (url.includes('/api/jsonws/ddm.ddmtemplate/get-templates?companyId=10157&groupId=20121')) {
+          return new Response(
+            '[{"templateId":"40801","templateKey":"NEWS_TEMPLATE","externalReferenceCode":"NEWS_TEMPLATE","nameCurrentValue":"News Template","classPK":301,"script":"<#-- ftl -->"}]',
+            {status: 200},
+          );
+        }
+
+        if (url.endsWith('/o/headless-admin-content/v1.0/sites/20121/display-page-templates?pageSize=200')) {
+          return new Response(
+            JSON.stringify({
+              items: [
+                {
+                  displayPageTemplateKey: 'news_article_detail',
+                  title: 'NEWS_ARTICLE_DETAIL',
+                  pageDefinition: {
+                    pageElement: {
+                      type: 'Root',
+                      pageElements: [
+                        {
+                          type: 'Fragment',
+                          definition: {
+                            fragmentFields: [
+                              {
+                                id: 'element-html',
+                                value: {
+                                  html: {
+                                    mapping: {
+                                      fieldKey: 'ddmTemplate_NEWS_TEMPLATE_DETAIL',
+                                      itemReference: {
+                                        contextSource: 'DisplayPageItem',
+                                      },
+                                    },
+                                  },
+                                },
+                              },
+                            ],
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              ],
+            }),
+            {status: 200},
+          );
+        }
+
+        if (url.endsWith('/o/headless-delivery/v1.0/structured-contents/41001')) {
+          return new Response(
+            JSON.stringify({
+              id: 41001,
+              contentStructureId: 301,
+              externalReferenceCode: 'sample-erc-001',
+              uuid: 'sample-uuid-001',
+              renderedContents: [
+                {
+                  contentTemplateName: 'NEWS_ARTICLE_DETAIL',
+                  renderedContentURL:
+                    '/o/headless-delivery/v1.0/structured-contents/41001/rendered-content-by-display-page/news_article_detail',
+                  markedAsDefault: true,
+                },
+              ],
+              taxonomyCategoryBriefs: [{taxonomyCategoryName: 'Category A'}, {taxonomyCategoryName: 'Category B'}],
+              contentFields: [
+                {
+                  label: 'Headline',
+                  name: 'headline',
+                  dataType: 'string',
+                  contentFieldValue: {data: 'News title'},
+                },
+              ],
+            }),
+            {status: 200},
+          );
+        }
+
+        if (url.endsWith('/o/headless-delivery/v1.0/content-structures/301')) {
+          return new Response('{"id":301,"name":"News"}', {status: 200});
+        }
+
+        throw new Error(`Unexpected URL ${url}`);
+      }),
+    );
+
+    const originalCwd = process.cwd();
+    process.chdir(repoRoot);
+    try {
+      const cli = createCli();
+      cli.exitOverride();
+      await cli.parseAsync(
+        ['liferay', 'inventory', 'page', '--site', 'guest', '--friendly-url', '/w/news-article', '--json', '--full'],
+        {from: 'user'},
+      );
+    } finally {
+      process.chdir(originalCwd);
+    }
+
+    const parsed = parseTestJson<FullDisplayPagePayload>(output.stdout());
+    expect(parsed.page).toMatchObject({type: 'displayPage', friendlyUrl: '/w/news-article'});
+    expect(parsed.full.articleDetails?.contentFields).toMatchObject([{name: 'headline', value: 'News title'}]);
+    expect(parsed.full.articleDetails?.renderedContents).toMatchObject([{contentTemplateName: 'NEWS_ARTICLE_DETAIL'}]);
+    expect(parsed.full.articleDetails?.taxonomyCategoryBriefs).toMatchObject([
+      {taxonomyCategoryName: 'Category A'},
+      {taxonomyCategoryName: 'Category B'},
+    ]);
+    expect(parsed.full.contentStructures).toMatchObject([{contentStructureId: 301}]);
     expect(output.stderr()).toBe('');
   });
 });

--- a/tests/unit/agent-bootstrap.test.ts
+++ b/tests/unit/agent-bootstrap.test.ts
@@ -139,7 +139,6 @@ describe('parseBootstrapCacheTtl', () => {
 function makeContextReport(overrides?: Partial<AgentContextReport>): AgentContextReport {
   return {
     ok: true,
-    contractVersion: 2,
     generatedAt: '2026-04-22T10:00:00.000Z',
     project: {
       type: 'ldev-native',
@@ -236,7 +235,6 @@ function makeContextReport(overrides?: Partial<AgentContextReport>): AgentContex
 function makeDoctorReport(overrides?: Partial<DoctorReport>): DoctorReport {
   return {
     ok: true,
-    contractVersion: 2,
     generatedAt: '2026-04-22T10:00:00.000Z',
     ranChecks: ['basic', 'runtime'],
     summary: {
@@ -249,7 +247,6 @@ function makeDoctorReport(overrides?: Partial<DoctorReport>): DoctorReport {
     stamp: {
       projectType: 'ldev-native',
       portalUrl: 'http://localhost:8080',
-      contractVersion: 2,
     },
     tools: {
       git: {status: 'pass', available: true, version: 'git version'},

--- a/tests/unit/capabilities.test.ts
+++ b/tests/unit/capabilities.test.ts
@@ -91,8 +91,6 @@ describe('capabilities', () => {
         },
       },
     });
-
-    expect(report.contractVersion).toBe(2);
     expect(report.tools.git.available).toBe(true);
     expect(report.tools.git.status).toBe('pass');
     expect(report.tools.blade.available).toBe(true);

--- a/tests/unit/liferay-inventory-page.test.ts
+++ b/tests/unit/liferay-inventory-page.test.ts
@@ -1618,6 +1618,43 @@ describe('liferay inventory page', () => {
     expect(JSON.stringify(projected.contentSummary)).not.toContain('XXIX Premi');
   });
 
+  test('projectLiferayInventoryPageJson decodes HTML entities only once in display summaries', () => {
+    const projected = projectLiferayInventoryPageJson({
+      pageType: 'displayPage',
+      pageSubtype: 'journalArticle',
+      contentItemType: 'WebContent',
+      siteName: 'Guest',
+      siteFriendlyUrl: '/guest',
+      groupId: 20121,
+      url: '/web/guest/w/news',
+      friendlyUrl: '/w/news',
+      article: {
+        id: 41001,
+        key: 'ART-001',
+        title: 'AT&amp;T &amp;lt;safe&amp;gt;',
+        friendlyUrlPath: 'news',
+        contentStructureId: 301,
+      },
+      journalArticles: [
+        {
+          articleId: 'ART-001',
+          title: 'AT&amp;T &amp;lt;safe&amp;gt;',
+          ddmStructureKey: 'NEWS',
+          description: '<p>Fish &amp;amp; Chips &amp;lt;b&amp;gt;literal&amp;lt;/b&amp;gt;</p>',
+        },
+      ],
+    });
+
+    if (!('contentSummary' in projected) || !projected.contentSummary) {
+      throw new Error('Expected display-page content summary');
+    }
+
+    expect(projected.contentSummary).toMatchObject({
+      headline: 'AT&T &lt;safe&gt;',
+      lead: 'Fish &amp; Chips &lt;b&gt;literal&lt;/b&gt;',
+    });
+  });
+
   test('projectLiferayInventoryPageJson normalizes site-root output into the page envelope', () => {
     const projected = projectLiferayInventoryPageJson({
       pageType: 'siteRoot',

--- a/tests/unit/liferay-inventory-page.test.ts
+++ b/tests/unit/liferay-inventory-page.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import {createLiferayApiClient} from '../../src/core/http/client.js';
 import {
   formatLiferayInventoryPage,
+  projectLiferayInventoryPageJson,
   resolveInventoryPageRequest,
   runLiferayInventoryPage,
 } from '../../src/features/liferay/inventory/liferay-inventory-page.js';
@@ -336,7 +337,6 @@ describe('liferay inventory page', () => {
     expect(() => validateLiferayInventoryPageResultV2(result)).not.toThrow();
 
     expect(result).toMatchObject({
-      contractVersion: '2',
       pageType: 'regularPage',
       pageSubtype: 'content',
       pageUiType: 'Content Page',
@@ -521,10 +521,14 @@ describe('liferay inventory page', () => {
     expect(() => validateLiferayInventoryPageResultV2(result)).not.toThrow();
 
     expect(result).toMatchObject({
-      contractVersion: '2',
       pageType: 'regularPage',
       pageSubtype: 'portlet',
       pageUiType: 'Widget Page',
+      pageSummary: {
+        layoutTemplateId: 'home',
+        fragmentCount: 0,
+        widgetCount: 2,
+      },
       portlets: [
         {
           columnId: 'column-top',
@@ -1040,7 +1044,6 @@ describe('liferay inventory page', () => {
     expect(() => validateLiferayInventoryPageResultV2(result)).not.toThrow();
 
     expect(result).toMatchObject({
-      contractVersion: '2',
       pageType: 'displayPage',
       contentItemType: 'WebContent',
       url: '/web/guest/w/news-article',
@@ -1224,5 +1227,417 @@ describe('liferay inventory page', () => {
     await expect(
       runLiferayInventoryPage(CONFIG, {url: '/web/guest/missing'}, {apiClient, tokenClient: TOKEN_CLIENT}),
     ).rejects.toThrow('Layout not found');
+  });
+
+  test('projectLiferayInventoryPageJson keeps full widget metadata in full regular-page output', () => {
+    const projected = projectLiferayInventoryPageJson(
+      {
+        pageType: 'regularPage',
+        pageSubtype: 'content',
+        pageUiType: 'Content Page',
+        siteName: 'Guest',
+        siteFriendlyUrl: '/guest',
+        groupId: 20121,
+        url: '/web/guest/home',
+        friendlyUrl: '/home',
+        pageName: 'Home',
+        privateLayout: false,
+        layout: {
+          layoutId: 11,
+          plid: 1011,
+          friendlyUrl: '/home',
+          type: 'content',
+          hidden: false,
+        },
+        layoutDetails: {},
+        adminUrls: {
+          view: 'http://localhost:8080/web/guest/home',
+          edit: 'http://localhost:8080/web/guest/home?p_l_mode=edit',
+          configureGeneral: 'http://localhost:8080/group/guest/general',
+          configureDesign: 'http://localhost:8080/group/guest/design',
+          configureSeo: 'http://localhost:8080/group/guest/seo',
+          configureOpenGraph: 'http://localhost:8080/group/guest/open-graph',
+          configureCustomMetaTags: 'http://localhost:8080/group/guest/custom-meta-tags',
+          translate: 'http://localhost:8080/group/guest/translate',
+        },
+        fragmentEntryLinks: [
+          {
+            type: 'widget',
+            widgetName: 'com_liferay_journal_content_web_portlet_JournalContentPortlet',
+            portletId: 'com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_abc',
+            configuration: {articleId: 'ART-001'},
+            elementName: 'Main journal widget',
+            cssClasses: ['widget-shell', 'widget-shell-primary'],
+            customCSS: '.widget-shell-primary { color: red; }',
+          },
+        ],
+      },
+      {full: true},
+    );
+
+    if (!('page' in projected) || projected.page.type !== 'regularPage') {
+      throw new Error('Expected full regular-page widget output');
+    }
+
+    const regularProjected = projected as Extract<
+      ReturnType<typeof projectLiferayInventoryPageJson>,
+      {page: {type: 'regularPage'}}
+    >;
+
+    if (!regularProjected.full?.components?.widgets) {
+      throw new Error('Expected full regular-page widget output');
+    }
+
+    expect(regularProjected.full.components.widgets).toMatchObject([
+      {
+        widgetName: 'com_liferay_journal_content_web_portlet_JournalContentPortlet',
+        portletId: 'com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_abc',
+        configuration: {articleId: 'ART-001'},
+        elementName: 'Main journal widget',
+        cssClasses: ['widget-shell', 'widget-shell-primary'],
+        customCSS: '.widget-shell-primary { color: red; }',
+      },
+    ]);
+  });
+
+  test('projectLiferayInventoryPageJson exposes classic portlet composition in default output', () => {
+    const projected = projectLiferayInventoryPageJson({
+      pageType: 'regularPage',
+      pageSubtype: 'portlet',
+      pageUiType: 'Widget Page',
+      siteName: 'Guest',
+      siteFriendlyUrl: '/guest',
+      groupId: 20121,
+      url: '/web/guest/home',
+      friendlyUrl: '/home',
+      pageName: 'Home',
+      privateLayout: false,
+      pageSummary: {
+        layoutTemplateId: 'home',
+        fragmentCount: 0,
+        widgetCount: 2,
+      },
+      layout: {
+        layoutId: 11,
+        plid: 1011,
+        friendlyUrl: '/home',
+        type: 'portlet',
+        hidden: false,
+      },
+      layoutDetails: {layoutTemplateId: 'home'},
+      adminUrls: {
+        view: 'http://localhost:8080/web/guest/home',
+        edit: 'http://localhost:8080/web/guest/home?p_l_mode=edit',
+        configureGeneral: 'http://localhost:8080/group/guest/general',
+        configureDesign: 'http://localhost:8080/group/guest/design',
+        configureSeo: 'http://localhost:8080/group/guest/seo',
+        configureOpenGraph: 'http://localhost:8080/group/guest/open-graph',
+        configureCustomMetaTags: 'http://localhost:8080/group/guest/custom-meta-tags',
+        translate: 'http://localhost:8080/group/guest/translate',
+      },
+      componentInspectionSupported: false,
+      portlets: [
+        {
+          columnId: 'column-top',
+          position: 0,
+          portletId: 'com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet_INSTANCE_top',
+          portletName: 'com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet',
+          instanceId: 'top',
+          configuration: {columnId: 'column-top', position: '0', layoutTemplateId: 'home'},
+        },
+        {
+          columnId: 'column-fluid',
+          position: 0,
+          portletId: 'com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_main',
+          portletName: 'com_liferay_journal_content_web_portlet_JournalContentPortlet',
+          instanceId: 'main',
+          configuration: {columnId: 'column-fluid', position: '0', layoutTemplateId: 'home'},
+        },
+      ],
+    });
+
+    if (!('page' in projected) || projected.page.type !== 'regularPage') {
+      throw new Error('Expected regular-page output');
+    }
+
+    const regularProjected = projected as Extract<
+      ReturnType<typeof projectLiferayInventoryPageJson>,
+      {page: {type: 'regularPage'}}
+    >;
+
+    expect(regularProjected.summary).toMatchObject({
+      layoutTemplateId: 'home',
+      fragmentCount: 0,
+      widgetCount: 2,
+    });
+    expect(regularProjected.components?.portlets).toEqual([
+      {
+        columnId: 'column-top',
+        position: 0,
+        portletId: 'com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet_INSTANCE_top',
+        portletName: 'com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet',
+        instanceId: 'top',
+        configuration: {columnId: 'column-top', position: '0', layoutTemplateId: 'home'},
+      },
+      {
+        columnId: 'column-fluid',
+        position: 0,
+        portletId: 'com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_main',
+        portletName: 'com_liferay_journal_content_web_portlet_JournalContentPortlet',
+        instanceId: 'main',
+        configuration: {columnId: 'column-fluid', position: '0', layoutTemplateId: 'home'},
+      },
+    ]);
+    expect(regularProjected.full).toBeUndefined();
+  });
+
+  test('projectLiferayInventoryPageJson keeps cheap regular-page content breadcrumbs in default output', () => {
+    const projected = projectLiferayInventoryPageJson({
+      pageType: 'regularPage',
+      pageSubtype: 'content',
+      pageUiType: 'Content Page',
+      siteName: 'Guest',
+      siteFriendlyUrl: '/guest',
+      groupId: 20121,
+      url: '/web/guest/home',
+      friendlyUrl: '/home',
+      pageName: 'Home',
+      privateLayout: false,
+      layout: {
+        layoutId: 11,
+        plid: 1011,
+        friendlyUrl: '/home',
+        type: 'content',
+        hidden: false,
+      },
+      layoutDetails: {},
+      adminUrls: {
+        view: 'http://localhost:8080/web/guest/home',
+        edit: 'http://localhost:8080/web/guest/home?p_l_mode=edit',
+        configureGeneral: 'http://localhost:8080/group/guest/general',
+        configureDesign: 'http://localhost:8080/group/guest/design',
+        configureSeo: 'http://localhost:8080/group/guest/seo',
+        configureOpenGraph: 'http://localhost:8080/group/guest/open-graph',
+        configureCustomMetaTags: 'http://localhost:8080/group/guest/custom-meta-tags',
+        translate: 'http://localhost:8080/group/guest/translate',
+      },
+      fragmentEntryLinks: [
+        {
+          type: 'fragment',
+          fragmentKey: 'banner',
+          fragmentSiteFriendlyUrl: '/global',
+          fragmentExportPath: 'C:\\repo\\liferay\\fragments\\banner',
+          contentSummary: 'title=Welcome',
+        },
+      ],
+      journalArticles: [
+        {
+          groupId: 20122,
+          siteFriendlyUrl: '/global',
+          siteName: 'Global',
+          articleId: 'ART-001',
+          title: 'Home article',
+          ddmStructureKey: 'BASIC',
+          ddmStructureSiteFriendlyUrl: '/global',
+          structureExportPath: 'C:\\repo\\liferay\\resources\\journal\\structures\\global\\BASIC.json',
+          contentStructureId: 301,
+          ddmTemplateKey: 'BASIC_DETAIL',
+          ddmTemplateSiteFriendlyUrl: '/global',
+          templateExportPath: 'C:\\repo\\liferay\\resources\\journal\\templates\\global\\BASIC_DETAIL.ftl',
+          contentFields: [{path: 'Body', label: 'Body', name: 'body', type: 'string', value: 'Long body'}],
+        },
+      ],
+    });
+
+    if (!('page' in projected) || projected.page.type !== 'regularPage') {
+      throw new Error('Expected regular-page output');
+    }
+
+    const regularProjected = projected as Extract<
+      ReturnType<typeof projectLiferayInventoryPageJson>,
+      {page: {type: 'regularPage'}}
+    >;
+
+    expect(regularProjected.components?.fragments).toEqual([
+      {
+        fragmentKey: 'banner',
+        fragmentSiteFriendlyUrl: '/global',
+        fragmentExportPath: 'C:\\repo\\liferay\\fragments\\banner',
+        contentSummary: 'title=Welcome',
+      },
+    ]);
+    expect(regularProjected.contentRefs).toEqual([
+      {
+        articleId: 'ART-001',
+        title: 'Home article',
+        groupId: 20122,
+        siteFriendlyUrl: '/global',
+        siteName: 'Global',
+        structureKey: 'BASIC',
+        structureSiteFriendlyUrl: '/global',
+        structureExportPath: 'C:\\repo\\liferay\\resources\\journal\\structures\\global\\BASIC.json',
+        contentStructureId: 301,
+        templateKey: 'BASIC_DETAIL',
+        templateSiteFriendlyUrl: '/global',
+        templateExportPath: 'C:\\repo\\liferay\\resources\\journal\\templates\\global\\BASIC_DETAIL.ftl',
+      },
+    ]);
+    expect(JSON.stringify(regularProjected.contentRefs)).not.toContain('Long body');
+  });
+
+  test('projectLiferayInventoryPageJson derives display-page default template only from display-page rendered contents', () => {
+    const projected = projectLiferayInventoryPageJson(
+      {
+        pageType: 'displayPage',
+        pageSubtype: 'journalArticle',
+        contentItemType: 'WebContent',
+        siteName: 'Guest',
+        siteFriendlyUrl: '/guest',
+        groupId: 20121,
+        url: '/web/guest/w/news-article',
+        friendlyUrl: '/w/news-article',
+        article: {
+          id: 41001,
+          key: 'ART-001',
+          title: 'News article',
+          friendlyUrlPath: 'news-article',
+          contentStructureId: 301,
+        },
+        journalArticles: [
+          {
+            groupId: 20121,
+            siteId: 20121,
+            siteFriendlyUrl: '/guest',
+            siteName: 'Guest',
+            articleId: 'ART-001',
+            title: 'News article',
+            ddmStructureKey: 'NEWS',
+            ddmStructureSiteFriendlyUrl: '/global',
+            structureExportPath: 'C:\\repo\\liferay\\resources\\journal\\structures\\global\\NEWS.json',
+            contentStructureId: 301,
+            ddmTemplateKey: 'NEWS_WIDGET_TEMPLATE',
+            ddmTemplateSiteFriendlyUrl: '/global',
+            templateExportPath: 'C:\\repo\\liferay\\resources\\journal\\templates\\global\\NEWS_WIDGET_TEMPLATE.ftl',
+            widgetDefaultTemplate: 'NEWS_WIDGET_TEMPLATE',
+            renderedContents: [
+              {
+                contentTemplateName: 'NEWS_WIDGET_TEMPLATE',
+                renderedContentURL:
+                  'http://localhost:8080/o/headless-delivery/v1.0/structured-contents/41001/rendered-content/NEWS_WIDGET_TEMPLATE',
+                markedAsDefault: true,
+              },
+              {
+                contentTemplateName: 'NEWS_ARTICLE_DETAIL',
+                renderedContentURL:
+                  'http://localhost:8080/o/headless-delivery/v1.0/structured-contents/41001/rendered-content-by-display-page/news_article_detail',
+                markedAsDefault: true,
+              },
+            ],
+          },
+        ],
+        contentStructures: [],
+      },
+      {full: false},
+    );
+
+    if (!('rendering' in projected) || !projected.rendering) {
+      throw new Error('Expected display-page rendering block');
+    }
+
+    expect(projected.rendering).toMatchObject({
+      widgetDefaultTemplate: 'NEWS_WIDGET_TEMPLATE',
+      displayPageDefaultTemplate: 'NEWS_ARTICLE_DETAIL',
+      hasWidgetRendering: true,
+      hasDisplayPageRendering: true,
+    });
+    expect(projected.article).toMatchObject({
+      groupId: 20121,
+      siteId: 20121,
+      siteFriendlyUrl: '/guest',
+      siteName: 'Guest',
+      structureKey: 'NEWS',
+      structureSiteFriendlyUrl: '/global',
+      structureExportPath: 'C:\\repo\\liferay\\resources\\journal\\structures\\global\\NEWS.json',
+      templateKey: 'NEWS_WIDGET_TEMPLATE',
+      templateSiteFriendlyUrl: '/global',
+      templateExportPath: 'C:\\repo\\liferay\\resources\\journal\\templates\\global\\NEWS_WIDGET_TEMPLATE.ftl',
+    });
+  });
+
+  test('projectLiferayInventoryPageJson keeps display summaries on Liferay article fields', () => {
+    const projected = projectLiferayInventoryPageJson({
+      pageType: 'displayPage',
+      pageSubtype: 'journalArticle',
+      contentItemType: 'WebContent',
+      siteName: 'Facultat',
+      siteFriendlyUrl: '/facultat',
+      groupId: 27528220,
+      url: '/web/facultat/w/news',
+      friendlyUrl: '/w/news',
+      article: {
+        id: 48218747,
+        key: '48218745',
+        title: '20260204-La Dra. Mirèia Guil Egea guanya el premi',
+        friendlyUrlPath: 'news',
+        contentStructureId: 2685187,
+      },
+      journalArticles: [
+        {
+          articleId: '48218745',
+          title: '20260204-La Dra. Mirèia Guil Egea guanya el premi',
+          ddmStructureKey: 'UB_STR_NOVEDAD',
+          description: '<p>Top-level Liferay description&nbsp;only</p>',
+          contentFields: [
+            {
+              path: 'Títol',
+              label: 'Títol',
+              name: 'titulo',
+              type: 'string',
+              value: 'La Dra. Mirèia Guil Egea guanya el XXIX Premi 2025',
+            },
+            {
+              path: 'Descripció',
+              label: 'Descripció',
+              name: 'descripcion',
+              type: 'string',
+              value: '<p>Investigadora del&nbsp;Programa de doctorat</p>',
+            },
+          ],
+        },
+      ],
+    });
+
+    if (!('contentSummary' in projected) || !projected.contentSummary) {
+      throw new Error('Expected display-page content summary');
+    }
+
+    expect(projected.contentSummary).toMatchObject({
+      headline: '20260204-La Dra. Mirèia Guil Egea guanya el premi',
+      lead: 'Top-level Liferay description only',
+    });
+    expect(JSON.stringify(projected.contentSummary)).not.toContain('XXIX Premi');
+  });
+
+  test('projectLiferayInventoryPageJson normalizes site-root output into the page envelope', () => {
+    const projected = projectLiferayInventoryPageJson({
+      pageType: 'siteRoot',
+      siteName: 'Guest',
+      siteFriendlyUrl: '/guest',
+      groupId: 20121,
+      url: '/web/guest/',
+      pages: [{layoutId: 11, friendlyUrl: '/home', name: 'Home', type: 'content'}],
+    });
+
+    expect(projected).toMatchObject({
+      page: {
+        type: 'siteRoot',
+        siteName: 'Guest',
+        siteFriendlyUrl: '/guest',
+        groupId: 20121,
+        url: '/web/guest/',
+      },
+      pages: [{layoutId: 11, friendlyUrl: '/home', name: 'Home', type: 'content'}],
+    });
+    expect(projected).not.toHaveProperty('pageType');
   });
 });


### PR DESCRIPTION
## Summary

- Streamline `portal inventory page --json` into a lean agent-facing contract, with expanded raw details gated behind `--full`.
- Add default breadcrumbs for regular/content pages, display pages, and classic portlet pages without exposing heavy raw payloads.
- Remove unused `contractVersion` fields from command JSON outputs and tests.
- Document when agents should use the default inventory output versus `--full`.

## Details

- Adds `projectLiferayInventoryPageJson` and a JSON schema for the normalized page inventory contract.
- Includes lightweight component data by default:
  - fragments with keys, config, export paths, and summaries
  - widgets with portlet IDs and config
  - classic portlets with column, position, portlet identity, and instance ID
- Keeps heavy data in `full`, including raw configuration, content fields, template candidates, rendered contents, and full component metadata.
- Updates agent guidance and Liferay skills to prefer the lean default output and only request `--full` when raw details are needed.

## Verification

- `npm.cmd run typecheck`
- `npx.cmd vitest run tests/unit/liferay-inventory-page.test.ts`
- `npx.cmd vitest run tests/smoke/liferay-inventory-smoke.test.ts`
- `npm.cmd run build`
- `git diff --check HEAD`

close #105 