### PR TITLE
feat(ai-skills): refactor skills with reference architecture and fill command gaps

### DIFF
--- a/templates/ai/docs/SKILL_REVIEW_CHECKLIST.md
+++ b/templates/ai/docs/SKILL_REVIEW_CHECKLIST.md
@@ -1,0 +1,39 @@
+# Skill Review Checklist
+
+Use this checklist when adding or reviewing a skill change.
+
+## Activation and scope
+
+- `description` clearly says what the skill does and when to trigger it
+- trigger language is specific enough to distinguish it from neighboring skills
+- vendor skills stay reusable across `ldev` projects
+- project overlays stay project-specific and do not duplicate vendor workflows
+
+## Structure
+
+- `SKILL.md` stays focused on activation, flow, guardrails, and exit criteria
+- durable detail lives in `references/` or `scripts/`
+- reusable templates and checklists are not embedded inline in long sections
+- router skills route quickly instead of becoming mini playbooks
+
+## Duplication and context
+
+- no paragraph-level duplication between `SKILL.md` and nearby references
+- the same workflow is not repeated across vendor and project skills without a clear boundary
+- deep references are linked from the skill instead of copied into it
+
+## Safety and verification
+
+- commands use public `ldev` entrypoints
+- mutation guardrails remain visible in `SKILL.md`
+- verification criteria are still reachable after any extraction to references
+- any project-specific evidence or handoff rules still live in project overlays
+- if a handoff covers runtime-backed resources in production, it includes both
+	the preferred `ldev` path and a manual Liferay UI fallback when remote `ldev`
+	access is not guaranteed
+
+## Heuristics
+
+- `SKILL.md` is under 100 lines, or the overage is intentional and justified
+- if a section is only needed for some invocations, it probably belongs in a reference
+- if a section mostly names neighboring references, it probably belongs in a routing reference

--- a/templates/ai/docs/SKILL_STANDARDS.md
+++ b/templates/ai/docs/SKILL_STANDARDS.md
@@ -23,6 +23,8 @@ Short guide to maintain high-quality skills, based on patterns from:
 
 1. Progressive disclosure:
    - Keep `SKILL.md` as short as possible.
+   - Prefer `SKILL.md` under 100 lines; if it grows beyond that, treat it as a
+     smell that detail probably belongs in `references/`.
    - Move details and variations to `references/`.
    - Use `scripts/` for deterministic and repetitive steps.
 2. Precise trigger:
@@ -30,9 +32,20 @@ Short guide to maintain high-quality skills, based on patterns from:
    - Include concrete activation verbs (`Use when...`).
 3. Output contract:
    - Define what the agent must deliver (artifacts, checks, format).
+   - Put reusable templates, checklists, and file formats in dedicated
+     references instead of embedding large contracts inline in `SKILL.md`.
 4. No duplication:
    - Do not repeat the same content in `SKILL.md` and `references/`.
 5. Efficient context:
    - If the skill grows, prioritize a summary + internal links to references.
+6. Role clarity:
+   - Router skills should route quickly and link outward.
+   - Playbook skills should keep the workflow core in `SKILL.md` and push
+     long edge cases into `references/`.
+
+## Review Surface
+
+Use `SKILL_REVIEW_CHECKLIST.md` during review so the package enforces the same
+shape it recommends.
 
 

--- a/templates/ai/project/skills/issue-engineering/SKILL.md
+++ b/templates/ai/project/skills/issue-engineering/SKILL.md
@@ -45,6 +45,11 @@ Review the issue in the tracker and capture only project-specific process data:
 - project evidence requirements
 - project closure expectations
 
+If the issue, review request, or repro notes mention one or more portal URLs,
+resolve every one of them through `ldev portal inventory page --url` at intake
+before code search or browser reproduction. Treat this as the default first
+technical context step, not an optional follow-up.
+
 If technical discovery is required, switch immediately to the correct vendor
 skill instead of documenting the flow here.
 

--- a/templates/ai/project/skills/issue-engineering/SKILL.md
+++ b/templates/ai/project/skills/issue-engineering/SKILL.md
@@ -32,23 +32,8 @@ skip intake and proceed directly.
 For scope boundaries and invalid shortcuts, read
 `references/boundary-rules.md` only when needed.
 
-## Recommended gate order
-
-For `ldev-native` non-trivial tasks (bugs, features, migrations), follow this order:
-
-1. `Red-1` reproduction in the current runtime
-2. isolated worktree setup and active edit-root lock
-3. `Red-2` reproduction in the worktree runtime
-4. import/deploy verification with runtime evidence
-5. `Red -> Green` visual validation on the same local URL
-
-For clearly trivial tasks where the developer has explicitly defined the exact scope,
-confirm with them whether the full gate applies or whether they prefer to proceed
-directly. Never omit safety invariants (--check-only, read-after-write, ID resolution)
-regardless of which path is chosen.
-
-For `blade-workspace`, keep the same intake and validation discipline but do
-not invent a fake worktree phase.
+Use `references/execution-flow.md` for the full gate order, worktree phase,
+scope lock, artifact preparation, and vendor-skill routing tree.
 
 ## 1. Intake
 
@@ -63,112 +48,81 @@ Review the issue in the tracker and capture only project-specific process data:
 If technical discovery is required, switch immediately to the correct vendor
 skill instead of documenting the flow here.
 
-Before leaving intake, scan the issue for ambiguous references to fields,
-layouts, or components (ordinals like "el primero", cross-references like
-"igual que X", vague selectors like "the description field"). If any are found,
-apply the **Ambiguity Escape** in `references/intake.md` and ask the user for
-the exact field key, structure ID, or layout section before proceeding to
-reproduction.
+Use `references/intake.md` for URL resolution, ambiguity escape, and the exact
+`before.png` capture flow.
 
 ## 2. Reproduce before edits
 
 **This step is a hard gate. Do not proceed to worktree setup or code changes without it.**
 
 Before writing any code, confirm the symptom exists in the local environment you
-will use for the fix:
-
-- resolve the reported issue URL to the local runtime first
-- use `playwright-cli` on that local URL and capture the failing state
-- save a full-page screenshot as `.tmp/issue-NUM/before.png`
-- if the symptom does not appear, stop and report to the user; the issue may
-  already be fixed, may require specific data, or may not affect this environment
-
-If the runtime is not available, explicitly block this step and tell the user
-reproduction is pending. Do not proceed silently.
+will use for the fix. If the runtime is not available, explicitly block this
+step and tell the user reproduction is pending. Do not proceed silently.
 
 This is distinct from intake. Intake resolves the surface; reproduction confirms
 the actual failure in the running environment.
 
-For `ldev-native`, this gate has two moments:
-
-- `Red-1`: confirm the bug locally before creating the isolated worktree so the
-  issue is real in the current project runtime
-- `Red-2`: after the isolated worktree runtime is started, confirm the same
-  symptom again there before editing code or importing resources
-
-Do not treat a production screenshot as `Red`. Production evidence explains the
-issue; local reproduction defines the bug you are actually fixing.
+For the full `Red-1` / worktree / `Red-2` sequence, read
+`references/execution-flow.md`.
 
 ## 3. Isolate the edit root
 
-**For `ldev-native` projects, worktree isolation is the strongly recommended default.**
-For non-trivial tasks (bug fixes, features, migrations), apply this step without
-negotiation. For clearly trivial tasks where the developer explicitly requests
-lightweight mode, surface the recommendation, explain the risk of working in the
-main checkout, and ask for their explicit go-ahead. Proceed per their answer.
+Worktree isolation is the strongly recommended default for `ldev-native`
+non-trivial tasks.
 
-If isolated worktrees are available:
+```bash
+ldev worktree setup --name <issue-id> --with-env --stop-main-for-clone --restart-main-after-clone
+cd .worktrees/<issue-id>
+ldev start
+```
 
-- use the vendor skill `isolating-worktrees` for setup, root lock, recovery,
-  and cleanup
-- use project worktree naming conventions if the repository has them
-- read `references/worktree-env.md` only for project-specific worktree
-  conventions layered on top of that vendor skill
-- keep environment-specific cleanup tied to the actual worktree used
-- after `ldev start`, reproduce the bug again in the worktree runtime before the
-  first code change
+**Red-2 (hard gate):** After the worktree runtime is running, confirm the same
+symptom again there before editing any code or importing any resource. This
+ensures the bug reproduces in the isolated environment.
 
-If the repository is a `blade-workspace`, do not invent a fake worktree phase.
-Stay in the repository process flow and use vendor skills directly.
+Do not proceed to edits until Red-2 passes. If the worktree runtime is not
+available, explicitly block this step.
+
+For project-specific branch naming, worktree naming conventions, and recovery
+from setup blockers, see `references/execution-flow.md` and
+`references/worktree-env.md`.
 
 ## 3.5. Lock scope before the first edit
 
-**Before writing any code or importing any resource**, confirm the planned scope
-matches exactly what the issue states:
+Before writing any code or importing any resource:
 
 1. List every file or resource you plan to change.
 2. Annotate each item with the reason it appears in the issue description.
-3. Remove any item that is not explicitly required or implied by the issue.
-4. If you discover a field, layout, or resource that is not in the original scope,
-   stop, add it to `solution-plan.md`, and surface it to the user before proceeding.
+3. Remove any item not explicitly required or implied by the issue.
+4. If you discover something outside the original scope, stop, add it to
+   `solution-plan.md`, and surface it to the user before proceeding.
 
-Common scope-creep traps:
-
-- Adding new structure fields when the issue says to reorder or show/hide existing ones.
-- Modifying a widget layout (grid columns, container) when the issue targets a template.
-- Changing a CSS class globally when only one component is affected.
-
-If during planning you discover a file, resource, or field that was not
-mentioned or clearly implied by the issue, surface it to the user and update
-`solution-plan.md` before proceeding. A planning-time discovery is not
-authorization to expand scope.
+Common scope-creep traps: adding fields when the issue only asks to reorder
+them; modifying a widget layout when the issue targets only a template; changing
+a CSS class globally when only one component is affected.
 
 ## 4. Prepare artifacts and route the technical work
 
-Before routing technical work, prepare the issue artifacts this repository
-expects under `.tmp/issue-<num>/`:
+Before routing technical work, create these files under `.tmp/issue-<num>/`:
 
-- `brief.md` — created after intake and `Red-1` reproduction; summarize the
-  verified local URL, resolved surface, symptom checklist, and any hard blockers
-- `solution-plan.md` — created only after the technical direction is known;
-  capture the smallest intended fix path, validation plan, and the vendor skill
-  that owns execution
+**`brief.md`** (after Red-1 and Red-2 reproduction):
+- Verified local URL where the symptom reproduces
+- What the symptom looks like (observed vs. expected)
+- Which site, page, or resource is affected
+- Any hard blockers
 
-These files are the inputs for thin wrappers such as `issue-resolver`,
-`build-verifier`, and `runtime-verifier`. Do not write them under `/tmp/`.
+**`solution-plan.md`** (after technical direction is known):
+- The smallest intended fix path
+- Validation plan (commands + browser steps)
+- Which vendor skill owns execution
 
-Route by task:
+Route by task type:
+- Vague failure or unknown cause → `troubleshooting-liferay`
+- Code, template, fragment, theme, or resource change → `developing-liferay`
+- Deploy, import, or verification only → `deploying-liferay`
+- Structure change that risks existing content → `migrating-journal-structures`
 
-- vague failure or incident:
-  - use `troubleshooting-liferay`
-- code, template, fragment, theme, or resource implementation:
-  - use `developing-liferay`
-- deploy, import, and runtime verification:
-  - use `deploying-liferay`
-- risky Journal schema migration:
-  - use `migrating-journal-structures`
-- browser-based verification or visual evidence:
-  - use `automating-browser-tests`
+For the full gate order and routing tree, see `references/execution-flow.md`.
 
 ## 5. Validate before handoff
 
@@ -183,52 +137,10 @@ validation with Playwright is strongly recommended before handoff.
   developer explicitly opts out for a clearly trivial visual change they've already
   confirmed, note the skip and proceed per their instruction)
 
-When reviewers need visual evidence directly in a GitHub issue or PR comment
-without committing branch artifacts, read
+Use `references/validation.md` for the Red -> Green loop, explicit assertions,
+and what counts as real evidence. When reviewers need evidence posted directly
+to GitHub without committing artifacts, read
 `references/github-visual-evidence.md` before posting anything.
-
-For bug fixes, visual regressions, layout changes, and other user-facing runtime
-changes, validation should follow a visible `Red -> Green` loop:
-
-- `Red`: capture the failing local state before the fix
-- `Green`: verify the exact symptom checklist from the issue is now satisfied on
-  the same local URL after the fix
-
-A screenshot file existing is not enough. The agent must compare the issue's
-expected/actual behaviors against the final page state and explicitly confirm
-the symptom is gone.
-
-**DOM counters (element counts, selector presence) are supplementary evidence
-only.** A counter that returns `1` proves an element exists; it does not prove
-the page looks correct. For visual/user-facing changes, prefer visual validation
-in addition to any scripted assertions.
-
-**Side-by-side comparison is the recommended default before declaring Green:**
-
-- Open `before.png` (captured at Red) and the new `after.png` side by side.
-- Confirm every symptom from the issue description is no longer visible.
-- Confirm no new visual regressions appear (unexpected layout shifts, overlapping
-  elements, missing sections).
-
-**Human confirmation is the recommended default before closing a visual Red loop:**
-
-For visual fixes, present the side-by-side evidence to the user and ask whether it
-looks correct before closing the Red loop. If the developer explicitly chooses a
-lighter validation path for a trivial or tightly scoped change, document that
-choice in the handoff and proceed per their instruction.
-
-**Revert-first on regression:** If a symptom appears in `after.png` (or in
-the running page) that was **not present in Red**, do not patch over it.
-
-1. Identify which commit, import, or deploy introduced the new symptom.
-2. Revert that unit to the pre-edit state (`git checkout <file>`, re-import
-   the previous resource, or redeploy the previous artifact).
-3. Confirm the regression is gone (the page matches Red, not a new broken state).
-4. Then restart the fix with the new constraint understood.
-
-Patching a regression with additional code accumulates invisible scope and
-makes the final diff harder to review. Always shrink back to the known-good
-baseline before trying again.
 
 If worktree isolation was skipped or the runtime is not available, explicitly
 block this step and tell the user validation is pending rather than silently
@@ -239,23 +151,19 @@ the task remains in `Red`.
 
 ## Project handoff
 
-After technical work is complete, apply the project process:
-
-- write a human-review handoff in the repository's expected format
-- include the verification steps the project wants reviewers to run
-- attach screenshots or evidence if the project requires them
-- wait for explicit human validation before opening a pull request or posting PR-related issue comments
+After technical work is complete, apply the project process in
+`references/human-review-and-cleanup.md`.
 
 ## Cleanup
 
-Only apply cleanup rules that are specific to this repository's process.
-
-If cleanup depends on technical `ldev` behavior, that guidance belongs in vendor
+Only apply cleanup rules that are specific to this repository's process. If
+cleanup depends on technical `ldev` behavior, that guidance belongs in vendor
 skills or `AGENTS.md`, not here.
 
 ## Allowed project-specific references
 
 - `references/boundary-rules.md`
+- `references/execution-flow.md`
 - `references/issue-workflow-contract.md`
 - `references/intake.md`
 - `references/playwright-liferay.md`

--- a/templates/ai/project/skills/issue-engineering/references/execution-flow.md
+++ b/templates/ai/project/skills/issue-engineering/references/execution-flow.md
@@ -51,7 +51,7 @@ If isolated worktrees are available:
 - use the vendor skill `isolating-worktrees` for setup, root lock, recovery,
   and cleanup
 - use project worktree naming conventions if the repository has them
-- read `references/worktree-env.md` only for project-specific conventions
+- read `worktree-env.md` only for project-specific conventions
 - keep environment-specific cleanup tied to the actual worktree used
 - after `ldev start`, reproduce the bug again in the worktree runtime before the
   first code change

--- a/templates/ai/project/skills/issue-engineering/references/execution-flow.md
+++ b/templates/ai/project/skills/issue-engineering/references/execution-flow.md
@@ -1,0 +1,102 @@
+# Execution Flow
+
+Use this reference for the full gate order once a task is confirmed to use the
+project issue workflow.
+
+## Recommended gate order
+
+For `ldev-native` non-trivial tasks (bugs, features, migrations), follow this order:
+
+1. `Red-1` reproduction in the current runtime
+2. isolated worktree setup and active edit-root lock
+3. `Red-2` reproduction in the worktree runtime
+4. import/deploy verification with runtime evidence
+5. `Red -> Green` visual validation on the same local URL
+
+For clearly trivial tasks where the developer has explicitly defined the exact
+scope, confirm with them whether the full gate applies or whether they prefer to
+proceed directly. Never omit safety invariants such as `--check-only`,
+read-after-write verification, or ID resolution regardless of which path is chosen.
+
+For `blade-workspace`, keep the same intake and validation discipline but do not
+invent a fake worktree phase.
+
+## Reproduce before edits
+
+This is a hard gate. Do not proceed to worktree setup or code changes without it.
+
+Before writing any code, confirm the symptom exists in the local environment you
+will use for the fix. If the runtime is not available, explicitly block this
+step and tell the user reproduction is pending.
+
+For `ldev-native`, this gate has two moments:
+
+- `Red-1`: confirm the bug locally before creating the isolated worktree so the
+  issue is real in the current project runtime
+- `Red-2`: after the isolated worktree runtime is started, confirm the same
+  symptom again there before editing code or importing resources
+
+Do not treat a production screenshot as `Red`. Production evidence explains the
+issue; local reproduction defines the bug you are actually fixing.
+
+## Isolate the edit root
+
+For `ldev-native` projects, worktree isolation is the strongly recommended default.
+For non-trivial tasks, apply this step without negotiation. For clearly trivial
+tasks where the developer explicitly requests lightweight mode, explain the risk
+of working in the main checkout and ask for explicit go-ahead.
+
+If isolated worktrees are available:
+
+- use the vendor skill `isolating-worktrees` for setup, root lock, recovery,
+  and cleanup
+- use project worktree naming conventions if the repository has them
+- read `references/worktree-env.md` only for project-specific conventions
+- keep environment-specific cleanup tied to the actual worktree used
+- after `ldev start`, reproduce the bug again in the worktree runtime before the
+  first code change
+
+If the repository is a `blade-workspace`, stay in the repository process flow
+and use vendor skills directly.
+
+## Lock scope before the first edit
+
+Before writing any code or importing any resource, confirm the planned scope
+matches exactly what the issue states:
+
+1. List every file or resource you plan to change.
+2. Annotate each item with the reason it appears in the issue description.
+3. Remove any item that is not explicitly required or implied by the issue.
+4. If you discover a field, layout, or resource that is not in the original
+   scope, stop, add it to `solution-plan.md`, and surface it to the user before
+   proceeding.
+
+Common scope-creep traps:
+
+- adding new structure fields when the issue only says to reorder or show/hide existing ones
+- modifying a widget layout when the issue targets a template
+- changing a CSS class globally when only one component is affected
+
+Planning-time discovery is not authorization to expand scope.
+
+## Prepare artifacts and route the technical work
+
+Before routing technical work, prepare the issue artifacts this repository
+expects under `.tmp/issue-<num>/`:
+
+- `brief.md` — created after intake and `Red-1` reproduction; summarize the
+  verified local URL, resolved surface, symptom checklist, and any hard blockers
+- `solution-plan.md` — created only after the technical direction is known;
+  capture the smallest intended fix path, validation plan, and the vendor skill
+  that owns execution
+
+These files are inputs for thin wrappers such as `issue-resolver`,
+`build-verifier`, and `runtime-verifier`. Do not write them under `/tmp/`.
+
+Route by task:
+
+- vague failure or incident -> `troubleshooting-liferay`
+- code, template, fragment, theme, or resource implementation -> `developing-liferay`
+- deploy, import, and runtime verification -> `deploying-liferay`
+- risky Journal schema migration -> `migrating-journal-structures`
+- browser-based verification or visual evidence -> `automating-browser-tests`

--- a/templates/ai/project/skills/issue-engineering/references/human-review-and-cleanup.md
+++ b/templates/ai/project/skills/issue-engineering/references/human-review-and-cleanup.md
@@ -23,6 +23,19 @@ validated the work and explicitly asked you to do that.
 - `Not validated`
 - `Unknowns`
 
+For runtime-backed resources such as templates, ADTs, structures, or fragments,
+the deployment notes must include:
+
+- the preferred `ldev` promotion path when available
+- the equivalent manual Liferay UI fallback when remote `ldev` access is not guaranteed
+- the exact site scope and resource identifiers needed to find the same object
+- a note that this is a runtime resource change and must not be applied through
+  theme or module deploy
+
+Use `runtime-resource-handoff-template.md` as the default structure and
+`../../../../skills/developing-liferay/references/runtime-resource-production-handoff.md`
+for the resource-specific fallback rules.
+
 `Validated` should contain only checks you actually executed.
 
 `Not validated` should contain anything you expected to verify but could not.

--- a/templates/ai/project/skills/issue-engineering/references/human-review-and-cleanup.md
+++ b/templates/ai/project/skills/issue-engineering/references/human-review-and-cleanup.md
@@ -33,7 +33,7 @@ the deployment notes must include:
   theme or module deploy
 
 Use `runtime-resource-handoff-template.md` as the default structure and
-`../../../../skills/developing-liferay/references/runtime-resource-production-handoff.md`
+`../../developing-liferay/references/runtime-resource-production-handoff.md`
 for the resource-specific fallback rules.
 
 `Validated` should contain only checks you actually executed.

--- a/templates/ai/project/skills/issue-engineering/references/intake.md
+++ b/templates/ai/project/skills/issue-engineering/references/intake.md
@@ -8,6 +8,16 @@ Use this reference when the issue arrives with weak technical context or mixes U
 - Turn issue URLs and clues into context verified with `ldev`
 - Make remaining unknowns explicit
 
+## Default URL rule
+
+If the issue, review, bug report, repro steps, or human notes mention portal
+URLs, inspect every one of them immediately with `ldev portal inventory page
+--url` before searching code, reproducing in the browser, or planning a fix.
+
+Treat this as the default entrypoint whenever a relevant URL exists. The goal is
+to turn each URL into concrete portal context first: local/runtime URL, site,
+page type, owning resource, and likely implementation surface.
+
 ## Recommended Flow
 
 1. Read the issue and comments:
@@ -16,7 +26,8 @@ Use this reference when the issue arrives with weak technical context or mixes U
 gh issue view NUM --json title,body,labels,comments
 ```
 
-2. Resolve each reported URL through `ldev` first:
+2. Resolve each reported URL through `ldev` first. If multiple URLs are named,
+run the command for each one rather than picking a single "main" URL:
 
 ```bash
 ldev context --json
@@ -26,6 +37,9 @@ ldev portal inventory page --url <issueUrl> --json
 If the issue URL is production, use it only as an identifier for discovery. Do
 not use the production host for browser reproduction. Reuse the resolved
 local/runtime URL from `ldev`.
+
+If a comment or reviewer drops an additional URL later in the thread, stop and
+inspect that URL too before assuming it is the same surface.
 
 The default output contains the fields needed for most intake tasks (page type,
 article identity, rendering templates, taxonomy, admin URLs). If you need

--- a/templates/ai/project/skills/issue-engineering/references/runtime-resource-handoff-template.md
+++ b/templates/ai/project/skills/issue-engineering/references/runtime-resource-handoff-template.md
@@ -1,0 +1,55 @@
+# Runtime Resource Handoff Template
+
+Use this template when the final handoff includes production promotion for a
+runtime-backed resource.
+
+````md
+## Production Promotion
+
+These changes affect runtime-backed resources. Do not deploy a theme or module
+to apply them.
+
+### Preferred path (`ldev`)
+
+1. Run the atomic import commands for the affected resource(s):
+
+```bash
+# Example: templates
+ldev resource import-template --site /<site> --template <TEMPLATE_KEY> --json
+```
+
+2. Run the normal runtime verification commands:
+
+```bash
+ldev portal check --json
+ldev logs diagnose --since 5m --json
+```
+
+### Manual UI fallback
+
+If production cannot run `ldev` directly, apply the same runtime resource in the
+Liferay UI:
+
+1. Open the resolved site scope: `/<site>`.
+2. Open the owning UI for the affected resource type.
+3. Find the existing resource by its exact identifier:
+   - template: `<TEMPLATE_KEY>`
+   - ADT: `<ADT_KEY>` or `<DISPLAY_STYLE>`
+   - structure: `<STRUCTURE_KEY>`
+   - fragment: `<FRAGMENT_KEY>`
+4. Replace or import the reviewed content from the repository.
+5. Save or publish the resource.
+
+### Resource-specific note
+
+- template: Web Content -> Templates
+- structure: Web Content -> Structures
+- fragment: Fragments
+- ADT: the owning display-template UI for the affected widget or content type
+
+### Visual verification
+
+- verify the affected production URL
+- confirm the expected runtime behavior changed
+- confirm no adjacent regressions are visible
+````

--- a/templates/ai/project/skills/issue-engineering/references/validation.md
+++ b/templates/ai/project/skills/issue-engineering/references/validation.md
@@ -17,6 +17,19 @@ Checklist to decide whether the fix is actually done.
 ldev logs --since 2m --no-follow
 ```
 
+Before any validation claim, confirm the edited surface was actually applied to
+the runtime with the matching action:
+
+- module or deployable Gradle unit changed -> `ldev deploy module <module-name>`
+- theme assets or theme CSS/JS/templates changed -> `ldev deploy theme`
+- structure changed -> `ldev resource import-structure --site /<site> --structure <STRUCTURE_KEY>`
+- ADT changed -> `ldev resource import-adt --site /<site> --file <path/to/adt.ftl>`
+- template changed -> `ldev resource import-template --site /<site> --template <TEMPLATE_ID>`
+- fragment changed -> `ldev resource import-fragment --site /<site> --fragment <fragment-key>`
+- properties or source OSGi config changed -> `ldev env restart`
+
+If that step did not happen, stay in `Red` even if the source files look correct.
+
 If an OSGi module applies:
 
 ```bash

--- a/templates/ai/skills/deploying-liferay/SKILL.md
+++ b/templates/ai/skills/deploying-liferay/SKILL.md
@@ -31,6 +31,29 @@ checks before deploying.
 - If any of those fields is missing, stop and report that the installed `ldev`
   AI assets are out of sync with the CLI.
 
+## Prepare before deploy
+
+When the change needs artifact staging before runtime deployment (CI/CD flows,
+fresh checkout, or after a `ldev worktree setup`):
+
+```bash
+ldev deploy prepare
+```
+
+This compiles artifacts and writes commit markers without touching the running
+runtime. Use it before `ldev deploy module` or `ldev deploy theme` when the
+build artifacts are stale or missing.
+
+If the runtime is already running and you need to force preparation anyway:
+
+```bash
+ldev deploy prepare --allow-running-env
+```
+
+Do not use `ldev deploy prepare` as a substitute for `ldev deploy module` or
+`ldev deploy theme` — prepare stages artifacts only; it does not hot-deploy
+them to the running portal.
+
 ## Smallest deploy first
 
 Choose the smallest command that matches the change.
@@ -78,6 +101,11 @@ proved with `ldev deploy module <module-name>` or `ldev deploy theme`.
 For file-based portal resources, use the runtime resource import flow. A Gradle
 or theme deploy will not apply Journal templates, ADTs, fragments, or
 structures.
+
+If the final output includes production promotion instructions for a runtime-backed
+resource, include both the preferred `ldev resource ...` path and the manual
+Liferay UI fallback from
+`../developing-liferay/references/runtime-resource-production-handoff.md`.
 
 Validate before mutating:
 
@@ -158,6 +186,8 @@ Minimum done criteria:
 - Do not mark portal resource work done until the runtime import and browser
   verification have passed in the prepared environment.
 - Prefer `--json` on verification commands when the result will be consumed by an agent.
+- Do not write production notes that only mention `ldev` for runtime-backed
+  resources when the target environment may require manual UI promotion.
 - If the env is unhealthy, stop here and switch to `troubleshooting-liferay`.
 
 Reference:

--- a/templates/ai/skills/developing-liferay/SKILL.md
+++ b/templates/ai/skills/developing-liferay/SKILL.md
@@ -82,26 +82,10 @@ ldev resource export-adt --site /<site> --adt <ADT_KEY> --widget-type <widget-ty
 ldev resource export-fragment --site /<site> --fragment <FRAGMENT_KEY>
 ```
 
-### Pattern discovery before writing FTL or DDM logic
-
-Before writing any new FreeMarker template logic or DDM field accessor, grep
-the repository for the canonical pattern used for that field type:
-
-```bash
-# Find how the repo reads boolean or checkbox DDM fields
-grep -rE "getterUtil|getData|has_content" . --include="*.ftl" -l
-grep -rE "getterUtil" . --include="*.ftl" -n | head -20
-
-# Find existing examples for a specific field name
-grep -rE "<DDM_FIELD_NAME>" . --include="*.ftl" -n
-```
-
-Do not invent a new accessor pattern. Copy the dominant pattern from existing
-files.
-
-Common pitfall: using `?has_content` on a boolean DDM field returns `true` even
-when the field value is `false`, because the string `"false"` is non-empty. Use
-`getterUtil.getBoolean(fieldVar.getData())` instead for boolean DDM fields.
+Before writing new FTL or DDM accessor logic, inspect the dominant pattern in
+the repository first. Do not invent a new accessor style when the repo already
+has a stable one. For the repository-backed export/import loop, read
+`references/resource-workflow.md`.
 
 ## Decision: import vs. migrate
 
@@ -111,95 +95,56 @@ with existing data.
 Switch to `migrating-journal-structures` before editing when existing Journal
 content makes a direct import risky.
 
+
 ## Repository-backed resource workflow
 
-When structures, templates, ADTs, or fragments should be reviewed in Git, use
-the full file workflow instead of editing through the UI.
-
-These resources live in the portal runtime. Do not run `ldev deploy theme`,
-`ldev deploy module`, or a broad deploy for them; those commands will not
-apply Journal templates, ADTs, fragments, or structures. Use
-`ldev resource import-*` against a prepared runtime and verify with browser
-automation when the change affects rendered pages.
-
-### 1. Discover exact identifiers
+When structures, templates, ADTs, or fragments should be reviewed in Git,
+use this sequence:
 
 ```bash
+# 1. Discover exact identifiers
 ldev portal inventory structures --site /<site> --json
 ldev portal inventory templates --site /<site> --json
 ldev resource fragments --site /<site> --json
-```
 
-### 2. Export current portal state
-
-Use focused exports when changing one object:
-
-```bash
+# 2. Export current state from portal
 ldev resource export-structure --site /<site> --structure <STRUCTURE_KEY>
 ldev resource export-template --site /<site> --template <TEMPLATE_ID>
 ldev resource export-adt --site /<site> --adt <ADT_KEY> --widget-type <widget-type>
 ldev resource export-fragment --site /<site> --fragment <FRAGMENT_KEY>
-```
 
-If you intentionally need several resources, repeat the singular export command
-per resource. Do not use plural export commands unless a human explicitly asked
-for a bulk refresh and accepted the larger diff.
-
-### 3. Edit the exported files locally
-
-Review the exported resource files like any other source change.
-
-### 4. Validate before mutating
-
-Preview the local repository state first:
-
-```bash
+# 3. Edit locally, then validate before import
 ldev resource import-structure --site /<site> --structure <STRUCTURE_KEY> --check-only
 ldev resource import-template --site /<site> --template <TEMPLATE_ID> --check-only
 ldev resource import-adt --site /<site> --file <path/to/adt.ftl> --check-only
-```
+# Note: import-fragment has no --check-only flag; validate the source file manually before importing
+ldev resource import-fragment --site /<site> --fragment <fragment-key>
 
-**`--check-only` semantics:** This flag passes only when the local file is
-byte-identical to what the portal already has stored. It is a drift-detection
-tool, not a pre-import validator. If you have modified the file, `--check-only`
-will always report a hash mismatch — that is expected and correct behavior, not
-an error. Do not interpret a mismatch as a sign that the import will fail.
-Proceed to step 5 (the actual import) after reviewing the diff.
-
-If you intentionally need to validate multiple files, repeat the singular
-import command per changed resource so failures stay attributable.
-
-### 5. Apply the smallest safe import
-
-```bash
+# 4. Apply the import (structures, templates, ADTs)
 ldev resource import-structure --site /<site> --structure <STRUCTURE_KEY>
 ldev resource import-template --site /<site> --template <TEMPLATE_ID>
 ldev resource import-adt --site /<site> --file <path/to/adt.ftl>
-ldev resource import-fragment --site /<site> --fragment <fragment-key>
 ```
+
+These resources live in the portal runtime. Do not run `ldev deploy theme`,
+`ldev deploy module`, or a broad deploy for them; those commands will not
+apply Journal templates, ADTs, fragments, or structures.
+
+For bulk export/import, extended examples, and ADT/fragment-specific loops,
+see `references/resource-workflow.md`.
 
 ## Choose the smallest implementation path
 
-### Theme and frontend source
+Choose the narrowest path that matches the changed surface:
 
-Use when the change is in SCSS, JS, theme templates or other packaged theme
-assets.
-
-Reference: `references/theme.md`
+**Theme and frontend source** (SCSS, JS, FreeMarker theme templates):
 
 ```bash
 ldev deploy theme
 ldev logs --since 2m --service liferay --no-follow
 ```
 
-### OSGi modules and Java
-
-Use when the change lives in `modules/` or another deployable Gradle unit.
-
-References:
-
-- `references/osgi.md`
-- `references/extending-liferay.md`
+**OSGi modules and Java code:**
 
 ```bash
 ldev deploy module <module-name>
@@ -207,61 +152,33 @@ ldev osgi status <bundle-symbolic-name> --json
 ldev osgi diag <bundle-symbolic-name> --json
 ```
 
-### Service Builder
+**Journal structures, templates, and ADTs:**
+Use the repository-backed resource workflow above.
 
-Run only after a confirmed Service Builder change to `service.xml` or the
-generated service layer. This is broader than a module deploy, so do not use it
-as a generic fix-up step. If a single generated module can prove the change, use
-`ldev deploy module <module-name>` instead.
+**Service Builder, Liferay Objects, and Fragments:**
+For commands, decision criteria, and examples for these paths, see
+`references/implementation-paths.md`.
 
-### Liferay Objects
+## Portal configuration
 
-Use for custom data models on DXP 7.4+ that need their own headless REST API
-without traditional OSGi modules.
-
-References:
-
-- `references/objects.md` — field types, relationships, auto-generated API, Actions, Validations
-- `references/oauth2-setup.md` — OAuth2 portal setup and `ldev oauth install --write-env`
-- `references/headless-openapi.md` — local OpenAPI spec URLs for headless REST discovery
-
-### Journal structures, templates and ADTs
-
-Use the stable file-based resource workflows instead of ad hoc API calls.
-Each command requires its identifier; use `--check-only` to preview before
-mutating.
-
-References:
-
-- `references/structures.md` — CLI workflow (export, validate, import)
-- `references/structure-field-catalog.md` — field type JSON catalog (use when authoring or editing structure JSON directly)
-- `references/workflow.md` — approval workflow states, inspection, and publish failures
-- `references/groovy-console.md` — portal console scripts, ERC vocabulary fixes, bulk operations with no `ldev` equivalent
+To read or write portal properties and OSGi config from local files:
 
 ```bash
-ldev resource import-structure --site /<site> --structure <STRUCTURE_KEY> --check-only
-ldev resource import-template --site /<site> --template <TEMPLATE_ID> --check-only
-ldev resource import-adt --site /<site> --file <path/to/adt.ftl> --check-only
+# Read one portal property or OSGi config PID
+ldev portal config get <target> --json
+ldev portal config get <target> --source source --json   # from source file, not effective
+
+# Write one portal property
+ldev portal config set <target> --value <value> --json
+
+# Write one OSGi config key within a PID
+ldev portal config set <pid> --key <key> --value <value> --json
 ```
 
-When validation looks correct, run the same command without `--check-only`.
-
-### Fragments
-
-Treat fragments as versioned source plus explicit import workflow:
-
-Reference: `references/fragments.md`
-
-```bash
-ldev resource fragments --site /<site> --json
-ldev resource import-fragment --site /<site> --fragment <fragment-key>
-```
-
-> `import-fragment` has no `--check-only` flag. Validate the fragment source
-> file manually before importing.
-
-If the project uses a separate fragment authoring flow outside `ldev`, follow
-that project-owned workflow instead of inventing custom commands.
+Use `config get` before `config set` to confirm the current value. Do not
+guess property keys — resolve them from the portal docs or from existing local
+config files under `configs/`. Changes take effect after `ldev env restart`
+or a portal restart.
 
 ## Guardrails
 
@@ -276,6 +193,14 @@ that project-owned workflow instead of inventing custom commands.
 - Do not guess IDs, keys or site names when `ldev portal inventory ...` can resolve them.
 - For scripts and agents, prefer `--json` on all discovery and verification commands.
 - If a command fails because the portal is not reachable, re-check with `ldev status --json` and start the env before deeper debugging.
+- If the final handoff covers production promotion for templates, ADTs,
+  structures, or fragments, write BOTH:
+  1. The exact `ldev resource import-*` command with site and resource key.
+  2. The equivalent manual Liferay UI fallback path (e.g. Site Menu → Design → Templates)
+     so a human can apply the change without `ldev` access on production.
+  Do not assume `ldev` is available on the target environment. For full wording
+  templates and per-resource-type UI paths, see
+  `references/runtime-resource-production-handoff.md`.
 
 ## Minimum verification
 

--- a/templates/ai/skills/developing-liferay/SKILL.md
+++ b/templates/ai/skills/developing-liferay/SKILL.md
@@ -137,6 +137,9 @@ see `references/resource-workflow.md`.
 
 Choose the narrowest path that matches the changed surface:
 
+Do not treat a file edit as applied until the matching runtime action below has
+been executed successfully. Editing source alone is still `Red`.
+
 **Theme and frontend source** (SCSS, JS, FreeMarker theme templates):
 
 ```bash
@@ -159,6 +162,20 @@ Use the repository-backed resource workflow above.
 For commands, decision criteria, and examples for these paths, see
 `references/implementation-paths.md`.
 
+Use this mapping as a hard rule after edits:
+
+- changed files under `modules/` or another deployable Gradle unit -> `ldev deploy module <module-name>`
+- changed theme assets, theme CSS, theme JS, or theme FreeMarker templates -> `ldev deploy theme`
+- changed Journal structure source -> `ldev resource import-structure --site /<site> --structure <STRUCTURE_KEY>`
+- changed ADT source -> `ldev resource import-adt --site /<site> --file <path/to/adt.ftl>`
+- changed Journal template source -> `ldev resource import-template --site /<site> --template <TEMPLATE_ID>`
+- changed fragment source -> `ldev resource import-fragment --site /<site> --fragment <fragment-key>`
+- changed portal properties or source OSGi config files -> `ldev env restart` before validation
+
+If more than one surface changed, run each matching action. Do not assume a
+theme deploy applies module changes, a module deploy applies portal resources,
+or an import applies config changes.
+
 ## Portal configuration
 
 To read or write portal properties and OSGi config from local files:
@@ -180,6 +197,11 @@ guess property keys — resolve them from the portal docs or from existing local
 config files under `configs/`. Changes take effect after `ldev env restart`
 or a portal restart.
 
+If the task edited source configuration files such as `portal-ext.properties`,
+`portal-setup-wizard.properties`, `.config`, or `.cfg` files, do not claim
+runtime validation until the environment has been restarted and the new value
+has been read back or otherwise verified.
+
 ## Guardrails
 
 - Use `ldev` as the entrypoint.
@@ -188,6 +210,8 @@ or a portal restart.
 - Use `ldev deploy module <module-name>` only for modules or deployable Gradle units.
 - Use singular `ldev resource import-*` and `ldev resource export-*` commands for
   Journal templates, ADTs, fragments, and structures.
+- After editing source, always run the matching deploy, import, or restart step
+  before calling the change applied.
 - Do not use plural resource commands or a broad deploy unless a human
   explicitly asks for a bulk operation and the risk is written down first.
 - Do not guess IDs, keys or site names when `ldev portal inventory ...` can resolve them.

--- a/templates/ai/skills/developing-liferay/references/implementation-paths.md
+++ b/templates/ai/skills/developing-liferay/references/implementation-paths.md
@@ -2,6 +2,9 @@
 
 Use this reference once the affected surface is already clear.
 
+File edits do not update the runtime by themselves. After editing, run the
+matching `ldev` action for that surface before validation or handoff.
+
 ## Theme and frontend source
 
 Use when the change is in SCSS, JS, theme templates, or other packaged theme
@@ -13,6 +16,9 @@ Reference: `theme.md`
 ldev deploy theme
 ldev logs --since 2m --service liferay --no-follow
 ```
+
+If the fix is only in theme CSS and you do not run `ldev deploy theme`, the
+runtime has not been updated yet.
 
 ## OSGi modules and Java
 
@@ -28,6 +34,9 @@ ldev deploy module <module-name>
 ldev osgi status <bundle-symbolic-name> --json
 ldev osgi diag <bundle-symbolic-name> --json
 ```
+
+Editing Java, JSP, or other module-owned source without `ldev deploy module`
+does not count as applying the fix.
 
 ## Service Builder
 
@@ -66,6 +75,12 @@ ldev resource import-adt --site /<site> --file <path/to/adt.ftl> --check-only
 
 When validation looks correct, run the same command without `--check-only`.
 
+Use the import that matches the edited resource type:
+
+- structure -> `ldev resource import-structure --site /<site> --structure <STRUCTURE_KEY>`
+- template -> `ldev resource import-template --site /<site> --template <TEMPLATE_ID>`
+- ADT -> `ldev resource import-adt --site /<site> --file <path/to/adt.ftl>`
+
 ## Fragments
 
 Treat fragments as versioned source plus explicit import workflow.
@@ -79,6 +94,22 @@ ldev resource import-fragment --site /<site> --fragment <fragment-key>
 
 `import-fragment` has no `--check-only` flag. Validate the fragment source file
 manually before importing.
+
+If the fragment source changed, the fix is not applied until
+`ldev resource import-fragment` has run.
+
+## Portal properties and source config
+
+Use when the task changes source configuration such as `portal-ext.properties`,
+`portal-setup-wizard.properties`, `.config`, or `.cfg` files.
+
+```bash
+ldev env restart
+ldev logs --since 2m --no-follow
+```
+
+Do not assume source config edits are live until the environment restart has
+completed and the effective value has been verified.
 
 If the project uses a separate fragment authoring flow outside `ldev`, follow
 that project-owned workflow instead of inventing custom commands.

--- a/templates/ai/skills/developing-liferay/references/implementation-paths.md
+++ b/templates/ai/skills/developing-liferay/references/implementation-paths.md
@@ -7,7 +7,7 @@ Use this reference once the affected surface is already clear.
 Use when the change is in SCSS, JS, theme templates, or other packaged theme
 assets.
 
-Reference: `references/theme.md`
+Reference: `theme.md`
 
 ```bash
 ldev deploy theme
@@ -20,8 +20,8 @@ Use when the change lives in `modules/` or another deployable Gradle unit.
 
 References:
 
-- `references/osgi.md`
-- `references/extending-liferay.md`
+- `osgi.md`
+- `extending-liferay.md`
 
 ```bash
 ldev deploy module <module-name>
@@ -43,9 +43,9 @@ without traditional OSGi modules.
 
 References:
 
-- `references/objects.md`
-- `references/oauth2-setup.md`
-- `references/headless-openapi.md`
+- `objects.md`
+- `oauth2-setup.md`
+- `headless-openapi.md`
 
 ## Journal structures, templates, and ADTs
 
@@ -53,10 +53,10 @@ Use the stable file-based resource workflows instead of ad hoc API calls.
 
 References:
 
-- `references/structures.md`
-- `references/structure-field-catalog.md`
-- `references/workflow.md`
-- `references/groovy-console.md`
+- `structures.md`
+- `structure-field-catalog.md`
+- `workflow.md`
+- `groovy-console.md`
 
 ```bash
 ldev resource import-structure --site /<site> --structure <STRUCTURE_KEY> --check-only
@@ -70,7 +70,7 @@ When validation looks correct, run the same command without `--check-only`.
 
 Treat fragments as versioned source plus explicit import workflow.
 
-Reference: `references/fragments.md`
+Reference: `fragments.md`
 
 ```bash
 ldev resource fragments --site /<site> --json

--- a/templates/ai/skills/developing-liferay/references/implementation-paths.md
+++ b/templates/ai/skills/developing-liferay/references/implementation-paths.md
@@ -1,0 +1,84 @@
+# Implementation Paths
+
+Use this reference once the affected surface is already clear.
+
+## Theme and frontend source
+
+Use when the change is in SCSS, JS, theme templates, or other packaged theme
+assets.
+
+Reference: `references/theme.md`
+
+```bash
+ldev deploy theme
+ldev logs --since 2m --service liferay --no-follow
+```
+
+## OSGi modules and Java
+
+Use when the change lives in `modules/` or another deployable Gradle unit.
+
+References:
+
+- `references/osgi.md`
+- `references/extending-liferay.md`
+
+```bash
+ldev deploy module <module-name>
+ldev osgi status <bundle-symbolic-name> --json
+ldev osgi diag <bundle-symbolic-name> --json
+```
+
+## Service Builder
+
+Run only after a confirmed Service Builder change to `service.xml` or the
+generated service layer. This is broader than a module deploy, so do not use it
+as a generic fix-up step. If a single generated module can prove the change, use
+`ldev deploy module <module-name>` instead.
+
+## Liferay Objects
+
+Use for custom data models on DXP 7.4+ that need their own headless REST API
+without traditional OSGi modules.
+
+References:
+
+- `references/objects.md`
+- `references/oauth2-setup.md`
+- `references/headless-openapi.md`
+
+## Journal structures, templates, and ADTs
+
+Use the stable file-based resource workflows instead of ad hoc API calls.
+
+References:
+
+- `references/structures.md`
+- `references/structure-field-catalog.md`
+- `references/workflow.md`
+- `references/groovy-console.md`
+
+```bash
+ldev resource import-structure --site /<site> --structure <STRUCTURE_KEY> --check-only
+ldev resource import-template --site /<site> --template <TEMPLATE_ID> --check-only
+ldev resource import-adt --site /<site> --file <path/to/adt.ftl> --check-only
+```
+
+When validation looks correct, run the same command without `--check-only`.
+
+## Fragments
+
+Treat fragments as versioned source plus explicit import workflow.
+
+Reference: `references/fragments.md`
+
+```bash
+ldev resource fragments --site /<site> --json
+ldev resource import-fragment --site /<site> --fragment <fragment-key>
+```
+
+`import-fragment` has no `--check-only` flag. Validate the fragment source file
+manually before importing.
+
+If the project uses a separate fragment authoring flow outside `ldev`, follow
+that project-owned workflow instead of inventing custom commands.

--- a/templates/ai/skills/developing-liferay/references/resource-workflow.md
+++ b/templates/ai/skills/developing-liferay/references/resource-workflow.md
@@ -1,0 +1,67 @@
+# Repository-Backed Resource Workflow
+
+Use this reference when structures, templates, ADTs, or fragments should be
+reviewed as files in Git instead of edited ad hoc through the UI.
+
+## 1. Discover exact identifiers
+
+```bash
+ldev portal inventory structures --site /<site> --json
+ldev portal inventory templates --site /<site> --json
+ldev resource fragments --site /<site> --json
+```
+
+## 2. Export current portal state
+
+Use focused exports when changing one object:
+
+```bash
+ldev resource export-structure --site /<site> --structure <STRUCTURE_KEY>
+ldev resource export-template --site /<site> --template <TEMPLATE_ID>
+ldev resource export-adt --site /<site> --adt <ADT_KEY> --widget-type <widget-type>
+ldev resource export-fragment --site /<site> --fragment <FRAGMENT_KEY>
+```
+
+If you intentionally need several resources, repeat the singular export command
+per resource. Do not use plural export commands unless a human explicitly asked
+for a bulk refresh and accepted the larger diff.
+
+## 3. Edit locally
+
+Review the exported resource files like any other source change.
+
+## 4. Validate before mutating
+
+```bash
+ldev resource import-structure --site /<site> --structure <STRUCTURE_KEY> --check-only
+ldev resource import-template --site /<site> --template <TEMPLATE_ID> --check-only
+ldev resource import-adt --site /<site> --file <path/to/adt.ftl> --check-only
+```
+
+`--check-only` is drift detection, not a semantic validator. If you changed the
+file, a hash mismatch is expected. Review the diff, then proceed to the real
+import when the change is intentional.
+
+## 5. Apply the smallest safe import
+
+```bash
+ldev resource import-structure --site /<site> --structure <STRUCTURE_KEY>
+ldev resource import-template --site /<site> --template <TEMPLATE_ID>
+ldev resource import-adt --site /<site> --file <path/to/adt.ftl>
+ldev resource import-fragment --site /<site> --fragment <fragment-key>
+```
+
+`import-fragment` has no `--check-only` flag. Validate the fragment source
+manually before importing.
+
+## Guardrails
+
+- Do not deploy themes or modules to apply Journal templates, ADTs, fragments,
+  or structures.
+- Do not use plural export/import commands unless a human accepted the broader
+  diff or mutation scope.
+- Verify browser-visible changes after import; import success alone is not
+  sufficient evidence.
+- If you write production promotion notes for a runtime-backed resource,
+  include the matching manual Liferay UI fallback from
+  `runtime-resource-production-handoff.md`; do not assume remote `ldev` access.

--- a/templates/ai/skills/developing-liferay/references/runtime-resource-production-handoff.md
+++ b/templates/ai/skills/developing-liferay/references/runtime-resource-production-handoff.md
@@ -1,0 +1,89 @@
+# Runtime Resource Production Handoff
+
+Use this reference when the final handoff explains how to promote a runtime-backed
+resource to production.
+
+This applies to resources such as Journal templates, ADTs, structures, and
+fragments. The promotion target is the runtime resource itself, not a theme or
+module deploy.
+
+## Required handoff contract
+
+When production promotion is mentioned for a runtime-backed resource, the handoff
+must include all of the following:
+
+1. **Preferred path** — the `ldev resource ...` command sequence when that path
+   is available in the target environment.
+2. **Manual UI fallback** — the equivalent Liferay UI path when remote `ldev`
+   access is not guaranteed.
+3. **Resource identity** — site scope plus exact key, template, ADT, or fragment
+   identifier so the human can find the same object in the UI.
+4. **Equivalence statement** — say explicitly that the UI fallback applies the
+   same runtime resource and must not be replaced with theme or module deploy.
+5. **Post-apply verification** — what to check after import or manual update.
+
+Do not write production notes that only mention `ldev` when the real workflow
+may require UI-based promotion.
+
+## Manual UI fallback by resource type
+
+UI labels vary by Liferay version, edition, and language pack. Use the site or
+global scope resolved during discovery and adapt the exact menu label to the
+target environment.
+
+### Journal template
+
+1. Open the resolved site scope, such as `/global`.
+2. Go to the Web Content administration area and open **Templates**.
+3. Find the template by the exact template key or name from the handoff.
+4. Open the existing template and replace the template script with the reviewed
+   repository content.
+5. Save or publish the template.
+
+### ADT
+
+1. Open the resolved site scope.
+2. Go to the Application Display Template or owning display-template UI for the
+   relevant widget or content type.
+3. Find the ADT by the exact ADT key, display style, or name from the handoff.
+4. Replace the template script with the reviewed repository content.
+5. Save or publish the ADT.
+
+### Structure
+
+1. Open the resolved site scope.
+2. Go to the Web Content administration area and open **Structures**.
+3. Find the structure by the exact structure key or name from the handoff.
+4. If the UI supports structure import in that environment, import the reviewed
+   structure definition. Otherwise, open the existing structure and apply the
+   reviewed field and settings changes manually.
+5. Save or publish the structure.
+
+### Fragment
+
+1. Open the resolved site scope.
+2. Go to **Fragments**.
+3. Find the fragment collection and fragment by the exact identifiers from the
+   handoff.
+4. If the environment uses fragment import packages, import the reviewed asset.
+   Otherwise, open the fragment and apply the reviewed HTML, CSS, JS, and
+   configuration changes manually.
+5. Publish the fragment if the UI requires it.
+
+## Required wording in the handoff
+
+Use wording with this shape:
+
+- **Preferred path (`ldev`)**: the exact atomic import commands.
+- **Manual UI fallback**: how to locate and update the same runtime resource in
+  Liferay when `ldev` cannot be executed against production.
+- **Important**: this is a runtime resource change; do not deploy a theme or
+  module to apply it.
+
+## Verification after apply
+
+After either the `ldev` path or the manual UI fallback:
+
+- confirm the resolved resource now matches the intended reviewed content
+- verify the affected page or widget visually
+- confirm the expected symptom or behavior changed in the runtime, not only in Git

--- a/templates/ai/skills/developing-liferay/references/structure-field-catalog.md
+++ b/templates/ai/skills/developing-liferay/references/structure-field-catalog.md
@@ -16,6 +16,37 @@ Validate before mutating:
 ldev resource import-structure --site /<site> --structure <STRUCTURE_KEY> --check-only
 ```
 
+## FTL field accessor patterns
+
+Before writing any new FreeMarker template logic or DDM field accessor, grep
+the repository for the canonical pattern used for that field type:
+
+```bash
+# Find how the repo reads boolean or checkbox DDM fields
+grep -rE "getterUtil|getData|has_content" . --include="*.ftl" -l
+grep -rE "getterUtil" . --include="*.ftl" -n | head -20
+
+# Find existing examples for a specific field name
+grep -rE "<DDM_FIELD_NAME>" . --include="*.ftl" -n
+```
+
+Do not invent a new accessor pattern. Copy the dominant pattern from existing files.
+
+**Critical pitfall — boolean/checkbox fields:**
+Using `?has_content` on a boolean DDM field returns `true` even when the field
+value is `false`, because the string `"false"` is non-empty.
+
+```freemarker
+<#-- WRONG: always true even when checkbox is unchecked -->
+<#if myBooleanField?has_content>...</#if>
+
+<#-- CORRECT: use getterUtil.getBoolean to read boolean DDM fields -->
+<#if getterUtil.getBoolean(myBooleanField.getData())>...</#if>
+```
+
+Apply `getterUtil.getBoolean(fieldVar.getData())` for any `checkbox` or
+`boolean` field type.
+
 ---
 
 ## Top-level skeleton

--- a/templates/ai/skills/liferay-expert/SKILL.md
+++ b/templates/ai/skills/liferay-expert/SKILL.md
@@ -59,30 +59,12 @@ ldev portal inventory page --url <fullUrl> --json --full
 
 ## Routing rules
 
-- If the cause is not clear yet:
-  - use `troubleshooting-liferay`
-  - useful references there:
-    - `../troubleshooting-liferay/references/reindex-after-import.md`
-    - `../troubleshooting-liferay/references/reindex-journal.md`
-    - `../troubleshooting-liferay/references/ddm-migration.md`
-    - `../troubleshooting-liferay/references/search-debug.md` — for buscador / search widget failures
-    - `../troubleshooting-liferay/references/content-versions.md` — for version accumulation or empty language versions
-- If the change is known and you need to edit source or portal resources:
-  - use `developing-liferay`
-  - useful references there:
-    - `../developing-liferay/references/theme.md`
-    - `../developing-liferay/references/structures.md`
-    - `../developing-liferay/references/fragments.md`
-    - `../developing-liferay/references/osgi.md`
-    - `../developing-liferay/references/extending-liferay.md`
-    - `../developing-liferay/references/groovy-console.md` — for portal console scripts, ERC vocabulary fixes
-    - `../developing-liferay/references/workflow.md` — for publish failures and workflow approval issues
-- If the change already exists and you need to build, deploy or verify runtime:
-  - use `deploying-liferay`
-  - useful reference there:
-    - `../deploying-liferay/references/worktree-pitfalls.md`
-- If the task changes Journal structures with data migration risk:
-  - use `migrating-journal-structures`
+Choose the next specialist skill using `references/routing.md`:
+
+- unclear cause -> `troubleshooting-liferay`
+- known implementation change -> `developing-liferay`
+- existing change that needs deploy or verification -> `deploying-liferay`
+- Journal migration risk -> `migrating-journal-structures`
 
 ## Site-level objects
 
@@ -95,14 +77,64 @@ ldev portal inventory pages --site /<site> --json
 ldev portal inventory page --url <fullUrl> --json
 ```
 
-For details on Display Page Templates, Navigation Menus, multi-site resource
-ownership, and content volume inspection, see
+For deeper routing notes and specialist reference entrypoints, read
+`references/routing.md`. For details on Display Page Templates, Navigation
+Menus, multi-site resource ownership, and content volume inspection, see
 `references/site-objects.md`.
+
+## Discovery commands
+
+Three commands are often confused — use the right one for each situation:
+
+- `ldev context --json` — offline project facts (repo config, auth state, resource
+  paths, version). No runtime required. Use for routing decisions and bootstrap.
+- `ldev status --json` — Docker/runtime state (containers running, ports). Use to
+  confirm the env is up before portal or deploy operations.
+- `ldev doctor --json` — active failures and readiness checks. Cheap by default
+  (repo/config/tool presence only). Add scope flags when runtime checks matter:
+  `--runtime`, `--portal`, `--osgi`.
+
+## AI asset maintenance
+
+When skills or agent context files are out of date:
+
+```bash
+# Check installed skill state and drift
+ldev ai status --target <project-root> --json
+
+# Update vendor skills to the latest published versions
+ldev ai update --target <project-root>
+
+# Update only a specific skill
+ldev ai update --target <project-root> --skill <skill-name>
+```
+
+Run `ldev ai status` first to understand what is installed before updating.
+
+## OAuth2 prerequisite
+
+Most portal and resource commands require OAuth2 credentials. If
+`context.liferay.auth.oauth2.clientId.status` is not `"present"`, set up
+credentials first:
+
+```bash
+ldev start
+ldev oauth install --write-env
+```
+
+`--write-env` persists the credentials to `.liferay-cli.local.yml` so all
+subsequent commands and agents can use them without re-running the installer.
+If the admin account is in password-reset state, unblock it first:
+
+```bash
+ldev oauth admin-unblock
+```
 
 ## Shared guardrails
 
 - Use `ldev` as the official interface.
-- Prefer `ldev context --json`, `ldev doctor --json` and `ldev status --json` for automation and agents.
+- Use `ldev context --json` for offline routing; use `ldev status --json` only
+  to confirm runtime state. They are not interchangeable.
 - Prefer the smallest deploy or import that proves the change.
 - Do not invent portal mutations if an `ldev resource ...` workflow already exists.
 - For site-level objects without dedicated `ldev` commands, verify MCP with

--- a/templates/ai/skills/liferay-expert/references/routing.md
+++ b/templates/ai/skills/liferay-expert/references/routing.md
@@ -14,25 +14,25 @@ technical Liferay work and you need the next specialized skill.
 
 ### Troubleshooting
 
-- `../troubleshooting-liferay/references/reindex-after-import.md`
-- `../troubleshooting-liferay/references/reindex-journal.md`
-- `../troubleshooting-liferay/references/ddm-migration.md`
-- `../troubleshooting-liferay/references/search-debug.md`
-- `../troubleshooting-liferay/references/content-versions.md`
+- `../../troubleshooting-liferay/references/reindex-after-import.md`
+- `../../troubleshooting-liferay/references/reindex-journal.md`
+- `../../troubleshooting-liferay/references/ddm-migration.md`
+- `../../troubleshooting-liferay/references/search-debug.md`
+- `../../troubleshooting-liferay/references/content-versions.md`
 
 ### Implementation
 
-- `../developing-liferay/references/theme.md`
-- `../developing-liferay/references/structures.md`
-- `../developing-liferay/references/fragments.md`
-- `../developing-liferay/references/osgi.md`
-- `../developing-liferay/references/extending-liferay.md`
-- `../developing-liferay/references/groovy-console.md`
-- `../developing-liferay/references/workflow.md`
+- `../../developing-liferay/references/theme.md`
+- `../../developing-liferay/references/structures.md`
+- `../../developing-liferay/references/fragments.md`
+- `../../developing-liferay/references/osgi.md`
+- `../../developing-liferay/references/extending-liferay.md`
+- `../../developing-liferay/references/groovy-console.md`
+- `../../developing-liferay/references/workflow.md`
 
 ### Deploy and verify
 
-- `../deploying-liferay/references/worktree-pitfalls.md`
+- `../../deploying-liferay/references/worktree-pitfalls.md`
 
 ## Site-level objects
 

--- a/templates/ai/skills/liferay-expert/references/routing.md
+++ b/templates/ai/skills/liferay-expert/references/routing.md
@@ -1,0 +1,41 @@
+# Routing Reference
+
+Use this reference when `liferay-expert` has already determined that the task is
+technical Liferay work and you need the next specialized skill.
+
+## Choose the next skill
+
+- If the cause is not clear yet -> `troubleshooting-liferay`
+- If the change is known and you need to edit source or portal resources -> `developing-liferay`
+- If the change already exists and you need to build, deploy, or verify runtime -> `deploying-liferay`
+- If the task changes Journal structures with data migration risk -> `migrating-journal-structures`
+
+## Useful follow-up references
+
+### Troubleshooting
+
+- `../troubleshooting-liferay/references/reindex-after-import.md`
+- `../troubleshooting-liferay/references/reindex-journal.md`
+- `../troubleshooting-liferay/references/ddm-migration.md`
+- `../troubleshooting-liferay/references/search-debug.md`
+- `../troubleshooting-liferay/references/content-versions.md`
+
+### Implementation
+
+- `../developing-liferay/references/theme.md`
+- `../developing-liferay/references/structures.md`
+- `../developing-liferay/references/fragments.md`
+- `../developing-liferay/references/osgi.md`
+- `../developing-liferay/references/extending-liferay.md`
+- `../developing-liferay/references/groovy-console.md`
+- `../developing-liferay/references/workflow.md`
+
+### Deploy and verify
+
+- `../deploying-liferay/references/worktree-pitfalls.md`
+
+## Site-level objects
+
+When the task involves Display Page Templates, Navigation Menus, multi-site
+resource ownership, or content volume inspection, resolve the affected site
+first and then use `site-objects.md` for the deeper object guidance.

--- a/templates/ai/skills/troubleshooting-liferay/SKILL.md
+++ b/templates/ai/skills/troubleshooting-liferay/SKILL.md
@@ -81,7 +81,10 @@ ldev osgi thread-dump
 
 ### Portal discovery issues
 
-If a page, site, structure or template is involved, resolve it from the portal:
+If a page, site, structure or template is involved, resolve it from the portal
+immediately. When the report mentions one or more URLs, inspect every mentioned
+URL with `ldev portal inventory page --url` before code search, browser
+reproduction, or speculative diagnosis:
 
 ```bash
 ldev portal inventory page --url <fullUrl> --json
@@ -91,6 +94,9 @@ ldev portal inventory templates --site /<site> --json
 
 For structure/template incidents, treat `--with-templates` as the default
 discovery path to avoid separate lookup rounds.
+
+Do not assume two reported URLs point to the same page state, site, or owning
+resource until both have been inspected.
 
 When the default output is not enough (e.g. you need content fields, all template
 candidates, or the raw page definition), add `--full`:

--- a/templates/ai/skills/troubleshooting-liferay/SKILL.md
+++ b/templates/ai/skills/troubleshooting-liferay/SKILL.md
@@ -24,6 +24,19 @@ Inspect:
 - `doctor.checks[]` — active failures and remedies.
 - `doctor.readiness.*` — command-level readiness.
 
+`ldev status --json` returns Docker/container state. `ldev context --json`
+returns offline repo/config/auth facts. They are not interchangeable — use
+`ldev status` only to confirm the env is running, not for routing decisions.
+
+When `doctor.checks[]` contains failures, add the matching scope flag for
+deeper checks:
+
+```bash
+ldev doctor --runtime --json   # container and service health
+ldev doctor --portal --json    # portal API reachability and auth
+ldev doctor --osgi --json      # bundle state and missing requirements
+```
+
 If the env is not running, start it before deeper analysis:
 
 ```bash
@@ -92,136 +105,40 @@ candidates, all `renderedContents`. For regular pages: `full.configurationRaw` a
 
 ### Production reproduction
 
-When the issue does not reproduce with clean local data, bring production-like
-state into the local environment before guessing:
+When a clean local environment is not enough, import production-like state
+before guessing:
 
 ```bash
+# Sync database from Liferay Cloud
 ldev db sync --environment <env> --project <lcp-project> --force
-```
-
-If you already have a local backup file:
-
-```bash
+# OR import a local backup
 ldev db import --file /path/to/backup.sql.gz --force
-```
 
-When the issue depends on Document Library files:
-
-```bash
+# If the issue depends on Document Library files, download them first
 ldev db files-download --environment <env> --project <lcp-project> --doclib-dest docker/doclib/<env>
 ldev db files-mount --path docker/doclib/<env>
-```
+# OR mount a local path directly
+ldev db files-mount --path /path/to/doclib
 
-If the files are not coming from Liferay Cloud, mount the prepared local path:
-
-```bash
-ldev db files-mount --path /path/to/manual/doclib
-```
-
-Then restart the local diagnosis loop:
-
-```bash
+# Restart and verify
 ldev start
 ldev doctor --json
-ldev portal inventory sites --json
 ldev logs diagnose --since 15m --json
 ```
 
-### Post-import content volume
-
-After importing a production database, Journal content volume may be too large
-for practical local reindexing or day-to-day use.
-
-Check content volume per site before reindexing:
+After import, check content volume before reindexing:
 
 ```bash
 ldev portal inventory sites --with-content --sort-by content
 ```
 
-Scope to one site for folder-level detail:
+For database restore options, file-download flows, content pruning, and
+post-import tuning, see `references/production-reproduction.md`.
 
-```bash
-ldev portal inventory sites --site /<site> --with-structures --limit 20
-```
+### Specialized diagnosis paths
 
-If volume is too high, preview a prune first:
-
-```bash
-ldev portal content prune \
-  --group-id <groupId> \
-  --root-folder <folderId> \
-  --keep 100 \
-  --dry-run
-```
-
-Review the dry-run output (`articleCount`, `keptCount`, `deletedCount`,
-`Breakdown by structure`) before applying. Run without `--dry-run` only when
-the plan is correct.
-
-Use `--keep-scope structure` when you want to retain N most recent articles per
-structure type across all selected folders instead of per folder.
-
-### Isolated worktree troubleshooting
-
-Use `isolating-worktrees` for the canonical setup, root lock, recovery, and cleanup flow.
-
-When a risky fix or a production-like reproduction should not share runtime
-state with the main checkout, isolate it:
-
-```bash
-ldev worktree setup --name incident-<id> --with-env --stop-main-for-clone --restart-main-after-clone
-cd .worktrees/incident-<id>
-ldev start
-ldev status --json
-```
-
-If a human explicitly wants the main checkout left stopped after cloning, use
-this exception path instead:
-
-```bash
-ldev worktree setup --name incident-<id> --with-env --stop-main-for-clone
-```
-
-Use a worktree when:
-
-- one branch is reproducing an incident and another is active development
-- a migration or reproduction needs its own local DB or mounted file state
-- you need to compare behavior across branches without mixing runtime state
-
-### Reindex issues
-
-References:
-
-- `references/reindex-after-import.md`
-- `references/reindex-journal.md`
-
-### Search and buscadores not working
-
-Reference: `references/search-debug.md`
-
-Covers: search widget returning 0 results, filter widgets (category/tag) not
-working, persistent visual bugs such as a hidden "Limpiar" button, and guest
-vs. authenticated result differences.
-
-### Content version accumulation or empty language versions
-
-Reference: `references/content-versions.md`
-
-Covers: articles with excessive version history, empty linguistic versions
-added by bulk sync processes, and Groovy-based bulk version cleanup.
-
-```bash
-ldev portal reindex status --json
-ldev portal reindex tasks --json
-ldev portal reindex watch --json
-```
-
-Enable temporary speedup only while an actual reindex is active:
-
-```bash
-ldev portal reindex speedup-on
-ldev portal reindex speedup-off
-```
+Use `references/specialized-diagnosis.md` for isolated worktree incidents,
+reindex incidents, search widget failures, and content-version cleanup cases.
 
 ## Recovery actions
 
@@ -230,6 +147,8 @@ Use these only when diagnosis points to broken local runtime state:
 Reference:
 
 - `references/ddm-migration.md`
+- `references/production-reproduction.md`
+- `references/specialized-diagnosis.md`
 
 ```bash
 ldev stop

--- a/templates/ai/skills/troubleshooting-liferay/references/production-reproduction.md
+++ b/templates/ai/skills/troubleshooting-liferay/references/production-reproduction.md
@@ -1,0 +1,71 @@
+# Production-Like Reproduction
+
+Use this reference when a problem depends on real data volume, imported content,
+or runtime state that a clean local environment cannot reproduce.
+
+## Bring production-like state locally
+
+```bash
+ldev db sync --environment <env> --project <lcp-project> --force
+```
+
+If you already have a local backup file:
+
+```bash
+ldev db import --file /path/to/backup.sql.gz --force
+```
+
+When the issue depends on Document Library files:
+
+```bash
+ldev db files-download --environment <env> --project <lcp-project> --doclib-dest docker/doclib/<env>
+ldev db files-mount --path docker/doclib/<env>
+```
+
+If the files are not coming from Liferay Cloud, mount the prepared local path:
+
+```bash
+ldev db files-mount --path /path/to/manual/doclib
+```
+
+Then restart the diagnosis loop:
+
+```bash
+ldev start
+ldev doctor --json
+ldev portal inventory sites --json
+ldev logs diagnose --since 15m --json
+```
+
+## Post-import content volume
+
+After importing a production database, Journal content volume may be too large
+for practical local reindexing or normal day-to-day use.
+
+Check volume per site before reindexing:
+
+```bash
+ldev portal inventory sites --with-content --sort-by content
+```
+
+Scope to one site for folder-level detail:
+
+```bash
+ldev portal inventory sites --site /<site> --with-structures --limit 20
+```
+
+If volume is too high, preview a prune first:
+
+```bash
+ldev portal content prune \
+  --group-id <groupId> \
+  --root-folder <folderId> \
+  --keep 100 \
+  --dry-run
+```
+
+Review the dry-run output before applying. Run without `--dry-run` only when
+the plan is correct.
+
+Use `--keep-scope structure` when you want to retain the N most recent articles
+per structure type across all selected folders instead of per folder.

--- a/templates/ai/skills/troubleshooting-liferay/references/specialized-diagnosis.md
+++ b/templates/ai/skills/troubleshooting-liferay/references/specialized-diagnosis.md
@@ -33,8 +33,8 @@ Use a worktree when:
 
 References:
 
-- `references/reindex-after-import.md`
-- `references/reindex-journal.md`
+- `reindex-after-import.md`
+- `reindex-journal.md`
 
 ```bash
 ldev portal reindex status --json
@@ -51,7 +51,7 @@ ldev portal reindex speedup-off
 
 ## Search and buscadores
 
-Reference: `references/search-debug.md`
+Reference: `search-debug.md`
 
 Covers search widgets returning 0 results, filter widgets not working,
 persistent visual bugs such as a hidden "Limpiar" button, and guest versus
@@ -59,7 +59,7 @@ authenticated result differences.
 
 ## Content version accumulation or empty language versions
 
-Reference: `references/content-versions.md`
+Reference: `content-versions.md`
 
 Covers excessive version history, empty linguistic versions added by bulk sync
 processes, and Groovy-based cleanup workflows.

--- a/templates/ai/skills/troubleshooting-liferay/references/specialized-diagnosis.md
+++ b/templates/ai/skills/troubleshooting-liferay/references/specialized-diagnosis.md
@@ -1,0 +1,115 @@
+# Specialized Diagnosis Paths
+
+Use this reference for troubleshooting branches that are important but only
+apply to specific incident shapes.
+
+## Isolated worktree troubleshooting
+
+Use `isolating-worktrees` for the canonical setup, root lock, recovery, and cleanup flow.
+
+When a risky fix or a production-like reproduction should not share runtime
+state with the main checkout, isolate it:
+
+```bash
+ldev worktree setup --name incident-<id> --with-env --stop-main-for-clone --restart-main-after-clone
+cd .worktrees/incident-<id>
+ldev start
+ldev status --json
+```
+
+If a human explicitly wants the main checkout left stopped after cloning, use:
+
+```bash
+ldev worktree setup --name incident-<id> --with-env --stop-main-for-clone
+```
+
+Use a worktree when:
+
+- one branch is reproducing an incident and another is active development
+- a migration or reproduction needs its own local DB or mounted file state
+- you need to compare behavior across branches without mixing runtime state
+
+## Reindex incidents
+
+References:
+
+- `references/reindex-after-import.md`
+- `references/reindex-journal.md`
+
+```bash
+ldev portal reindex status --json
+ldev portal reindex tasks --json
+ldev portal reindex watch --json
+```
+
+Enable temporary speedup only while an actual reindex is active:
+
+```bash
+ldev portal reindex speedup-on
+ldev portal reindex speedup-off
+```
+
+## Search and buscadores
+
+Reference: `references/search-debug.md`
+
+Covers search widgets returning 0 results, filter widgets not working,
+persistent visual bugs such as a hidden "Limpiar" button, and guest versus
+authenticated result differences.
+
+## Content version accumulation or empty language versions
+
+Reference: `references/content-versions.md`
+
+Covers excessive version history, empty linguistic versions added by bulk sync
+processes, and Groovy-based cleanup workflows.
+
+## Environment lifecycle and recovery
+
+When basic `ldev start` / `ldev stop` are not enough:
+
+```bash
+# Restart only the liferay service (faster than full stop/start)
+ldev env restart
+ldev env restart --timeout 300
+
+# Full container recreation (destroys and recreates docker resources)
+ldev env recreate
+
+# Wipe local docker resources and bind-mounted runtime data (destructive)
+ldev env clean --force
+
+# Restore runtime data from main checkout or BTRFS_BASE snapshot
+ldev env restore
+
+# Wait for health in scripts or after a restart
+ldev env wait --timeout 300
+
+# Scriptable health check (exits 1 if unhealthy)
+ldev env is-healthy --json
+
+# Compare current environment against a saved baseline
+ldev env diff --json
+ldev env diff --write-baseline   # save current state as new baseline
+```
+
+Use `ldev env clean --force` only as a last resort — it removes all local
+runtime data. Use `ldev env restore` first when the goal is to reset to a
+known good state.
+
+## Emergency SQL diagnosis
+
+When portal APIs are unavailable or return inconsistent results, query the
+database directly:
+
+```bash
+# Inline query
+ldev db query "SELECT * FROM JournalArticle WHERE groupId = <groupId> LIMIT 10"
+
+# From a file
+ldev db query --file /path/to/diagnostic.sql
+```
+
+Use `ldev db query` for read-only diagnosis. For any mutating SQL, confirm
+explicitly with the developer before executing. Always scope queries with
+`WHERE` or `LIMIT` to avoid locking or performance issues on large tables.

--- a/templates/ai/workspace-rules/ldev-native-agent-workflow.md
+++ b/templates/ai/workspace-rules/ldev-native-agent-workflow.md
@@ -60,7 +60,21 @@ Deploy commands are only for deployable artifacts. Use `ldev deploy theme`
 when the theme changed, and `ldev deploy module <module-name>` when modules or
 deployable Gradle units changed. For Journal templates, ADTs, fragments, and
 structures, use the runtime resource import workflow and validate the affected
-page with `playwright-cli`.
+page with `playwright-cli`. If source config or properties changed, restart the
+environment before validation.
+
+Hard rule after edits:
+
+- `modules/` changed -> `ldev deploy module <module-name>`
+- theme source changed -> `ldev deploy theme`
+- structure changed -> `ldev resource import-structure --site /<site> --structure <STRUCTURE_KEY>`
+- ADT changed -> `ldev resource import-adt --site /<site> --file <path/to/adt.ftl>`
+- template changed -> `ldev resource import-template --site /<site> --template <TEMPLATE_ID>`
+- fragment changed -> `ldev resource import-fragment --site /<site> --fragment <fragment-key>`
+- properties or source config changed -> `ldev env restart`
+
+Do not say the fix is applied just because files were edited. The matching
+deploy, import, or restart step is part of the fix.
 
 Before creating an isolated worktree, verify the current branch. If the primary
 checkout is not on `main`, pass the intended `--base <ref>` explicitly instead

--- a/templates/ai/workspace-rules/ldev-native-agent-workflow.md
+++ b/templates/ai/workspace-rules/ldev-native-agent-workflow.md
@@ -48,9 +48,11 @@ Prefer atomic commands. Do not use plural resource commands or a broad deploy
 unless a human explicitly asks for a bulk operation and the risk is written down
 first.
 
-When an issue starts from a URL, do not reproduce or validate against the
-production host. Resolve the page through `ldev portal inventory page --url`,
-switch to the local runtime URL, and inspect that page before searching code.
+When an issue starts from one or more URLs, do not reproduce or validate against
+the production host. Resolve every mentioned page through
+`ldev portal inventory page --url`, switch to the local runtime URL, and inspect
+those pages before searching code. Treat that inspection as the default first
+context-gathering step whenever a relevant URL is available.
 Use page inspection to identify the concrete ADT, template, fragment, module,
 or theme surface first; broad grep comes after that.
 


### PR DESCRIPTION
## Changes per skill

### `liferay-expert`
- Added `status` / `context` / `doctor` disambiguation — they are not interchangeable
- Added `ldev doctor --runtime/--portal/--osgi` scope flags inline with descriptions
- Added AI asset maintenance section (`ldev ai status`, `ldev ai update --skill`)
- Added OAuth2 prerequisite sequence (`ldev oauth install --write-env`, `admin-unblock`)
- New: `references/routing.md`

### `developing-liferay`
- Resource workflow fully inline (4-step sequence with correct `import-fragment` caveat — no `--check-only`)
- Implementation paths partially inline; detail in `references/implementation-paths.md`
- Added portal config section (`ldev portal config get/set`)
- **Restored:** boolean DDM field pitfall — `?has_content` always returns `true` on the string `"false"`;
  fix is `getterUtil.getBoolean(fieldVar.getData())` — in `references/structure-field-catalog.md`
- **Restored:** FTL pattern grep discovery commands (find dominant pattern before writing new accessor logic)
- New: `references/resource-workflow.md`, `references/implementation-paths.md`,
  `references/runtime-resource-production-handoff.md`

### `deploying-liferay`
- Added `ldev deploy prepare` section (stages artifacts without hot-deploying; `--allow-running-env` flag)

### `troubleshooting-liferay`
- `ldev doctor --runtime/--portal/--osgi` scope flags inline with descriptions
- `ldev status` vs `ldev context` disambiguation inline
- Production reproduction sequence condensed inline; db files flow and content prune detail in references
- New: `references/production-reproduction.md`, `references/specialized-diagnosis.md`
  (worktree isolation, reindex, search debug, content-version cleanup, env lifecycle, emergency SQL)

### `issue-engineering`
- Red-2 gate + worktree setup commands inline
- Scope lock checklist and scope-creep traps inline
- Artifact contract (`brief.md` / `solution-plan.md`) inline with routing table
- Gate order and extended detail moved to `references/execution-flow.md`
- New: `references/execution-flow.md`, `references/runtime-resource-handoff-template.md`

## New docs

| File | Purpose |
|---|---|
| `docs/SKILL_STANDARDS.md` | Canonical rules for maintaining this architecture |
| `docs/SKILL_REVIEW_CHECKLIST.md` | Checklist for reviewing future skill changes |

## Stats

17 files changed, 942 insertions(+), 408 deletions(-)