### PR TITLE
Fix multi-site structure and template discovery

### DIFF
--- a/docs/commands/discovery.md
+++ b/docs/commands/discovery.md
@@ -136,6 +136,8 @@ ldev portal inventory structures --all-sites --with-templates --json
 
 Prefer `--with-templates` as the first discovery step for structure/template incidents: it returns structures enriched with their associated templates in one call.
 
+In text mode, `--with-templates` renders a detailed site -> structure -> template view. In `--all-sites` text mode, sites with no structures are omitted to keep discovery output focused.
+
 ## `ldev portal inventory templates`
 
 List web content templates for a site.

--- a/docs/core-concepts/structured-output.md
+++ b/docs/core-concepts/structured-output.md
@@ -11,7 +11,7 @@ Every `ldev` command that returns data supports a structured output mode.
 
 - `--format text` (default for most) — human-readable output
 - `--json` / `--format json` — pretty-printed JSON, one object per command run
-- `--ndjson` / `--format ndjson` — one JSON value per line, suitable for streaming commands
+- `--ndjson` / `--format ndjson` — newline-delimited JSON output; most commands still emit one final JSON value, while streaming-style commands may emit multiple lines
 - `--strict` — return a non-zero exit code when the result indicates something is wrong (even if the command itself succeeded)
 
 Some commands default to JSON because their output is primarily structured:

--- a/src/features/liferay/inventory/liferay-inventory-structures.ts
+++ b/src/features/liferay/inventory/liferay-inventory-structures.ts
@@ -1,6 +1,7 @@
 import type {AppConfig} from '../../../core/config/load-config.js';
 import type {HttpApiClient} from '../../../core/http/client.js';
 import type {OAuthTokenClient} from '../../../core/http/auth.js';
+import {isCliError} from '../../../core/errors.js';
 import {fetchPagedItems} from './liferay-inventory-shared.js';
 import {normalizeLocalizedName, resolveSite} from '../portal/site-resolution.js';
 import {runLiferayInventoryTemplates} from './liferay-inventory-templates.js';
@@ -75,19 +76,31 @@ export async function runLiferayInventoryStructuresAllSites(
     dependencies,
   );
 
-  const rows = await Promise.all(
-    sites.map(async (site) => ({
-      siteGroupId: site.groupId,
-      siteFriendlyUrl: site.siteFriendlyUrl,
-      siteName: site.name,
-      structures: await runLiferayInventoryStructuresForSiteId(
-        config,
-        site.groupId,
-        {site: site.siteFriendlyUrl, pageSize: options?.pageSize, withTemplates: options?.withTemplates},
-        dependencies,
-      ),
-    })),
-  );
+  const rows = (
+    await Promise.all(
+      sites.map(async (site) => {
+        try {
+          return {
+            siteGroupId: site.groupId,
+            siteFriendlyUrl: site.siteFriendlyUrl,
+            siteName: site.name,
+            structures: await runLiferayInventoryStructuresForSiteId(
+              config,
+              site.groupId,
+              {site: site.siteFriendlyUrl, pageSize: options?.pageSize, withTemplates: options?.withTemplates},
+              dependencies,
+            ),
+          };
+        } catch (error) {
+          if (isSkippableStructureInventoryError(error)) {
+            return null;
+          }
+
+          throw error;
+        }
+      }),
+    )
+  ).filter((row): row is LiferayInventoryStructuresSite => row !== null);
 
   return {
     sites: rows,
@@ -96,6 +109,14 @@ export async function runLiferayInventoryStructuresAllSites(
       totalStructures: rows.reduce((acc, row) => acc + row.structures.length, 0),
     },
   };
+}
+
+function isSkippableStructureInventoryError(error: unknown): boolean {
+  if (!isCliError(error) || error.code !== 'LIFERAY_INVENTORY_ERROR') {
+    return false;
+  }
+
+  return error.message.includes('status=400') && error.message.includes('/data-definitions/by-content-type/journal');
 }
 
 async function runLiferayInventoryStructuresForSiteId(
@@ -150,6 +171,18 @@ export function formatLiferayInventoryStructures(result: LiferayInventoryStructu
     return 'No structure data';
   }
 
+  if (hasTemplateDetails(result)) {
+    return formatLiferayInventoryStructuresTree(result);
+  }
+
+  return formatLiferayInventoryStructuresCompact(result);
+}
+
+function hasTemplateDetails(result: LiferayInventoryStructuresResult): boolean {
+  return result.sites.some((site) => site.structures.some((structure) => structure.templates !== undefined));
+}
+
+function formatLiferayInventoryStructuresCompact(result: LiferayInventoryStructuresResult): string {
   const lines: string[] = [];
 
   for (const site of result.sites) {
@@ -166,6 +199,41 @@ export function formatLiferayInventoryStructures(result: LiferayInventoryStructu
         );
       }
     }
+  }
+
+  lines.push(`totalSites=${result.summary.totalSites}`);
+  lines.push(`totalStructures=${result.summary.totalStructures}`);
+  return lines.join('\n');
+}
+
+function formatLiferayInventoryStructuresTree(result: LiferayInventoryStructuresResult): string {
+  const lines: string[] = [];
+  const sites = result.sites.length > 1 ? result.sites.filter((site) => site.structures.length > 0) : result.sites;
+
+  if (sites.length === 0) {
+    return 'No structure data';
+  }
+
+  for (const site of sites) {
+    lines.push(`site=${site.siteFriendlyUrl} name=${site.siteName} groupId=${site.siteGroupId}`);
+
+    for (const structure of site.structures) {
+      lines.push(`  structure=${structure.key} name=${structure.name} id=${structure.id}`);
+
+      if (!structure.templates || structure.templates.length === 0) {
+        lines.push('    template=(none)');
+      } else {
+        for (const template of structure.templates) {
+          lines.push(`    template=${template.name} erc=${template.externalReferenceCode} id=${template.id}`);
+        }
+      }
+    }
+
+    lines.push('');
+  }
+
+  if (lines.at(-1) === '') {
+    lines.pop();
   }
 
   lines.push(`totalSites=${result.summary.totalSites}`);

--- a/src/features/liferay/inventory/liferay-inventory-templates.ts
+++ b/src/features/liferay/inventory/liferay-inventory-templates.ts
@@ -1,6 +1,7 @@
 import type {AppConfig} from '../../../core/config/load-config.js';
 import type {HttpApiClient} from '../../../core/http/client.js';
 import type {OAuthTokenClient} from '../../../core/http/auth.js';
+import {isCliError} from '../../../core/errors.js';
 import {fetchPagedItems} from './liferay-inventory-shared.js';
 import {resolveSite} from '../portal/site-resolution.js';
 import {listDdmTemplates, resolveResourceSite} from '../portal/template-queries.js';
@@ -33,12 +34,22 @@ export async function runLiferayInventoryTemplates(
 
   for (const surface of policy.surfaces) {
     if (surface === 'headless-delivery') {
-      const rows = await fetchPagedItems<ContentTemplate>(
-        config,
-        `/o/headless-delivery/v1.0/sites/${site.id}/content-templates`,
-        pageSize,
-        dependencies,
-      );
+      let rows: ContentTemplate[];
+
+      try {
+        rows = await fetchPagedItems<ContentTemplate>(
+          config,
+          `/o/headless-delivery/v1.0/sites/${site.id}/content-templates`,
+          pageSize,
+          dependencies,
+        );
+      } catch (error) {
+        if (isSkippableHeadlessTemplateError(error)) {
+          continue;
+        }
+
+        throw error;
+      }
 
       if (rows.length > 0) {
         return rows.map(normalizeContentTemplate);
@@ -55,6 +66,14 @@ export async function runLiferayInventoryTemplates(
   }
 
   return [];
+}
+
+function isSkippableHeadlessTemplateError(error: unknown): boolean {
+  if (!isCliError(error) || error.code !== 'LIFERAY_INVENTORY_ERROR') {
+    return false;
+  }
+
+  return error.message.includes('status=400') && error.message.includes('/content-templates');
 }
 
 function normalizeContentTemplate(row: ContentTemplate): LiferayInventoryTemplate {

--- a/templates/ai/skills/developing-liferay/SKILL.md
+++ b/templates/ai/skills/developing-liferay/SKILL.md
@@ -65,6 +65,12 @@ ldev portal inventory page --url <fullUrl> --json
 ldev resource adt --display-style ddmTemplate_<ID> --site /<site> --json
 ```
 
+For cross-site structure/template incidents, use:
+
+```bash
+ldev portal inventory structures --with-templates --all-sites --json
+```
+
 If you are inside a worktree and the main runtime is still the source of truth
 for discovery, keep your shell in the worktree and call the global form:
 

--- a/templates/ai/skills/liferay-expert/SKILL.md
+++ b/templates/ai/skills/liferay-expert/SKILL.md
@@ -50,6 +50,12 @@ ldev portal inventory structures --site /<site> --json
 ldev portal inventory templates --site /<site> --json
 ```
 
+For cross-site structure/template discovery, prefer:
+
+```bash
+ldev portal inventory structures --with-templates --all-sites --json
+```
+
 The default page output is sufficient for routing. Add `--full` when the task
 requires content fields, all template candidates, or the raw page definition:
 

--- a/tests/unit/liferay-inventory.test.ts
+++ b/tests/unit/liferay-inventory.test.ts
@@ -349,7 +349,8 @@ describe('liferay inventory structures and templates', () => {
       summary: {totalSites: 1, totalStructures: 2},
     });
 
-    expect(formatLiferayInventoryStructures(result)).toContain('id=302 key=NEWS name=News templates=1');
+    expect(formatLiferayInventoryStructures(result)).toContain('structure=NEWS name=News id=302');
+    expect(formatLiferayInventoryStructures(result)).toContain('template=News Template erc=news-template id=40801');
   });
 
   test('lists structures for all sites in one run', async () => {
@@ -444,8 +445,106 @@ describe('liferay inventory structures and templates', () => {
       summary: {totalSites: 2, totalStructures: 2},
     });
 
-    expect(formatLiferayInventoryStructures(result)).toContain('site=/global groupId=20121 name=Global structures=1');
-    expect(formatLiferayInventoryStructures(result)).toContain('site=/ub groupId=20122 name=UB structures=1');
+    const formatted = formatLiferayInventoryStructures(result);
+
+    expect(formatted).toContain('site=/global name=Global groupId=20121');
+    expect(formatted).toContain('template=Global Template erc=global-template id=41001');
+    expect(formatted).toContain('site=/ub name=UB groupId=20122');
+  });
+
+  test('skips sites that reject structure inventory with 400 in all-sites mode', async () => {
+    const apiClient = createLiferayApiClient({
+      fetchImpl: createTestFetchImpl((url) => {
+        if (url.includes('/o/headless-admin-site/v1.0/sites?page=1&pageSize=2')) {
+          return new Response(
+            '{"items":[{"id":20121,"friendlyUrlPath":"/global","name":"Global"},{"id":20122,"friendlyUrlPath":"/unsupported","name":"Unsupported"},{"id":20123,"friendlyUrlPath":"/ub","name":"UB"}],"lastPage":1}',
+            {status: 200},
+          );
+        }
+
+        if (
+          url.includes('/o/data-engine/v2.0/sites/20121/data-definitions/by-content-type/journal?page=1&pageSize=2')
+        ) {
+          return new Response(
+            '{"items":[{"id":301,"dataDefinitionKey":"GLOBAL_BASIC","name":{"en_US":"Global Basic"}}],"lastPage":1}',
+            {status: 200},
+          );
+        }
+
+        if (
+          url.includes('/o/data-engine/v2.0/sites/20122/data-definitions/by-content-type/journal?page=1&pageSize=2')
+        ) {
+          return new Response('bad request', {status: 400});
+        }
+
+        if (
+          url.includes('/o/data-engine/v2.0/sites/20123/data-definitions/by-content-type/journal?page=1&pageSize=2')
+        ) {
+          return new Response(
+            '{"items":[{"id":302,"dataDefinitionKey":"UB_STR_NOVEDAD","name":{"en_US":"UB Novedad"}}],"lastPage":1}',
+            {status: 200},
+          );
+        }
+
+        throw new Error(`Unexpected URL ${url}`);
+      }),
+    });
+
+    const result = await runLiferayInventoryStructuresAllSites(
+      CONFIG,
+      {pageSize: 2},
+      {apiClient, tokenClient: TOKEN_CLIENT},
+    );
+
+    expect(result).toEqual({
+      sites: [
+        {
+          siteGroupId: 20121,
+          siteFriendlyUrl: '/global',
+          siteName: 'Global',
+          structures: [{id: 301, key: 'GLOBAL_BASIC', name: 'Global Basic'}],
+        },
+        {
+          siteGroupId: 20123,
+          siteFriendlyUrl: '/ub',
+          siteName: 'UB',
+          structures: [{id: 302, key: 'UB_STR_NOVEDAD', name: 'UB Novedad'}],
+        },
+      ],
+      summary: {totalSites: 2, totalStructures: 2},
+    });
+  });
+
+  test('hides empty sites in tree output for all-sites with templates', () => {
+    const formatted = formatLiferayInventoryStructures({
+      sites: [
+        {
+          siteGroupId: 20121,
+          siteFriendlyUrl: '/global',
+          siteName: 'Global',
+          structures: [
+            {
+              id: 301,
+              key: 'GLOBAL_BASIC',
+              name: 'Global Basic',
+              templates: [{id: '41001', name: 'Global Template', externalReferenceCode: 'global-template'}],
+            },
+          ],
+        },
+        {
+          siteGroupId: 20122,
+          siteFriendlyUrl: '/empty',
+          siteName: 'Empty',
+          structures: [],
+        },
+      ],
+      summary: {totalSites: 2, totalStructures: 1},
+    });
+
+    expect(formatted).toContain('site=/global name=Global groupId=20121');
+    expect(formatted).not.toContain('site=/empty name=Empty groupId=20122');
+    expect(formatted).toContain('totalSites=2');
+    expect(formatted).toContain('totalStructures=1');
   });
 
   test('lists templates for a site', async () => {
@@ -493,6 +592,61 @@ describe('liferay inventory structures and templates', () => {
 
         if (url.includes('/sites/20121/content-templates?page=1&pageSize=200')) {
           return new Response('{"items":[],"lastPage":1}', {status: 200});
+        }
+
+        if (url.includes('/api/jsonws/group/get-group?groupId=20121')) {
+          return new Response('{"companyId":10157}', {status: 200});
+        }
+
+        if (
+          url.includes(
+            '/api/jsonws/classname/fetch-class-name?value=com.liferay.dynamic.data.mapping.model.DDMStructure',
+          )
+        ) {
+          return new Response('{"classNameId":3001}', {status: 200});
+        }
+
+        if (url.includes('/api/jsonws/classname/fetch-class-name?value=com.liferay.journal.model.JournalArticle')) {
+          return new Response('{"classNameId":2001}', {status: 200});
+        }
+
+        if (
+          url.includes(
+            '/api/jsonws/ddm.ddmtemplate/get-templates?companyId=10157&groupId=20121&classNameId=3001&resourceClassNameId=2001&status=0',
+          )
+        ) {
+          return new Response(
+            '[{"templateId":"40802","templateKey":"LEGACY_NEWS","externalReferenceCode":"legacy-news","nameCurrentValue":"Legacy News","classPK":302,"script":"<#-- legacy -->"}]',
+            {status: 200},
+          );
+        }
+
+        throw new Error(`Unexpected URL ${url}`);
+      }),
+    });
+
+    const result = await runLiferayInventoryTemplates(CONFIG, {site: '20121'}, {apiClient, tokenClient: TOKEN_CLIENT});
+
+    expect(result).toEqual([
+      {
+        id: '',
+        name: 'Legacy News',
+        contentStructureId: 302,
+        externalReferenceCode: 'legacy-news',
+        templateScript: '<#-- legacy -->',
+      },
+    ]);
+  });
+
+  test('falls back to DDM templates when headless content templates return 400', async () => {
+    const apiClient = createLiferayApiClient({
+      fetchImpl: createTestFetchImpl((url) => {
+        if (url.includes('/o/headless-admin-site/v1.0/sites/20121')) {
+          return new Response('{"id":20121,"friendlyUrlPath":"/global","name":"Global"}', {status: 200});
+        }
+
+        if (url.includes('/sites/20121/content-templates?page=1&pageSize=200')) {
+          return new Response('bad request', {status: 400});
         }
 
         if (url.includes('/api/jsonws/group/get-group?groupId=20121')) {


### PR DESCRIPTION
## Summary
- skip unsupported 400 responses during all-sites structure inventory and template lookup fallback
- make text output for structures with templates easier to scan in all-sites discovery
- document the updated discovery guidance in docs and AI skills

## Validation
- npm run test:unit -- tests/unit/liferay-inventory.test.ts
- npm run build
- npm run docs:build