### PR TITLE
fix: support external linked git worktrees

### DIFF
--- a/docs/advanced/worktrees.md
+++ b/docs/advanced/worktrees.md
@@ -15,6 +15,20 @@ cd .worktrees/incident-123
 ldev start
 ```
 
+If you already created a linked git worktree manually outside `.worktrees/`, run
+`ldev worktree setup` from inside that checkout to wire its local environment in
+place:
+
+```bash
+git -C ..\labweb worktree add ..\labweb.worktrees\testworktree -b feat/testworktree HEAD
+cd ..\labweb.worktrees\testworktree
+ldev worktree setup --with-env
+```
+
+When you run `ldev worktree setup --name <name>` from the main checkout, `ldev`
+still prefers `.worktrees/<name>` when it exists. Otherwise it can reuse a
+registered external worktree whose checkout folder is also named `<name>`.
+
 If the main environment is still running and your platform cannot clone state
 hot, you can opt into a temporary handoff instead of doing the stop/start
 sequence manually:

--- a/docs/commands/advanced.md
+++ b/docs/commands/advanced.md
@@ -29,6 +29,8 @@ ldev worktree setup --name incident-123 --with-env
 ldev worktree setup --name feature-x --base origin/main --with-env
 ldev worktree setup --name feature-x --with-env --stop-main-for-clone
 ldev worktree setup --name feature-x --with-env --stop-main-for-clone --restart-main-after-clone
+cd ..\labweb.worktrees\feature-x
+ldev worktree setup --with-env
 cd .worktrees/incident-123
 ldev start
 
@@ -40,7 +42,8 @@ ldev worktree gc --days 14
 ldev worktree gc --days 14 --apply
 ```
 
-- `setup` — create or reuse a worktree under `.worktrees/<name>`
+- `setup` — create or reuse a worktree; `--name` is optional when running inside the target worktree
+- `setup` prefers `.worktrees/<name>` for managed worktrees, but can also reuse a registered external linked worktree whose checkout folder matches `<name>`
 - `setup --stop-main-for-clone` — opt-in: stop main automatically when a non-Btrfs clone needs exclusive access
 - `setup --restart-main-after-clone` — opt-in: after an automatic stop, start main again without waiting for full portal readiness
 - `start` — prepare and start the worktree's local env

--- a/docs/commands/discovery.md
+++ b/docs/commands/discovery.md
@@ -136,6 +136,8 @@ ldev portal inventory structures --all-sites --with-templates --json
 
 Prefer `--with-templates` as the first discovery step for structure/template incidents: it returns structures enriched with their associated templates in one call.
 
+In text mode, `--with-templates` renders a detailed site -> structure -> template view. In `--all-sites` text mode, sites with no structures are omitted to keep discovery output focused.
+
 ## `ldev portal inventory templates`
 
 List web content templates for a site.

--- a/docs/core-concepts/environments.md
+++ b/docs/core-concepts/environments.md
@@ -74,6 +74,17 @@ cd .worktrees/incident-123
 ldev start
 ```
 
+If the git worktree already exists elsewhere, go to that checkout and run:
+
+```bash
+ldev worktree setup --with-env
+ldev start
+```
+
+From the main checkout, `ldev worktree setup --name incident-123` still prefers
+`.worktrees/incident-123` when present. Otherwise it can reuse a registered
+external linked worktree with the same checkout folder name.
+
 Worktrees inherit the files that exist in the branch or commit used as their base. Make sure runtime Compose overrides (e.g. `docker-compose.liferay.volume.yml`) are committed to that branch before creating the worktree.
 
 On Linux + BTRFS, `ldev` uses subvolume snapshots to accelerate worktree env creation; refresh the base with `ldev worktree btrfs-refresh-base` when the main env changes.

--- a/docs/core-concepts/structured-output.md
+++ b/docs/core-concepts/structured-output.md
@@ -11,7 +11,7 @@ Every `ldev` command that returns data supports a structured output mode.
 
 - `--format text` (default for most) — human-readable output
 - `--json` / `--format json` — pretty-printed JSON, one object per command run
-- `--ndjson` / `--format ndjson` — one JSON value per line, suitable for streaming commands
+- `--ndjson` / `--format ndjson` — newline-delimited JSON output; most commands still emit one final JSON value, while streaming-style commands may emit multiple lines
 - `--strict` — return a non-zero exit code when the result indicates something is wrong (even if the command itself succeeded)
 
 Some commands default to JSON because their output is primarily structured:

--- a/docs/workflows/resource-migration-pipeline.md
+++ b/docs/workflows/resource-migration-pipeline.md
@@ -97,4 +97,8 @@ cd .worktrees/migration-test
 ldev start
 ```
 
+If `migration-test` is already a linked git worktree outside `.worktrees/`, run
+`ldev worktree setup --with-env` from inside that checkout instead of creating a
+second worktree.
+
 Then run the migration there first.

--- a/src/commands/worktree/worktree-commands-flow.ts
+++ b/src/commands/worktree/worktree-commands-flow.ts
@@ -13,7 +13,7 @@ import {formatWorktreeSetup, runWorktreeSetup} from '../../features/worktree/wor
 import {formatWorktreeStart, runWorktreeStart} from '../../features/worktree/worktree-start.js';
 
 type WorktreeSetupCommandOptions = {
-  name: string;
+  name?: string;
   base?: string;
   withEnv?: boolean;
   stopMainForClone?: boolean;
@@ -35,7 +35,7 @@ export function registerWorktreeFlowCommands(command: Command): void {
       .command('setup')
       .helpGroup('Daily worktree flow:')
       .description('Create or reuse a git worktree and optionally prepare its local env')
-      .requiredOption('--name <name>', 'Worktree name')
+      .option('--name <name>', 'Worktree name; optional when running inside the worktree')
       .option('--base <ref>', 'Base ref for a new worktree branch')
       .option('--with-env', 'Prepare worktree local env after creation')
       .option(

--- a/src/core/config/project-context.ts
+++ b/src/core/config/project-context.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import type {AppConfig} from './schema.js';
+import {resolveLinkedGitWorktree} from '../platform/git.js';
 import {readEnvFile} from './env-file.js';
 import {readProfileFile as readLiferayProfileFile, resolveLiferayProfileFiles} from './liferay-profile.js';
 import {detectProject, type ProjectType} from './project-type.js';
@@ -85,7 +86,7 @@ export function resolveProjectContext(options?: ResolveProjectContextOptions): P
 
   const projectDetection = detectProjectFn(cwd);
   const detectedRepoPaths = detectRepoPathsFn(cwd);
-  const worktree = detectWorktreePath(cwd);
+  const worktree = detectWorktreePath(cwd) ?? detectWorktreePath(detectedRepoPaths.repoRoot ?? cwd);
   const repoPaths =
     worktree && isWorktreeOverlay(worktree) ? resolveWorktreeRepoPaths(worktree, detectedRepoPaths) : detectedRepoPaths;
   const projectType = projectDetection.type;
@@ -270,6 +271,16 @@ type WorktreePath = {
 
 function detectWorktreePath(startDir: string): WorktreePath | null {
   const resolved = path.resolve(startDir);
+  const linkedWorktree = resolveLinkedGitWorktree(resolved);
+
+  if (linkedWorktree) {
+    return {
+      mainRepoRoot: linkedWorktree.mainRepoRoot,
+      worktreeName: linkedWorktree.worktreeName,
+      worktreeRoot: linkedWorktree.worktreeRoot,
+    };
+  }
+
   const parts = resolved.split(path.sep);
   const markerIndex = parts.lastIndexOf('.worktrees');
 

--- a/src/core/platform/git.ts
+++ b/src/core/platform/git.ts
@@ -1,7 +1,75 @@
+import fs from 'node:fs';
 import path from 'node:path';
 
 import {CliError} from '../../core/errors.js';
 import {runProcess} from './process.js';
+
+export type LinkedGitWorktree = {
+  mainRepoRoot: string;
+  worktreeName: string;
+  worktreeRoot: string;
+  gitDir: string;
+};
+
+export type GitWorktreeInfo = {
+  path: string;
+  branch: string | null;
+  detached: boolean;
+  prunable: boolean;
+};
+
+export function resolveLinkedGitWorktree(repoRoot: string): LinkedGitWorktree | null {
+  const worktreeRoot = path.resolve(repoRoot);
+  const gitEntry = path.join(worktreeRoot, '.git');
+
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(gitEntry);
+  } catch {
+    return null;
+  }
+
+  if (!stat.isFile()) {
+    return null;
+  }
+
+  const content = fs.readFileSync(gitEntry, 'utf8').trim();
+  const match = /^gitdir:\s*(.+)$/i.exec(content);
+  if (!match) {
+    return null;
+  }
+
+  const gitDir = path.resolve(worktreeRoot, match[1].trim());
+  const parts = path.normalize(gitDir).split(path.sep);
+  const gitIndex = parts.lastIndexOf('.git');
+
+  if (gitIndex <= 0 || parts[gitIndex + 1] !== 'worktrees' || gitIndex + 2 >= parts.length) {
+    return null;
+  }
+
+  return {
+    mainRepoRoot: path.resolve(parts.slice(0, gitIndex).join(path.sep) || path.sep),
+    worktreeName: path.basename(worktreeRoot),
+    worktreeRoot,
+    gitDir,
+  };
+}
+
+export function areSamePath(left: string, right: string): boolean {
+  return normalizePathForComparison(left) === normalizePathForComparison(right);
+}
+
+export function normalizePathForComparison(value: string): string {
+  let resolved = path.resolve(value);
+  try {
+    resolved = fs.realpathSync.native(resolved);
+  } catch {
+    // Missing paths can still be compared lexically during worktree creation.
+  }
+
+  const normalized = path.normalize(resolved);
+  return process.platform === 'win32' ? normalized.toLowerCase() : normalized;
+}
 
 export async function getRepoRoot(cwd: string): Promise<string | null> {
   const result = await runProcess('git', ['rev-parse', '--show-toplevel'], {cwd});
@@ -19,6 +87,10 @@ export async function isGitRepository(cwd: string): Promise<boolean> {
 }
 
 export async function isWorktree(cwd: string): Promise<boolean> {
+  if (resolveLinkedGitWorktree(cwd)) {
+    return true;
+  }
+
   if (path.normalize(cwd).includes(`${path.sep}.worktrees${path.sep}`)) {
     return true;
   }
@@ -29,7 +101,7 @@ export async function isWorktree(cwd: string): Promise<boolean> {
   }
 
   const normalized = path.normalize(repoRoot);
-  return normalized.includes(`${path.sep}.worktrees${path.sep}`);
+  return resolveLinkedGitWorktree(repoRoot) !== null || normalized.includes(`${path.sep}.worktrees${path.sep}`);
 }
 
 export async function initializeGitRepository(cwd: string): Promise<void> {
@@ -118,15 +190,51 @@ export async function addGitWorktree(options: {
 }
 
 export async function listGitWorktrees(cwd: string): Promise<string[]> {
+  return (await listGitWorktreeDetails(cwd)).map((worktree) => worktree.path);
+}
+
+export async function listGitWorktreeDetails(cwd: string): Promise<GitWorktreeInfo[]> {
   const result = await runProcess('git', ['worktree', 'list', '--porcelain'], {cwd});
   if (!result.ok) {
     return [];
   }
 
-  return result.stdout
-    .split(/\r?\n/)
-    .filter((line) => line.startsWith('worktree '))
-    .map((line) => path.normalize(line.slice('worktree '.length).trim()));
+  const worktrees: GitWorktreeInfo[] = [];
+  let current: GitWorktreeInfo | null = null;
+
+  for (const line of result.stdout.split(/\r?\n/)) {
+    if (line.startsWith('worktree ')) {
+      if (current) {
+        worktrees.push(current);
+      }
+      current = {
+        path: path.normalize(line.slice('worktree '.length).trim()),
+        branch: null,
+        detached: false,
+        prunable: false,
+      };
+      continue;
+    }
+
+    if (!current) {
+      continue;
+    }
+
+    if (line.startsWith('branch ')) {
+      const ref = line.slice('branch '.length).trim();
+      current.branch = ref.startsWith('refs/heads/') ? ref.slice('refs/heads/'.length) : ref;
+    } else if (line === 'detached') {
+      current.detached = true;
+    } else if (line.startsWith('prunable')) {
+      current.prunable = true;
+    }
+  }
+
+  if (current) {
+    worktrees.push(current);
+  }
+
+  return worktrees;
 }
 
 export async function removeGitWorktree(cwd: string, worktreePath: string): Promise<void> {

--- a/src/features/liferay/inventory/liferay-inventory-structures.ts
+++ b/src/features/liferay/inventory/liferay-inventory-structures.ts
@@ -1,6 +1,7 @@
 import type {AppConfig} from '../../../core/config/load-config.js';
 import type {HttpApiClient} from '../../../core/http/client.js';
 import type {OAuthTokenClient} from '../../../core/http/auth.js';
+import {isCliError} from '../../../core/errors.js';
 import {fetchPagedItems} from './liferay-inventory-shared.js';
 import {normalizeLocalizedName, resolveSite} from '../portal/site-resolution.js';
 import {runLiferayInventoryTemplates} from './liferay-inventory-templates.js';
@@ -75,19 +76,31 @@ export async function runLiferayInventoryStructuresAllSites(
     dependencies,
   );
 
-  const rows = await Promise.all(
-    sites.map(async (site) => ({
-      siteGroupId: site.groupId,
-      siteFriendlyUrl: site.siteFriendlyUrl,
-      siteName: site.name,
-      structures: await runLiferayInventoryStructuresForSiteId(
-        config,
-        site.groupId,
-        {site: site.siteFriendlyUrl, pageSize: options?.pageSize, withTemplates: options?.withTemplates},
-        dependencies,
-      ),
-    })),
-  );
+  const rows = (
+    await Promise.all(
+      sites.map(async (site) => {
+        try {
+          return {
+            siteGroupId: site.groupId,
+            siteFriendlyUrl: site.siteFriendlyUrl,
+            siteName: site.name,
+            structures: await runLiferayInventoryStructuresForSiteId(
+              config,
+              site.groupId,
+              {site: site.siteFriendlyUrl, pageSize: options?.pageSize, withTemplates: options?.withTemplates},
+              dependencies,
+            ),
+          };
+        } catch (error) {
+          if (isSkippableStructureInventoryError(error)) {
+            return null;
+          }
+
+          throw error;
+        }
+      }),
+    )
+  ).filter((row): row is LiferayInventoryStructuresSite => row !== null);
 
   return {
     sites: rows,
@@ -96,6 +109,14 @@ export async function runLiferayInventoryStructuresAllSites(
       totalStructures: rows.reduce((acc, row) => acc + row.structures.length, 0),
     },
   };
+}
+
+function isSkippableStructureInventoryError(error: unknown): boolean {
+  if (!isCliError(error) || error.code !== 'LIFERAY_INVENTORY_ERROR') {
+    return false;
+  }
+
+  return error.message.includes('status=400') && error.message.includes('/data-definitions/by-content-type/journal');
 }
 
 async function runLiferayInventoryStructuresForSiteId(
@@ -150,6 +171,18 @@ export function formatLiferayInventoryStructures(result: LiferayInventoryStructu
     return 'No structure data';
   }
 
+  if (hasTemplateDetails(result)) {
+    return formatLiferayInventoryStructuresTree(result);
+  }
+
+  return formatLiferayInventoryStructuresCompact(result);
+}
+
+function hasTemplateDetails(result: LiferayInventoryStructuresResult): boolean {
+  return result.sites.some((site) => site.structures.some((structure) => structure.templates !== undefined));
+}
+
+function formatLiferayInventoryStructuresCompact(result: LiferayInventoryStructuresResult): string {
   const lines: string[] = [];
 
   for (const site of result.sites) {
@@ -166,6 +199,41 @@ export function formatLiferayInventoryStructures(result: LiferayInventoryStructu
         );
       }
     }
+  }
+
+  lines.push(`totalSites=${result.summary.totalSites}`);
+  lines.push(`totalStructures=${result.summary.totalStructures}`);
+  return lines.join('\n');
+}
+
+function formatLiferayInventoryStructuresTree(result: LiferayInventoryStructuresResult): string {
+  const lines: string[] = [];
+  const sites = result.sites.length > 1 ? result.sites.filter((site) => site.structures.length > 0) : result.sites;
+
+  if (sites.length === 0) {
+    return 'No structure data';
+  }
+
+  for (const site of sites) {
+    lines.push(`site=${site.siteFriendlyUrl} name=${site.siteName} groupId=${site.siteGroupId}`);
+
+    for (const structure of site.structures) {
+      lines.push(`  structure=${structure.key} name=${structure.name} id=${structure.id}`);
+
+      if (!structure.templates || structure.templates.length === 0) {
+        lines.push('    template=(none)');
+      } else {
+        for (const template of structure.templates) {
+          lines.push(`    template=${template.name} erc=${template.externalReferenceCode} id=${template.id}`);
+        }
+      }
+    }
+
+    lines.push('');
+  }
+
+  if (lines.at(-1) === '') {
+    lines.pop();
   }
 
   lines.push(`totalSites=${result.summary.totalSites}`);

--- a/src/features/liferay/inventory/liferay-inventory-templates.ts
+++ b/src/features/liferay/inventory/liferay-inventory-templates.ts
@@ -1,6 +1,7 @@
 import type {AppConfig} from '../../../core/config/load-config.js';
 import type {HttpApiClient} from '../../../core/http/client.js';
 import type {OAuthTokenClient} from '../../../core/http/auth.js';
+import {isCliError} from '../../../core/errors.js';
 import {fetchPagedItems} from './liferay-inventory-shared.js';
 import {resolveSite} from '../portal/site-resolution.js';
 import {listDdmTemplates, resolveResourceSite} from '../portal/template-queries.js';
@@ -33,12 +34,22 @@ export async function runLiferayInventoryTemplates(
 
   for (const surface of policy.surfaces) {
     if (surface === 'headless-delivery') {
-      const rows = await fetchPagedItems<ContentTemplate>(
-        config,
-        `/o/headless-delivery/v1.0/sites/${site.id}/content-templates`,
-        pageSize,
-        dependencies,
-      );
+      let rows: ContentTemplate[];
+
+      try {
+        rows = await fetchPagedItems<ContentTemplate>(
+          config,
+          `/o/headless-delivery/v1.0/sites/${site.id}/content-templates`,
+          pageSize,
+          dependencies,
+        );
+      } catch (error) {
+        if (isSkippableHeadlessTemplateError(error)) {
+          continue;
+        }
+
+        throw error;
+      }
 
       if (rows.length > 0) {
         return rows.map(normalizeContentTemplate);
@@ -55,6 +66,14 @@ export async function runLiferayInventoryTemplates(
   }
 
   return [];
+}
+
+function isSkippableHeadlessTemplateError(error: unknown): boolean {
+  if (!isCliError(error) || error.code !== 'LIFERAY_INVENTORY_ERROR') {
+    return false;
+  }
+
+  return error.message.includes('status=400') && error.message.includes('/content-templates');
 }
 
 function normalizeContentTemplate(row: ContentTemplate): LiferayInventoryTemplate {

--- a/src/features/worktree/worktree-clean.ts
+++ b/src/features/worktree/worktree-clean.ts
@@ -7,8 +7,10 @@ import {loadConfig} from '../../core/config/load-config.js';
 import {readEnvFile} from '../../core/config/env-file.js';
 import {removePathRobust} from '../../core/platform/fs.js';
 import {
+  areSamePath,
   deleteGitBranch,
   isGitRepository,
+  listGitWorktreeDetails,
   listGitWorktrees,
   pruneGitWorktrees,
   removeGitWorktree,
@@ -19,7 +21,7 @@ import {runDocker, runDockerCompose} from '../../core/platform/docker.js';
 import {buildComposeEnv, resolveManagedStorages, type RuntimeStorageKey} from '../../core/runtime/env-context.js';
 import {WorktreeErrors} from './errors/worktree-error-factory.js';
 import {resolveBtrfsConfig} from './worktree-state.js';
-import {resolveWorktreeContext, resolveWorktreeTarget} from './worktree-paths.js';
+import {resolveWorktreeContext, resolveWorktreeTargetForContext, type WorktreeTarget} from './worktree-paths.js';
 
 export type WorktreeCleanResult = {
   ok: true;
@@ -49,7 +51,8 @@ export async function runWorktreeClean(options: {
   }
 
   const context = resolveWorktreeContext(config.repoRoot);
-  const target = resolveTarget(context, options.name);
+  const registered = await listGitWorktreeDetails(context.mainRepoRoot);
+  const target = resolveTarget(context, registered, options.name);
   const mainEnvFile = path.join(context.mainRepoRoot, 'docker', '.env');
   const mainEnvValues = readEnvFile(mainEnvFile);
   const mainDockerDir = path.join(context.mainRepoRoot, 'docker');
@@ -70,8 +73,7 @@ export async function runWorktreeClean(options: {
     },
     mainEnvValues,
   );
-  const registered = await listGitWorktrees(context.mainRepoRoot);
-  const isRegistered = registered.includes(target.worktreeDir);
+  const isRegistered = registered.some((worktree) => areSamePath(worktree.path, target.worktreeDir));
   const worktreeDirExists = await fs.pathExists(target.worktreeDir);
   if (
     !isRegistered &&
@@ -143,7 +145,9 @@ export async function runWorktreeClean(options: {
       }
 
       await pruneGitWorktrees(context.mainRepoRoot).catch(() => undefined);
-      const stillRegistered = (await listGitWorktrees(context.mainRepoRoot)).includes(target.worktreeDir);
+      const stillRegistered = (await listGitWorktrees(context.mainRepoRoot)).some((worktreePath) =>
+        areSamePath(worktreePath, target.worktreeDir),
+      );
       if (stillRegistered) {
         throw new CliError(
           `Git still has the worktree registered after cleanup: ${target.worktreeDir}\nRun 'git worktree prune' and retry.`,
@@ -244,13 +248,12 @@ export function formatWorktreeClean(result: WorktreeCleanResult): string {
 
 function resolveTarget(
   context: ReturnType<typeof resolveWorktreeContext>,
+  registeredWorktrees: Awaited<ReturnType<typeof listGitWorktreeDetails>>,
   explicitName?: string,
-): ReturnType<typeof resolveWorktreeTarget> {
-  if (explicitName && explicitName.trim() !== '') {
-    return resolveWorktreeTarget(context.mainRepoRoot, explicitName);
-  }
-  if (context.isWorktree && context.currentWorktreeName) {
-    return resolveWorktreeTarget(context.mainRepoRoot, context.currentWorktreeName);
+): WorktreeTarget {
+  const target = resolveWorktreeTargetForContext(context, explicitName, registeredWorktrees);
+  if (target) {
+    return target;
   }
   throw WorktreeErrors.nameRequired('worktree clean requires a NAME or must run inside the target worktree.');
 }

--- a/src/features/worktree/worktree-env.ts
+++ b/src/features/worktree/worktree-env.ts
@@ -8,7 +8,12 @@ import {loadConfig} from '../../core/config/load-config.js';
 import {readEnvFile, upsertEnvFileValues} from '../../core/config/env-file.js';
 import type {Printer} from '../../core/output/printer.js';
 import {resolveManagedStorages} from '../../core/runtime/env-context.js';
-import {resolveWorktreeContext, resolveWorktreeTarget, resolvePortSet, type WorktreeTarget} from './worktree-paths.js';
+import {
+  resolvePortSet,
+  resolveWorktreeContext,
+  resolveWorktreeTargetForContext,
+  type WorktreeTarget,
+} from './worktree-paths.js';
 import {syncWorktreeLocalArtifacts} from './worktree-local-artifacts.js';
 import {cloneInitialWorktreeState, resolveBtrfsConfig, worktreeEnvHasState} from './worktree-state.js';
 
@@ -173,17 +178,15 @@ export function formatWorktreeEnv(result: WorktreeEnvResult): string {
 }
 
 function resolveTarget(context: ReturnType<typeof resolveWorktreeContext>, name?: string): WorktreeTarget {
-  if (name && name.trim() !== '') {
-    return resolveWorktreeTarget(context.mainRepoRoot, name);
-  }
+  const target = resolveWorktreeTargetForContext(context, name);
 
-  if (!context.isWorktree || !context.currentWorktreeName) {
+  if (!target) {
     throw new CliError('worktree env must run inside a worktree or receive --name.', {
       code: 'WORKTREE_NAME_REQUIRED',
     });
   }
 
-  return resolveWorktreeTarget(context.mainRepoRoot, context.currentWorktreeName);
+  return target;
 }
 
 async function ensurePortalExtLocalOverride(worktreeDir: string, httpPort: string): Promise<void> {

--- a/src/features/worktree/worktree-paths.ts
+++ b/src/features/worktree/worktree-paths.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 
 import {CliError} from '../../core/errors.js';
+import {areSamePath, resolveLinkedGitWorktree, type GitWorktreeInfo} from '../../core/platform/git.js';
 
 export type WorktreeContext = {
   currentRepoRoot: string;
@@ -19,6 +20,17 @@ export type WorktreeTarget = {
 
 export function resolveWorktreeContext(repoRoot: string): WorktreeContext {
   const normalized = path.resolve(repoRoot);
+  const linkedWorktree = resolveLinkedGitWorktree(normalized);
+
+  if (linkedWorktree) {
+    return {
+      currentRepoRoot: normalized,
+      mainRepoRoot: linkedWorktree.mainRepoRoot,
+      isWorktree: true,
+      currentWorktreeName: linkedWorktree.worktreeName,
+    };
+  }
+
   const marker = `${path.sep}.worktrees${path.sep}`;
   const markerIndex = normalized.indexOf(marker);
 
@@ -51,13 +63,106 @@ export function resolveWorktreeTarget(mainRepoRoot: string, name: string): Workt
   const normalizedName = name.trim();
   const worktreeDir = path.join(path.resolve(mainRepoRoot), '.worktrees', normalizedName);
 
+  return resolveWorktreeTargetFromDir(worktreeDir, normalizedName);
+}
+
+export function resolveWorktreeTargetFromDir(
+  worktreeDir: string,
+  name: string,
+  branch?: string | null,
+): WorktreeTarget {
+  if (name.trim() === '') {
+    throw new CliError('The worktree name cannot be empty.', {code: 'WORKTREE_NAME_REQUIRED'});
+  }
+
+  const normalizedName = name.trim();
+  const normalizedDir = path.resolve(worktreeDir);
+
   return {
     name: normalizedName,
-    branch: `fix/${normalizedName}`,
-    worktreeDir,
-    dockerDir: path.join(worktreeDir, 'docker'),
-    envFile: path.join(worktreeDir, 'docker', '.env'),
+    branch: branch ?? `fix/${normalizedName}`,
+    worktreeDir: normalizedDir,
+    dockerDir: path.join(normalizedDir, 'docker'),
+    envFile: path.join(normalizedDir, 'docker', '.env'),
   };
+}
+
+export function resolveExistingWorktreeTarget(
+  mainRepoRoot: string,
+  name: string,
+  registeredWorktrees: WorktreeRegistration[],
+): WorktreeTarget | null {
+  const normalizedName = name.trim();
+  if (normalizedName === '') {
+    return null;
+  }
+
+  const normalizedMainRepoRoot = path.resolve(mainRepoRoot);
+  const matches = registeredWorktrees
+    .map(normalizeWorktreeRegistration)
+    .filter(
+      (worktree) =>
+        !areSamePath(worktree.path, normalizedMainRepoRoot) &&
+        !worktree.prunable &&
+        path.basename(worktree.path) === normalizedName,
+    );
+
+  if (matches.length === 0) {
+    return null;
+  }
+
+  const managedPath = path.join(normalizedMainRepoRoot, '.worktrees', normalizedName);
+  const managedMatch = matches.find((worktree) => areSamePath(worktree.path, managedPath));
+  if (managedMatch) {
+    return resolveWorktreeTargetFromDir(managedMatch.path, normalizedName, managedMatch.branch);
+  }
+
+  if (matches.length > 1) {
+    throw new CliError(
+      `More than one registered worktree is named '${normalizedName}': ${matches.map((item) => item.path).join(', ')}`,
+      {
+        code: 'WORKTREE_NAME_AMBIGUOUS',
+      },
+    );
+  }
+
+  return resolveWorktreeTargetFromDir(matches[0].path, normalizedName, matches[0].branch);
+}
+
+export function resolveWorktreeTargetByName(
+  mainRepoRoot: string,
+  name: string,
+  registeredWorktrees?: WorktreeRegistration[],
+): WorktreeTarget {
+  const existingTarget = registeredWorktrees
+    ? resolveExistingWorktreeTarget(mainRepoRoot, name, registeredWorktrees)
+    : null;
+
+  return existingTarget ?? resolveWorktreeTarget(mainRepoRoot, name);
+}
+
+export function resolveWorktreeTargetForContext(
+  context: WorktreeContext,
+  name?: string,
+  registeredWorktrees?: WorktreeRegistration[],
+): WorktreeTarget | null {
+  const explicitName = name?.trim();
+
+  if (explicitName) {
+    if (context.isWorktree && context.currentWorktreeName === explicitName) {
+      const current = findRegisteredWorktreeByPath(context.currentRepoRoot, registeredWorktrees);
+      return resolveWorktreeTargetFromDir(context.currentRepoRoot, explicitName, current?.branch);
+    }
+
+    return resolveWorktreeTargetByName(context.mainRepoRoot, explicitName, registeredWorktrees);
+  }
+
+  if (!context.isWorktree || !context.currentWorktreeName) {
+    return null;
+  }
+
+  const current = findRegisteredWorktreeByPath(context.currentRepoRoot, registeredWorktrees);
+  return resolveWorktreeTargetFromDir(context.currentRepoRoot, context.currentWorktreeName, current?.branch);
 }
 
 export function resolvePortSet(name: string): {
@@ -85,4 +190,37 @@ function checksum(value: string): number {
     hash = (hash * 33 + character.charCodeAt(0)) >>> 0;
   }
   return hash;
+}
+
+type WorktreeRegistration = string | GitWorktreeInfo;
+
+function normalizeWorktreeRegistration(registration: WorktreeRegistration): GitWorktreeInfo {
+  if (typeof registration === 'string') {
+    return {
+      path: path.resolve(registration),
+      branch: null,
+      detached: false,
+      prunable: false,
+    };
+  }
+
+  return {
+    ...registration,
+    path: path.resolve(registration.path),
+  };
+}
+
+function findRegisteredWorktreeByPath(
+  worktreePath: string,
+  registeredWorktrees?: WorktreeRegistration[],
+): GitWorktreeInfo | null {
+  if (!registeredWorktrees) {
+    return null;
+  }
+
+  return (
+    registeredWorktrees
+      .map(normalizeWorktreeRegistration)
+      .find((worktree) => areSamePath(worktree.path, worktreePath)) ?? null
+  );
 }

--- a/src/features/worktree/worktree-setup.ts
+++ b/src/features/worktree/worktree-setup.ts
@@ -3,13 +3,13 @@
 import {loadConfig} from '../../core/config/load-config.js';
 import {readEnvFile} from '../../core/config/env-file.js';
 import {resolveEnvContext} from '../../core/runtime/env-context.js';
-import {addGitWorktree, listGitWorktrees} from '../../core/platform/git.js';
+import {addGitWorktree, areSamePath, listGitWorktreeDetails} from '../../core/platform/git.js';
 import type {Printer} from '../../core/output/printer.js';
 import {withProgress} from '../../core/output/printer.js';
 import {WorktreeErrors} from './errors/worktree-error-factory.js';
 import {runWorktreeEnv} from './worktree-env.js';
 import {prepareWorktreeFlow} from './worktree-flow.js';
-import {resolveWorktreeTarget} from './worktree-paths.js';
+import {resolveWorktreeTargetForContext} from './worktree-paths.js';
 import {assertSafeMainEnvClone, resolveBtrfsConfig} from './worktree-state.js';
 
 type WorktreeEnvStopFn = (
@@ -42,7 +42,7 @@ export type WorktreeSetupResult = {
 
 export async function runWorktreeSetup(options: {
   cwd: string;
-  name: string;
+  name?: string;
   baseRef?: string;
   withEnv?: boolean;
   stopMainForClone?: boolean;
@@ -97,12 +97,15 @@ export async function runWorktreeSetup(options: {
     }
   }
 
-  const target = resolveWorktreeTarget(context.mainRepoRoot, options.name);
-  const existing = await listGitWorktrees(context.mainRepoRoot);
+  const existing = await listGitWorktreeDetails(context.mainRepoRoot);
+  const target = resolveWorktreeTargetForContext(context, options.name, existing);
+  if (!target) {
+    throw WorktreeErrors.nameRequired('worktree setup requires a NAME or must run inside the target worktree.');
+  }
 
   let reused = false;
   if (await fs.pathExists(target.worktreeDir)) {
-    if (existing.includes(target.worktreeDir)) {
+    if (existing.some((worktree) => areSamePath(worktree.path, target.worktreeDir))) {
       reused = true;
     } else {
       throw WorktreeErrors.pathConflict(`The path exists but is not a registered git worktree: ${target.worktreeDir}`);

--- a/src/features/worktree/worktree-start.ts
+++ b/src/features/worktree/worktree-start.ts
@@ -1,13 +1,13 @@
 import fs from 'fs-extra';
 
 import {loadConfig, type AppConfig} from '../../core/config/load-config.js';
-import {listGitWorktrees} from '../../core/platform/git.js';
+import {areSamePath, listGitWorktreeDetails} from '../../core/platform/git.js';
 import type {Printer} from '../../core/output/printer.js';
 import {WorktreeErrors} from './errors/worktree-error-factory.js';
 import {assertPrimaryCheckoutGuardrail} from './worktree-guardrails.js';
 import {runWorktreeEnv} from './worktree-env.js';
 import {prepareWorktreeFlow} from './worktree-flow.js';
-import {resolveWorktreeTarget} from './worktree-paths.js';
+import {resolveWorktreeTargetForContext} from './worktree-paths.js';
 
 export type WorktreeStartResult = {
   ok: true;
@@ -45,11 +45,8 @@ export async function runWorktreeStart(options: {
   const {context} = await prepareWorktreeFlow({cwd: options.cwd, commandName: 'start'});
   await assertPrimaryCheckoutGuardrail(context, 'start a worktree from the wrong checkout root');
 
-  const target = options.name
-    ? resolveWorktreeTarget(context.mainRepoRoot, options.name)
-    : context.isWorktree && context.currentWorktreeName
-      ? resolveWorktreeTarget(context.mainRepoRoot, context.currentWorktreeName)
-      : null;
+  const existing = await listGitWorktreeDetails(context.mainRepoRoot);
+  const target = resolveWorktreeTargetForContext(context, options.name, existing);
 
   if (!target) {
     throw WorktreeErrors.nameRequired('worktree start requires a NAME or execution inside the target worktree.');
@@ -61,8 +58,7 @@ export async function runWorktreeStart(options: {
     );
   }
 
-  const existing = await listGitWorktrees(context.mainRepoRoot);
-  if (!existing.includes(target.worktreeDir)) {
+  if (!existing.some((worktree) => areSamePath(worktree.path, target.worktreeDir))) {
     throw WorktreeErrors.notRegistered(`The path exists but is not a registered git worktree: ${target.worktreeDir}`);
   }
 

--- a/templates/ai/skills/developing-liferay/SKILL.md
+++ b/templates/ai/skills/developing-liferay/SKILL.md
@@ -65,6 +65,12 @@ ldev portal inventory page --url <fullUrl> --json
 ldev resource adt --display-style ddmTemplate_<ID> --site /<site> --json
 ```
 
+For cross-site structure/template incidents, use:
+
+```bash
+ldev portal inventory structures --with-templates --all-sites --json
+```
+
 If you are inside a worktree and the main runtime is still the source of truth
 for discovery, keep your shell in the worktree and call the global form:
 

--- a/templates/ai/skills/liferay-expert/SKILL.md
+++ b/templates/ai/skills/liferay-expert/SKILL.md
@@ -50,6 +50,12 @@ ldev portal inventory structures --site /<site> --json
 ldev portal inventory templates --site /<site> --json
 ```
 
+For cross-site structure/template discovery, prefer:
+
+```bash
+ldev portal inventory structures --with-templates --all-sites --json
+```
+
 The default page output is sufficient for routing. Add `--full` when the task
 requires content fields, all template candidates, or the raw page definition:
 

--- a/tests/integration/cleanup.integration.test.ts
+++ b/tests/integration/cleanup.integration.test.ts
@@ -27,7 +27,7 @@ describe('cleanup integration', () => {
   test('env clean removes local data root inside repo and requires --force', async () => {
     const repoRoot = await createRepoWithEnv();
     const fakeBinDir = await createFakeDockerBin();
-    const env = {...process.env, PATH: `${fakeBinDir}:${process.env.PATH ?? ''}`};
+    const env = {...process.env, PATH: `${fakeBinDir}${path.delimiter}${process.env.PATH ?? ''}`};
 
     const reject = await runCli(['env', 'clean'], {cwd: repoRoot, env});
     expect(reject.exitCode).toBe(1);
@@ -108,6 +108,32 @@ describe('cleanup integration', () => {
     expect(gcPreview.exitCode).toBe(0);
     expect(parseTestJson<WorktreeGcPayload>(gcPreview.stdout).candidates).toContain('issue-702');
   }, 90000);
+
+  test('worktree clean deletes the real branch for a reused external worktree', async () => {
+    const repoRoot = await createWorktreeRepoFixture();
+    const fakeBinDir = await createFakeDockerBin();
+    const env = {...process.env, PATH: `${fakeBinDir}:${process.env.PATH ?? ''}`};
+    const externalParent = createTempDir('dev-cli-clean-external-worktree-parent-');
+    const externalRoot = path.join(externalParent, 'external-clean');
+
+    expect(
+      (await runProcess('git', ['worktree', 'add', '-b', 'feat/external-clean', externalRoot, 'HEAD'], {cwd: repoRoot}))
+        .exitCode,
+    ).toBe(0);
+
+    const cleanResult = await runCli(
+      ['worktree', 'clean', 'external-clean', '--force', '--delete-branch', '--format', 'json'],
+      {cwd: repoRoot, env},
+    );
+
+    expect(cleanResult.exitCode).toBe(0);
+    expect(parseTestJson<{branchDeleted: boolean}>(cleanResult.stdout).branchDeleted).toBe(true);
+    expect(await fs.pathExists(externalRoot)).toBe(false);
+    expect(
+      (await runProcess('git', ['show-ref', '--verify', '--quiet', 'refs/heads/feat/external-clean'], {cwd: repoRoot}))
+        .exitCode,
+    ).not.toBe(0);
+  }, 45000);
 
   test('worktree clean preserves ENV_DATA_ROOT outside the worktree perimeter', async () => {
     const repoRoot = await createWorktreeRepoFixture();

--- a/tests/integration/worktree.integration.test.ts
+++ b/tests/integration/worktree.integration.test.ts
@@ -147,6 +147,84 @@ describe('worktree integration', () => {
     expect(await fs.readFile(path.join(result.dataRoot, 'liferay-data', 'home.marker'), 'utf8')).toBe('main-home\n');
   }, 15000);
 
+  test('worktree setup reuses an existing external git worktree and prepares its env in place', async () => {
+    const repoRoot = await createWorktreeRepoFixture();
+    const externalParent = createTempDir('dev-cli-external-worktree-parent-');
+    const externalRoot = path.join(externalParent, 'external-issue');
+
+    expect(
+      (await runProcess('git', ['worktree', 'add', '-b', 'fix/external-issue', externalRoot, 'HEAD'], {cwd: repoRoot}))
+        .exitCode,
+    ).toBe(0);
+
+    const result = await runWorktreeSetup({
+      cwd: externalRoot,
+      name: 'external-issue',
+      withEnv: true,
+      printer: silentPrinter,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.reused).toBe(true);
+    expect(result.branch).toBe('fix/external-issue');
+    expect(path.normalize(result.worktreeDir)).toBe(path.normalize(externalRoot));
+    expect(await fs.pathExists(path.join(externalRoot, 'docker', '.env'))).toBe(true);
+    expect(await fs.pathExists(path.join(externalRoot, 'docker', 'data', 'envs', 'external-issue'))).toBe(true);
+  }, 15000);
+
+  test('worktree setup from the main checkout reuses an existing external git worktree by name', async () => {
+    const repoRoot = await createWorktreeRepoFixture();
+    const externalParent = createTempDir('dev-cli-external-worktree-parent-');
+    const externalRoot = path.join(externalParent, 'testworktree');
+
+    expect(
+      (
+        await runProcess('git', ['worktree', 'add', '-b', 'feat/external-testworktree', externalRoot, 'HEAD'], {
+          cwd: repoRoot,
+        })
+      ).exitCode,
+    ).toBe(0);
+
+    const result = await runWorktreeSetup({
+      cwd: repoRoot,
+      name: 'testworktree',
+      withEnv: true,
+      printer: silentPrinter,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.reused).toBe(true);
+    expect(result.branch).toBe('feat/external-testworktree');
+    expect(path.normalize(result.worktreeDir)).toBe(path.normalize(externalRoot));
+    expect(await fs.pathExists(path.join(externalRoot, 'docker', '.env'))).toBe(true);
+    expect(await fs.pathExists(path.join(externalRoot, 'docker', 'data', 'envs', 'testworktree'))).toBe(true);
+  }, 15000);
+
+  test('worktree setup CLI reuses the current external worktree without --name', async () => {
+    const repoRoot = await createWorktreeRepoFixture();
+    const externalParent = createTempDir('dev-cli-external-worktree-parent-');
+    const externalRoot = path.join(externalParent, 'current-external');
+
+    expect(
+      (
+        await runProcess('git', ['worktree', 'add', '-b', 'feat/current-external', externalRoot, 'HEAD'], {
+          cwd: repoRoot,
+        })
+      ).exitCode,
+    ).toBe(0);
+
+    const result = await runCli(['worktree', 'setup', '--format', 'json'], {cwd: externalRoot});
+
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      ok: true,
+      worktreeName: 'current-external',
+      branch: 'feat/current-external',
+      reused: true,
+    });
+    expect(await fs.pathExists(path.join(repoRoot, '.worktrees', 'current-external'))).toBe(false);
+  }, 15000);
+
   test('worktree env syncs ignored local dependency artifacts from the main checkout', async () => {
     const repoRoot = await createWorktreeRepoFixture();
 

--- a/tests/unit/core-platform-git.test.ts
+++ b/tests/unit/core-platform-git.test.ts
@@ -1,3 +1,7 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
 import {describe, expect, test, vi} from 'vitest';
 
 import * as git from '../../src/core/platform/git.js';
@@ -125,6 +129,23 @@ describe('git platform utilities', () => {
     expect(runProcess).not.toHaveBeenCalled();
   });
 
+  test('isWorktree returns true for linked git worktree roots outside .worktrees', async () => {
+    const mainRepoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ldev-main-repo-'));
+    const worktreeParent = fs.mkdtempSync(path.join(os.tmpdir(), 'ldev-linked-worktree-parent-'));
+    const worktreeRoot = path.join(worktreeParent, 'external-issue');
+    const gitDir = path.join(mainRepoRoot, '.git', 'worktrees', 'external-issue');
+    const runProcess = vi.spyOn(process, 'runProcess');
+
+    fs.mkdirSync(worktreeRoot, {recursive: true});
+    fs.mkdirSync(gitDir, {recursive: true});
+    fs.writeFileSync(path.join(worktreeRoot, '.git'), `gitdir: ${gitDir}\n`);
+
+    const isWorktree = await git.isWorktree(worktreeRoot);
+
+    expect(isWorktree).toBe(true);
+    expect(runProcess).not.toHaveBeenCalled();
+  });
+
   test('isWorktree returns false when repo path does not contain .worktrees', async () => {
     vi.spyOn(process, 'runProcess').mockResolvedValue({
       command: 'git rev-parse --show-toplevel',
@@ -137,6 +158,58 @@ describe('git platform utilities', () => {
     const isWorktree = await git.isWorktree('/repo');
 
     expect(isWorktree).toBe(false);
+  });
+
+  test('listGitWorktreeDetails parses branch, detached, and prunable metadata', async () => {
+    vi.spyOn(process, 'runProcess').mockResolvedValue({
+      command: 'git worktree list --porcelain',
+      stdout: [
+        'worktree /repo',
+        'HEAD abc123',
+        'branch refs/heads/main',
+        '',
+        'worktree /outside/external-issue',
+        'HEAD def456',
+        'branch refs/heads/feat/external-issue',
+        '',
+        'worktree /outside/moved-issue',
+        'HEAD 789abc',
+        'detached',
+        'prunable gitdir file points to non-existent location',
+        '',
+      ].join('\n'),
+      stderr: '',
+      exitCode: 0,
+      ok: true,
+    });
+
+    await expect(git.listGitWorktreeDetails('/repo')).resolves.toEqual([
+      {path: path.normalize('/repo'), branch: 'main', detached: false, prunable: false},
+      {
+        path: path.normalize('/outside/external-issue'),
+        branch: 'feat/external-issue',
+        detached: false,
+        prunable: false,
+      },
+      {path: path.normalize('/outside/moved-issue'), branch: null, detached: true, prunable: true},
+    ]);
+  });
+
+  test('areSamePath compares existing symlinked paths by real path', () => {
+    const target = fs.mkdtempSync(path.join(os.tmpdir(), 'ldev-realpath-target-'));
+    const parent = fs.mkdtempSync(path.join(os.tmpdir(), 'ldev-realpath-link-parent-'));
+    const link = path.join(parent, 'link');
+
+    try {
+      fs.symlinkSync(target, link, globalThis.process.platform === 'win32' ? 'junction' : 'dir');
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'EPERM') {
+        return;
+      }
+      throw error;
+    }
+
+    expect(git.areSamePath(target, link)).toBe(true);
   });
 
   test('getGitRemoteUrl returns remote URL', async () => {

--- a/tests/unit/liferay-inventory.test.ts
+++ b/tests/unit/liferay-inventory.test.ts
@@ -349,7 +349,8 @@ describe('liferay inventory structures and templates', () => {
       summary: {totalSites: 1, totalStructures: 2},
     });
 
-    expect(formatLiferayInventoryStructures(result)).toContain('id=302 key=NEWS name=News templates=1');
+    expect(formatLiferayInventoryStructures(result)).toContain('structure=NEWS name=News id=302');
+    expect(formatLiferayInventoryStructures(result)).toContain('template=News Template erc=news-template id=40801');
   });
 
   test('lists structures for all sites in one run', async () => {
@@ -444,8 +445,106 @@ describe('liferay inventory structures and templates', () => {
       summary: {totalSites: 2, totalStructures: 2},
     });
 
-    expect(formatLiferayInventoryStructures(result)).toContain('site=/global groupId=20121 name=Global structures=1');
-    expect(formatLiferayInventoryStructures(result)).toContain('site=/ub groupId=20122 name=UB structures=1');
+    const formatted = formatLiferayInventoryStructures(result);
+
+    expect(formatted).toContain('site=/global name=Global groupId=20121');
+    expect(formatted).toContain('template=Global Template erc=global-template id=41001');
+    expect(formatted).toContain('site=/ub name=UB groupId=20122');
+  });
+
+  test('skips sites that reject structure inventory with 400 in all-sites mode', async () => {
+    const apiClient = createLiferayApiClient({
+      fetchImpl: createTestFetchImpl((url) => {
+        if (url.includes('/o/headless-admin-site/v1.0/sites?page=1&pageSize=2')) {
+          return new Response(
+            '{"items":[{"id":20121,"friendlyUrlPath":"/global","name":"Global"},{"id":20122,"friendlyUrlPath":"/unsupported","name":"Unsupported"},{"id":20123,"friendlyUrlPath":"/ub","name":"UB"}],"lastPage":1}',
+            {status: 200},
+          );
+        }
+
+        if (
+          url.includes('/o/data-engine/v2.0/sites/20121/data-definitions/by-content-type/journal?page=1&pageSize=2')
+        ) {
+          return new Response(
+            '{"items":[{"id":301,"dataDefinitionKey":"GLOBAL_BASIC","name":{"en_US":"Global Basic"}}],"lastPage":1}',
+            {status: 200},
+          );
+        }
+
+        if (
+          url.includes('/o/data-engine/v2.0/sites/20122/data-definitions/by-content-type/journal?page=1&pageSize=2')
+        ) {
+          return new Response('bad request', {status: 400});
+        }
+
+        if (
+          url.includes('/o/data-engine/v2.0/sites/20123/data-definitions/by-content-type/journal?page=1&pageSize=2')
+        ) {
+          return new Response(
+            '{"items":[{"id":302,"dataDefinitionKey":"UB_STR_NOVEDAD","name":{"en_US":"UB Novedad"}}],"lastPage":1}',
+            {status: 200},
+          );
+        }
+
+        throw new Error(`Unexpected URL ${url}`);
+      }),
+    });
+
+    const result = await runLiferayInventoryStructuresAllSites(
+      CONFIG,
+      {pageSize: 2},
+      {apiClient, tokenClient: TOKEN_CLIENT},
+    );
+
+    expect(result).toEqual({
+      sites: [
+        {
+          siteGroupId: 20121,
+          siteFriendlyUrl: '/global',
+          siteName: 'Global',
+          structures: [{id: 301, key: 'GLOBAL_BASIC', name: 'Global Basic'}],
+        },
+        {
+          siteGroupId: 20123,
+          siteFriendlyUrl: '/ub',
+          siteName: 'UB',
+          structures: [{id: 302, key: 'UB_STR_NOVEDAD', name: 'UB Novedad'}],
+        },
+      ],
+      summary: {totalSites: 2, totalStructures: 2},
+    });
+  });
+
+  test('hides empty sites in tree output for all-sites with templates', () => {
+    const formatted = formatLiferayInventoryStructures({
+      sites: [
+        {
+          siteGroupId: 20121,
+          siteFriendlyUrl: '/global',
+          siteName: 'Global',
+          structures: [
+            {
+              id: 301,
+              key: 'GLOBAL_BASIC',
+              name: 'Global Basic',
+              templates: [{id: '41001', name: 'Global Template', externalReferenceCode: 'global-template'}],
+            },
+          ],
+        },
+        {
+          siteGroupId: 20122,
+          siteFriendlyUrl: '/empty',
+          siteName: 'Empty',
+          structures: [],
+        },
+      ],
+      summary: {totalSites: 2, totalStructures: 1},
+    });
+
+    expect(formatted).toContain('site=/global name=Global groupId=20121');
+    expect(formatted).not.toContain('site=/empty name=Empty groupId=20122');
+    expect(formatted).toContain('totalSites=2');
+    expect(formatted).toContain('totalStructures=1');
   });
 
   test('lists templates for a site', async () => {
@@ -493,6 +592,61 @@ describe('liferay inventory structures and templates', () => {
 
         if (url.includes('/sites/20121/content-templates?page=1&pageSize=200')) {
           return new Response('{"items":[],"lastPage":1}', {status: 200});
+        }
+
+        if (url.includes('/api/jsonws/group/get-group?groupId=20121')) {
+          return new Response('{"companyId":10157}', {status: 200});
+        }
+
+        if (
+          url.includes(
+            '/api/jsonws/classname/fetch-class-name?value=com.liferay.dynamic.data.mapping.model.DDMStructure',
+          )
+        ) {
+          return new Response('{"classNameId":3001}', {status: 200});
+        }
+
+        if (url.includes('/api/jsonws/classname/fetch-class-name?value=com.liferay.journal.model.JournalArticle')) {
+          return new Response('{"classNameId":2001}', {status: 200});
+        }
+
+        if (
+          url.includes(
+            '/api/jsonws/ddm.ddmtemplate/get-templates?companyId=10157&groupId=20121&classNameId=3001&resourceClassNameId=2001&status=0',
+          )
+        ) {
+          return new Response(
+            '[{"templateId":"40802","templateKey":"LEGACY_NEWS","externalReferenceCode":"legacy-news","nameCurrentValue":"Legacy News","classPK":302,"script":"<#-- legacy -->"}]',
+            {status: 200},
+          );
+        }
+
+        throw new Error(`Unexpected URL ${url}`);
+      }),
+    });
+
+    const result = await runLiferayInventoryTemplates(CONFIG, {site: '20121'}, {apiClient, tokenClient: TOKEN_CLIENT});
+
+    expect(result).toEqual([
+      {
+        id: '',
+        name: 'Legacy News',
+        contentStructureId: 302,
+        externalReferenceCode: 'legacy-news',
+        templateScript: '<#-- legacy -->',
+      },
+    ]);
+  });
+
+  test('falls back to DDM templates when headless content templates return 400', async () => {
+    const apiClient = createLiferayApiClient({
+      fetchImpl: createTestFetchImpl((url) => {
+        if (url.includes('/o/headless-admin-site/v1.0/sites/20121')) {
+          return new Response('{"id":20121,"friendlyUrlPath":"/global","name":"Global"}', {status: 200});
+        }
+
+        if (url.includes('/sites/20121/content-templates?page=1&pageSize=200')) {
+          return new Response('bad request', {status: 400});
         }
 
         if (url.includes('/api/jsonws/group/get-group?groupId=20121')) {

--- a/tests/unit/worktree-paths.test.ts
+++ b/tests/unit/worktree-paths.test.ts
@@ -1,3 +1,5 @@
+import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 
 import {describe, expect, test} from 'vitest';
@@ -5,7 +7,9 @@ import {describe, expect, test} from 'vitest';
 import {
   resolvePortSet,
   resolveWorktreeContext,
+  resolveWorktreeTargetByName,
   resolveWorktreeTarget,
+  resolveWorktreeTargetForContext,
 } from '../../src/features/worktree/worktree-paths.js';
 
 describe('worktree paths', () => {
@@ -34,5 +38,68 @@ describe('worktree paths', () => {
 
     expect(resolvePortSet('issue-123')).toEqual(resolvePortSet('issue-123'));
     expect(resolvePortSet('issue-123').httpPort).not.toBe(resolvePortSet('issue-124').httpPort);
+  });
+
+  test('detects linked git worktrees outside the .worktrees directory and reuses their path', () => {
+    const mainRepoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ldev-main-repo-'));
+    const worktreeParent = fs.mkdtempSync(path.join(os.tmpdir(), 'ldev-linked-worktree-parent-'));
+    const worktreeRoot = path.join(worktreeParent, 'external-issue');
+    const gitDir = path.join(mainRepoRoot, '.git', 'worktrees', 'external-issue');
+
+    fs.mkdirSync(worktreeRoot, {recursive: true});
+    fs.mkdirSync(gitDir, {recursive: true});
+    fs.writeFileSync(path.join(worktreeRoot, '.git'), `gitdir: ${gitDir}\n`);
+
+    const context = resolveWorktreeContext(worktreeRoot);
+
+    expect(context).toEqual({
+      currentRepoRoot: path.resolve(worktreeRoot),
+      mainRepoRoot: path.resolve(mainRepoRoot),
+      isWorktree: true,
+      currentWorktreeName: 'external-issue',
+    });
+
+    const target = resolveWorktreeTargetForContext(context);
+    expect(target?.worktreeDir).toBe(path.resolve(worktreeRoot));
+  });
+
+  test('uses the registered branch when reusing an existing external worktree', () => {
+    const context = resolveWorktreeContext('/repo');
+
+    const target = resolveWorktreeTargetForContext(context, 'external-issue', [
+      {path: '/repo', branch: 'main', detached: false, prunable: false},
+      {path: '/outside/external-issue', branch: 'feat/external-issue', detached: false, prunable: false},
+    ]);
+
+    expect(target?.worktreeDir).toBe(path.resolve('/outside/external-issue'));
+    expect(target?.branch).toBe('feat/external-issue');
+  });
+
+  test('prefers the managed .worktrees path over an external worktree with the same basename', () => {
+    const target = resolveWorktreeTargetByName('/repo', 'issue-123', [
+      {path: '/outside/issue-123', branch: 'feat/outside', detached: false, prunable: false},
+      {path: '/repo/.worktrees/issue-123', branch: 'fix/issue-123', detached: false, prunable: false},
+    ]);
+
+    expect(target.worktreeDir).toBe(path.resolve('/repo/.worktrees/issue-123'));
+    expect(target.branch).toBe('fix/issue-123');
+  });
+
+  test('rejects ambiguous external worktrees with the same basename', () => {
+    expect(() =>
+      resolveWorktreeTargetByName('/repo', 'issue-123', [
+        {path: '/outside-a/issue-123', branch: 'feat/a', detached: false, prunable: false},
+        {path: '/outside-b/issue-123', branch: 'feat/b', detached: false, prunable: false},
+      ]),
+    ).toThrow("More than one registered worktree is named 'issue-123'");
+  });
+
+  test('ignores prunable registered worktrees when resolving by name from the main checkout', () => {
+    const target = resolveWorktreeTargetByName('/repo', 'issue-123', [
+      {path: '/outside/issue-123', branch: 'feat/stale', detached: false, prunable: true},
+    ]);
+
+    expect(target.worktreeDir).toBe(path.resolve('/repo/.worktrees/issue-123'));
+    expect(target.branch).toBe('fix/issue-123');
   });
 });

--- a/tests/unit/worktree-setup.test.ts
+++ b/tests/unit/worktree-setup.test.ts
@@ -1,14 +1,18 @@
+import os from 'node:os';
+import path from 'node:path';
+
+import fs from 'fs-extra';
 import {beforeEach, describe, expect, test, vi} from 'vitest';
 
 const loadConfigMock = vi.fn();
 const detectCapabilitiesMock = vi.fn();
 const isGitRepositoryMock = vi.fn();
-const listGitWorktreesMock = vi.fn();
+const listGitWorktreeDetailsMock = vi.fn();
 const addGitWorktreeMock = vi.fn();
 const readEnvFileMock = vi.fn();
 const resolveEnvContextMock = vi.fn();
 const resolveWorktreeContextMock = vi.fn();
-const resolveWorktreeTargetMock = vi.fn();
+const resolveWorktreeTargetForContextMock = vi.fn();
 const resolveBtrfsConfigMock = vi.fn();
 const assertSafeMainEnvCloneMock = vi.fn();
 
@@ -21,8 +25,9 @@ vi.mock('../../src/core/platform/capabilities.js', () => ({
 }));
 
 vi.mock('../../src/core/platform/git.js', () => ({
+  areSamePath: (left: string, right: string) => path.resolve(left) === path.resolve(right),
   isGitRepository: isGitRepositoryMock,
-  listGitWorktrees: listGitWorktreesMock,
+  listGitWorktreeDetails: listGitWorktreeDetailsMock,
   addGitWorktree: addGitWorktreeMock,
 }));
 
@@ -36,7 +41,7 @@ vi.mock('../../src/core/runtime/env-context.js', () => ({
 
 vi.mock('../../src/features/worktree/worktree-paths.js', () => ({
   resolveWorktreeContext: resolveWorktreeContextMock,
-  resolveWorktreeTarget: resolveWorktreeTargetMock,
+  resolveWorktreeTargetForContext: resolveWorktreeTargetForContextMock,
 }));
 
 vi.mock('../../src/features/worktree/worktree-state.js', () => ({
@@ -60,14 +65,38 @@ describe('runWorktreeSetup', () => {
     loadConfigMock.mockImplementation(({cwd}: {cwd: string}) => (cwd === mainRepoRoot ? mainConfig : repoConfig));
     detectCapabilitiesMock.mockResolvedValue({supportsWorktrees: true});
     isGitRepositoryMock.mockResolvedValue(true);
-    listGitWorktreesMock.mockResolvedValue([]);
+    listGitWorktreeDetailsMock.mockResolvedValue([]);
     addGitWorktreeMock.mockResolvedValue(undefined);
     readEnvFileMock.mockReturnValue({});
     resolveEnvContextMock.mockReturnValue(mainEnvContext);
     resolveWorktreeContextMock.mockReturnValue(worktreeContext);
-    resolveWorktreeTargetMock.mockReturnValue(worktreeTarget);
+    resolveWorktreeTargetForContextMock.mockReturnValue(worktreeTarget);
     resolveBtrfsConfigMock.mockResolvedValue({enabled: false});
     assertSafeMainEnvCloneMock.mockResolvedValue(undefined);
+  });
+
+  test('reuses an existing external registered worktree when setup runs from the main checkout', async () => {
+    const externalWorktreeDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ldev-external-worktree-'));
+    const externalTarget = {name: 'testworktree', worktreeDir: externalWorktreeDir, branch: 'fix/testworktree'};
+    const prepareWorktreeEnv = vi.fn().mockResolvedValue({ok: true});
+
+    listGitWorktreeDetailsMock.mockResolvedValue([
+      {path: mainRepoRoot, branch: 'main', detached: false, prunable: false},
+      {path: externalWorktreeDir, branch: 'feat/testworktree', detached: false, prunable: false},
+    ]);
+    resolveWorktreeTargetForContextMock.mockReturnValue(externalTarget);
+
+    const result = await runWorktreeSetup({
+      cwd: '/repo',
+      name: 'testworktree',
+      withEnv: true,
+      prepareWorktreeEnv,
+    });
+
+    expect(addGitWorktreeMock).not.toHaveBeenCalled();
+    expect(prepareWorktreeEnv).toHaveBeenCalledWith({cwd: externalWorktreeDir, printer: undefined});
+    expect(result.reused).toBe(true);
+    expect(result.worktreeDir).toBe(externalWorktreeDir);
   });
 
   test('stops and restarts main env around with-env clone handoff', async () => {


### PR DESCRIPTION
## Summary
- support reusing linked git worktrees created outside .worktrees, including running ldev worktree setup --with-env from inside the existing checkout
- preserve the real registered branch when reusing worktrees, detect ambiguous external matches, ignore prunable entries, and keep .worktrees/<name> as the preferred managed path
- update worktree docs to describe the external-worktree flow and the optional --name behavior inside an existing worktree

## Validation
- npm run docs:build
- npm run lint
- npm run format:check
- npm run typecheck
- npm run test:unit
- npm run build
- npm run test:smoke
- npx vitest run --config vitest.integration.config.ts tests/integration/worktree.integration.test.ts
- npx vitest run --config vitest.integration.config.ts tests/integration/cleanup.integration.test.ts