### PR TITLE
Refine inventory page request kinds for inventory

### DIFF
--- a/src/commands/liferay/inventory.command.ts
+++ b/src/commands/liferay/inventory.command.ts
@@ -11,6 +11,7 @@ import {
 import {
   formatLiferayInventoryPage,
   projectLiferayInventoryPageJson,
+  resolveInventoryPageRequest,
   runLiferayInventoryPage,
 } from '../../features/liferay/inventory/liferay-inventory-page.js';
 import {
@@ -247,13 +248,15 @@ Notes:
   ).action(
     createFormattedAction(
       async (context, options: InventoryPageCommandOptions) =>
-        runLiferayInventoryPage(context.config, {
-          url: options.url,
-          site: options.site,
-          friendlyUrl: options.friendlyUrl,
-          privateLayout: Boolean(options.privateLayout),
-          verbose: Boolean(options.verbose),
-        }),
+        runLiferayInventoryPage(
+          context.config,
+          resolveInventoryPageRequest({
+            url: options.url,
+            site: options.site,
+            friendlyUrl: options.friendlyUrl,
+            privateLayout: Boolean(options.privateLayout),
+          }),
+        ),
       (options: InventoryPageCommandOptions) => ({
         text: (result) => formatLiferayInventoryPage(result, Boolean(options.verbose)),
         json: (result) => projectLiferayInventoryPageJson(result, {full: Boolean(options.full)}),

--- a/src/features/liferay/inventory/liferay-inventory-page-url.ts
+++ b/src/features/liferay/inventory/liferay-inventory-page-url.ts
@@ -1,22 +1,21 @@
 import {LiferayErrors} from '../errors/index.js';
 
-export type InventoryPageRoute = 'portalHome' | 'siteRoot' | 'displayPage' | 'regularPage';
-
-export type InventoryPageRequest = {
-  siteSlug: string;
-  friendlyUrl: string;
-  privateLayout: boolean;
-  route: InventoryPageRoute;
-  displayPageUrlTitle: string | null;
-  localeHint?: string;
-};
-
-export function resolveInventoryPageRequest(options: {
+export type InventoryPageOptions = {
   url?: string;
   site?: string;
   friendlyUrl?: string;
   privateLayout?: boolean;
-}): InventoryPageRequest {
+};
+
+export type InventoryPageRequest =
+  | {kind: 'portalHome'}
+  | {kind: 'publicSiteRoot'; site: string; resolveHomeRedirect: boolean}
+  | {kind: 'privateSiteRoot'; site: string; resolveHomeRedirect: boolean}
+  | {kind: 'webContentDisplayPage'; site: string; friendlyUrl: string; urlTitle: string}
+  | {kind: 'publicRegularPage'; site: string; friendlyUrl: string; localeHint?: string}
+  | {kind: 'privateRegularPage'; site: string; friendlyUrl: string; localeHint?: string};
+
+export function resolveInventoryPageRequest(options: InventoryPageOptions): InventoryPageRequest {
   const sanitizedUrl = sanitizeInventoryUrl(options.url);
 
   if (sanitizedUrl) {
@@ -27,10 +26,10 @@ export function resolveInventoryPageRequest(options: {
       const rest = localeMatch[2];
       const localeHint = normalizeLocale(localePrefix);
       if (rest.startsWith('/web/')) {
-        return {...buildUrlRequest(rest, '/web/', false), localeHint};
+        return addLocaleHint(buildUrlRequest(rest, '/web/', false), localeHint);
       }
       if (rest.startsWith('/group/')) {
-        return {...buildUrlRequest(rest, '/group/', true), localeHint};
+        return addLocaleHint(buildUrlRequest(rest, '/group/', true), localeHint);
       }
     }
 
@@ -42,7 +41,7 @@ export function resolveInventoryPageRequest(options: {
       return buildUrlRequest(sanitizedUrl, '/group/', true);
     }
 
-    return buildRequest('', ensureLeadingSlash(sanitizedUrl), false);
+    return buildRequest('', ensureLeadingSlash(sanitizedUrl), false, true);
   }
 
   if (options.site && options.friendlyUrl) {
@@ -50,40 +49,44 @@ export function resolveInventoryPageRequest(options: {
       options.site.startsWith('/') ? options.site.slice(1) : options.site,
       ensureLeadingSlash(sanitizeInventoryUrl(options.friendlyUrl) ?? options.friendlyUrl),
       options.privateLayout ?? false,
+      false,
     );
   }
 
   throw LiferayErrors.inventoryError('Provide --url or both --site and --friendly-url.');
 }
 
-function buildRequest(siteSlug: string, friendlyUrl: string, privateLayout: boolean): InventoryPageRequest {
+function buildRequest(
+  siteSlug: string,
+  friendlyUrl: string,
+  privateLayout: boolean,
+  resolveHomeRedirect: boolean,
+): InventoryPageRequest {
   if (friendlyUrl === '/') {
-    return {
-      siteSlug,
-      friendlyUrl,
-      privateLayout,
-      route: siteSlug === '' ? 'portalHome' : 'siteRoot',
-      displayPageUrlTitle: null,
-    };
+    return siteSlug === ''
+      ? {kind: 'portalHome'}
+      : {kind: privateLayout ? 'privateSiteRoot' : 'publicSiteRoot', site: siteSlug, resolveHomeRedirect};
   }
 
   const displayPageUrlTitle = extractDisplayPageUrlTitle(friendlyUrl);
   if (displayPageUrlTitle) {
+    if (!siteSlug) {
+      throw LiferayErrors.inventoryError(
+        'Display pages (paths starting with /w/) require a site. Use /web/{site}/w/{urlTitle} or --site with --friendly-url.',
+      );
+    }
     return {
-      siteSlug,
+      kind: 'webContentDisplayPage',
+      site: siteSlug,
       friendlyUrl,
-      privateLayout,
-      route: 'displayPage',
-      displayPageUrlTitle,
+      urlTitle: displayPageUrlTitle,
     };
   }
 
   return {
-    siteSlug,
+    kind: privateLayout ? 'privateRegularPage' : 'publicRegularPage',
+    site: siteSlug,
     friendlyUrl,
-    privateLayout,
-    route: 'regularPage',
-    displayPageUrlTitle: null,
   };
 }
 
@@ -91,7 +94,29 @@ function buildUrlRequest(url: string, prefix: '/web/' | '/group/', privateLayout
   const nextSlash = url.indexOf('/', prefix.length);
   const siteSlug = url.slice(prefix.length, nextSlash > 0 ? nextSlash : url.length);
   const friendlyUrl = nextSlash > 0 ? url.slice(nextSlash) : '/';
-  return buildRequest(siteSlug, ensureLeadingSlash(friendlyUrl), privateLayout);
+  return buildRequest(siteSlug, ensureLeadingSlash(friendlyUrl), privateLayout, true);
+}
+
+function addLocaleHint(request: InventoryPageRequest, localeHint: string): InventoryPageRequest {
+  return isRegularPageRequest(request) ? {...request, localeHint} : request;
+}
+
+export function isSiteRootRequest(
+  request: InventoryPageRequest,
+): request is Extract<InventoryPageRequest, {kind: 'publicSiteRoot' | 'privateSiteRoot'}> {
+  return request.kind === 'publicSiteRoot' || request.kind === 'privateSiteRoot';
+}
+
+export function isRegularPageRequest(
+  request: InventoryPageRequest,
+): request is Extract<InventoryPageRequest, {kind: 'publicRegularPage' | 'privateRegularPage'}> {
+  return request.kind === 'publicRegularPage' || request.kind === 'privateRegularPage';
+}
+
+export function privateLayoutForInventoryPageRequest(
+  request: Exclude<InventoryPageRequest, {kind: 'portalHome' | 'webContentDisplayPage'}>,
+): boolean {
+  return request.kind === 'privateSiteRoot' || request.kind === 'privateRegularPage';
 }
 
 function sanitizeInventoryUrl(rawUrl?: string): string | null {
@@ -152,7 +177,7 @@ function normalizeLocale(locale: string): string {
 
 function extractDisplayPageUrlTitle(friendlyUrl: string): string | null {
   const candidate = friendlyUrl.startsWith('/') ? friendlyUrl.slice(1) : friendlyUrl;
-  if (!candidate.startsWith('w/')) {
+  if (!candidate.startsWith('w/') || candidate.length <= 2) {
     return null;
   }
   return candidate.slice(2);

--- a/src/features/liferay/inventory/liferay-inventory-page.ts
+++ b/src/features/liferay/inventory/liferay-inventory-page.ts
@@ -5,7 +5,14 @@ import {createLiferayApiClient} from '../../../core/http/client.js';
 import {LiferayErrors} from '../errors/index.js';
 import {createInventoryGateway} from './liferay-inventory-shared.js';
 import {resolveSite} from '../portal/site-resolution.js';
-import {resolveInventoryPageRequest} from './liferay-inventory-page-url.js';
+import {
+  isRegularPageRequest,
+  isSiteRootRequest,
+  privateLayoutForInventoryPageRequest,
+  resolveInventoryPageRequest,
+  type InventoryPageOptions,
+  type InventoryPageRequest,
+} from './liferay-inventory-page-url.js';
 import {buildPageUrl} from '../page-layout/liferay-layout-shared.js';
 import {
   fetchDisplayPageInventory,
@@ -248,29 +255,31 @@ export type ResolvedRegularLayoutPage = {
 
 export async function runLiferayInventoryPage(
   config: AppConfig,
-  options: {url?: string; site?: string; friendlyUrl?: string; privateLayout?: boolean; verbose?: boolean},
+  requestOrOptions: InventoryPageRequest | InventoryPageOptions,
   dependencies?: InventoryPageDependencies,
 ): Promise<LiferayInventoryPageResult> {
   const finalizeResult = (result: LiferayInventoryPageResult): LiferayInventoryPageResult =>
     validateLiferayInventoryPageResultV2(result) as LiferayInventoryPageResult;
 
-  const request = resolveInventoryPageRequest(options);
+  const request = isInventoryPageRequest(requestOrOptions)
+    ? requestOrOptions
+    : resolveInventoryPageRequest(requestOrOptions);
   const effectiveConfig = config;
   const apiClient = dependencies?.apiClient ?? createLiferayApiClient();
   const gateway = createInventoryGateway(effectiveConfig, apiClient, dependencies);
   const siteDependencies = {...dependencies, gateway};
 
-  if (request.route === 'portalHome') {
+  if (request.kind === 'portalHome') {
     const homeRequest = await resolvePortalHomeRequest(effectiveConfig);
     if (homeRequest) {
-      const site = await resolveSite(effectiveConfig, homeRequest.siteSlug, siteDependencies);
+      const site = await resolveSite(effectiveConfig, homeRequest.site, siteDependencies);
       return fetchRegularPageInventory(
         effectiveConfig,
         gateway,
         apiClient,
         site,
         homeRequest.friendlyUrl,
-        homeRequest.privateLayout,
+        privateLayoutForInventoryPageRequest(homeRequest),
         homeRequest.localeHint,
       ).then(finalizeResult);
     }
@@ -278,9 +287,9 @@ export async function runLiferayInventoryPage(
     return finalizeResult(await fetchSiteRootInventory(gateway, site, false));
   }
 
-  const site = await resolveSite(effectiveConfig, request.siteSlug, siteDependencies);
-  if (request.route === 'siteRoot') {
-    if (options.url) {
+  const site = await resolveSite(effectiveConfig, request.site, siteDependencies);
+  if (isSiteRootRequest(request)) {
+    if (request.resolveHomeRedirect || (!isInventoryPageRequest(requestOrOptions) && requestOrOptions.url)) {
       const redirectedRequest = await resolveSiteHomeRequest(effectiveConfig, request);
       if (redirectedRequest) {
         return fetchRegularPageInventory(
@@ -289,18 +298,16 @@ export async function runLiferayInventoryPage(
           apiClient,
           site,
           redirectedRequest.friendlyUrl,
-          redirectedRequest.privateLayout,
+          privateLayoutForInventoryPageRequest(redirectedRequest),
           redirectedRequest.localeHint,
         ).then(finalizeResult);
       }
     }
-    return finalizeResult(await fetchSiteRootInventory(gateway, site, request.privateLayout));
+    return finalizeResult(await fetchSiteRootInventory(gateway, site, privateLayoutForInventoryPageRequest(request)));
   }
 
-  if (request.route === 'displayPage') {
-    return finalizeResult(
-      await fetchDisplayPageInventory(effectiveConfig, gateway, apiClient, site, request.displayPageUrlTitle ?? ''),
-    );
+  if (request.kind === 'webContentDisplayPage') {
+    return finalizeResult(await fetchDisplayPageInventory(effectiveConfig, gateway, apiClient, site, request.urlTitle));
   }
 
   return finalizeResult(
@@ -310,10 +317,14 @@ export async function runLiferayInventoryPage(
       apiClient,
       site,
       request.friendlyUrl,
-      request.privateLayout,
+      privateLayoutForInventoryPageRequest(request),
       request.localeHint,
     ),
   );
+}
+
+function isInventoryPageRequest(value: InventoryPageRequest | InventoryPageOptions): value is InventoryPageRequest {
+  return 'kind' in value;
 }
 
 export function projectLiferayInventoryPageJson(
@@ -655,20 +666,23 @@ async function resolvePortalHomeRequest(config: AppConfig) {
   }
 
   const resolved = resolveInventoryPageRequest({url: redirectedUrl});
-  return resolved.route === 'regularPage' ? resolved : null;
+  return isRegularPageRequest(resolved) ? resolved : null;
 }
 
-async function resolveSiteHomeRequest(config: AppConfig, request: ReturnType<typeof resolveInventoryPageRequest>) {
+async function resolveSiteHomeRequest(
+  config: AppConfig,
+  request: Extract<InventoryPageRequest, {kind: 'publicSiteRoot' | 'privateSiteRoot'}>,
+) {
   const redirectedUrl = await detectPathRedirect(
     config,
-    buildPageUrl(`/${request.siteSlug}`, '/', request.privateLayout),
+    buildPageUrl(`/${request.site}`, '/', privateLayoutForInventoryPageRequest(request)),
   );
   if (!redirectedUrl) {
     return null;
   }
 
   const resolved = resolveInventoryPageRequest({url: redirectedUrl});
-  return resolved.route === 'regularPage' && resolved.siteSlug === request.siteSlug ? resolved : null;
+  return isRegularPageRequest(resolved) && resolved.site === request.site ? resolved : null;
 }
 
 async function detectPathRedirect(config: AppConfig, path: string): Promise<string | null> {
@@ -737,13 +751,20 @@ export async function resolveRegularLayoutPage(
   dependencies?: InventoryPageDependencies,
 ): Promise<ResolvedRegularLayoutPage> {
   const request = resolveInventoryPageRequest(options);
-  if (request.route !== 'regularPage') {
+  if (!isRegularPageRequest(request)) {
     throw LiferayErrors.inventoryError('Only a regular page can be resolved for this flow.');
   }
 
   const apiClient = dependencies?.apiClient ?? createLiferayApiClient();
   const gateway = createInventoryGateway(config, apiClient, dependencies);
-  const site = await resolveSite(config, request.siteSlug, {...dependencies, gateway});
+  const site = await resolveSite(config, request.site, {...dependencies, gateway});
 
-  return resolveRegularLayoutPageData(config, gateway, apiClient, site, request.friendlyUrl, request.privateLayout);
+  return resolveRegularLayoutPageData(
+    config,
+    gateway,
+    apiClient,
+    site,
+    request.friendlyUrl,
+    privateLayoutForInventoryPageRequest(request),
+  );
 }

--- a/tests/unit/liferay-inventory-page.test.ts
+++ b/tests/unit/liferay-inventory-page.test.ts
@@ -8,6 +8,11 @@ import {
   resolveInventoryPageRequest,
   runLiferayInventoryPage,
 } from '../../src/features/liferay/inventory/liferay-inventory-page.js';
+import {
+  isRegularPageRequest,
+  isSiteRootRequest,
+  privateLayoutForInventoryPageRequest,
+} from '../../src/features/liferay/inventory/liferay-inventory-page-url.js';
 import {validateLiferayInventoryPageResultV2} from '../../src/features/liferay/inventory/liferay-inventory-page-schema.js';
 import {createStaticTokenClient, createTestFetchImpl, createTokenClient} from '../../src/testing/cli-test-helpers.js';
 
@@ -89,32 +94,97 @@ afterEach(() => {
 describe('liferay inventory page', () => {
   test('resolves requests from full URLs and explicit site/friendly-url', () => {
     expect(resolveInventoryPageRequest({url: '/web/guest/home'})).toMatchObject({
-      siteSlug: 'guest',
+      kind: 'publicRegularPage',
+      site: 'guest',
       friendlyUrl: '/home',
-      privateLayout: false,
-      route: 'regularPage',
     });
 
     expect(resolveInventoryPageRequest({url: 'https://example.test/group/guest/private-page'})).toMatchObject({
-      siteSlug: 'guest',
+      kind: 'privateRegularPage',
+      site: 'guest',
       friendlyUrl: '/private-page',
-      privateLayout: true,
-      route: 'regularPage',
     });
 
     expect(resolveInventoryPageRequest({site: 'guest', friendlyUrl: '/w/news-article'})).toMatchObject({
-      siteSlug: 'guest',
+      kind: 'webContentDisplayPage',
+      site: 'guest',
       friendlyUrl: '/w/news-article',
-      route: 'displayPage',
-      displayPageUrlTitle: 'news-article',
+      urlTitle: 'news-article',
     });
 
     expect(resolveInventoryPageRequest({url: 'https://example.test/es/web/guest/aprende'})).toMatchObject({
-      siteSlug: 'guest',
+      kind: 'publicRegularPage',
+      site: 'guest',
       friendlyUrl: '/aprende',
-      privateLayout: false,
-      route: 'regularPage',
       localeHint: 'es_ES',
+    });
+
+    expect(resolveInventoryPageRequest({url: '/web/guest'})).toMatchObject({
+      kind: 'publicSiteRoot',
+      site: 'guest',
+      resolveHomeRedirect: true,
+    });
+
+    expect(resolveInventoryPageRequest({url: '/group/guest'})).toMatchObject({
+      kind: 'privateSiteRoot',
+      site: 'guest',
+      resolveHomeRedirect: true,
+    });
+
+    expect(resolveInventoryPageRequest({site: 'guest', friendlyUrl: '/'})).toMatchObject({
+      kind: 'publicSiteRoot',
+      site: 'guest',
+      resolveHomeRedirect: false,
+    });
+  });
+
+  test('narrowing helpers correctly classify InventoryPageRequest kinds', () => {
+    const publicRoot = resolveInventoryPageRequest({url: '/web/guest'});
+    const privateRoot = resolveInventoryPageRequest({url: '/group/guest'});
+    const publicPage = resolveInventoryPageRequest({url: '/web/guest/home'});
+    const privatePage = resolveInventoryPageRequest({url: '/group/guest/home'});
+    const displayPage = resolveInventoryPageRequest({site: 'guest', friendlyUrl: '/w/my-article'});
+    const portalHome = resolveInventoryPageRequest({url: '/'});
+
+    expect(isSiteRootRequest(publicRoot)).toBe(true);
+    expect(isSiteRootRequest(privateRoot)).toBe(true);
+    expect(isSiteRootRequest(publicPage)).toBe(false);
+    expect(isSiteRootRequest(displayPage)).toBe(false);
+    expect(isSiteRootRequest(portalHome)).toBe(false);
+
+    expect(isRegularPageRequest(publicPage)).toBe(true);
+    expect(isRegularPageRequest(privatePage)).toBe(true);
+    expect(isRegularPageRequest(publicRoot)).toBe(false);
+    expect(isRegularPageRequest(displayPage)).toBe(false);
+    expect(isRegularPageRequest(portalHome)).toBe(false);
+
+    // privateLayoutForInventoryPageRequest excludes portalHome and webContentDisplayPage at the type level;
+    // use inline objects to give TypeScript the narrowed type it needs.
+    expect(
+      privateLayoutForInventoryPageRequest({kind: 'publicSiteRoot', site: 'guest', resolveHomeRedirect: false}),
+    ).toBe(false);
+    expect(
+      privateLayoutForInventoryPageRequest({kind: 'privateSiteRoot', site: 'guest', resolveHomeRedirect: false}),
+    ).toBe(true);
+    expect(privateLayoutForInventoryPageRequest({kind: 'publicRegularPage', site: 'guest', friendlyUrl: '/home'})).toBe(
+      false,
+    );
+    expect(
+      privateLayoutForInventoryPageRequest({kind: 'privateRegularPage', site: 'guest', friendlyUrl: '/home'}),
+    ).toBe(true);
+  });
+
+  test('rejects display-page URL without a site segment', () => {
+    expect(() => resolveInventoryPageRequest({url: '/w/some-article'})).toThrow(
+      'Display pages (paths starting with /w/) require a site.',
+    );
+  });
+
+  test('treats bare /w/ path as a regular page (no urlTitle)', () => {
+    expect(resolveInventoryPageRequest({site: 'guest', friendlyUrl: '/w/'})).toMatchObject({
+      kind: 'publicRegularPage',
+      site: 'guest',
+      friendlyUrl: '/w/',
     });
   });
 


### PR DESCRIPTION
## Summary
- split inventory page requests into explicit public/private site root and regular page kinds
- update inventory page resolution to use kind-based narrowing instead of a generic privateLayout request field
- reject display-page paths without a site and add focused request helper tests

## Validation
- npx tsc --noEmit
- npx vitest run tests/unit/liferay-inventory-page.test.ts