### PR TITLE
feat: expand local MCP server support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ ldev doctor
 - **Reproduce Production Locally** — Docker, database, and worktree workflows help bring real issues into a controlled local setup.
 - **Apply Fixes Safely** — `ldev deploy`, `ldev osgi`, and related tooling support controlled runtime changes and verification.
 - **Work with Structured Output** — JSON output makes the same workflows usable for humans, scripts, and coding agents.
+- **Expose Local MCP Tools** — run selected `ldev` workflows directly from MCP-capable editors while keeping the CLI as the fallback.
 
 ## 🧭 Typical Incident Flow
 
@@ -60,6 +61,38 @@ ldev ai bootstrap --intent=develop --json
 ldev portal inventory sites --json
 ldev logs diagnose --json
 ```
+
+## Local MCP Server
+
+`ldev` includes a local stdio MCP server for editors and coding agents that
+support MCP. It exposes structured shortcuts over the operational CLI, including
+project context, runtime status, portal checks, log diagnosis, inventory, deploy
+status, OSGi diagnosis, and thread dumps.
+
+Configure supported clients from the project root:
+
+```bash
+ldev ai mcp-setup --target . --tool all
+```
+
+Use an explicit launch strategy when you need reproducible worktrees or global
+speed:
+
+```bash
+ldev ai mcp-setup --target . --tool vscode --strategy local
+ldev ai mcp-setup --target . --tool claude-code --strategy global
+ldev ai mcp-setup --target . --tool cursor --strategy npx
+```
+
+If an editor does not show the tools, validate the config and run a real
+handshake:
+
+```bash
+ldev mcp doctor --target . --tool all
+```
+
+The MCP layer is optional. Skills and agents should use MCP when available, and
+fall back to the same `ldev ... --json` commands when it is not.
 
 ## 📚 Documentation
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -71,7 +71,11 @@ export default defineConfig({
       },
       {
         text: 'Agentic',
-        items: [{text: 'Agent Workflows', link: '/agentic/'}],
+        items: [
+          {text: 'Agent Workflows', link: '/agentic/'},
+          {text: 'MCP Decision Route', link: '/agentic/mcp-decision-route'},
+          {text: 'MCP Server Inventory', link: '/agentic/mcp-server-inventory'},
+        ],
       },
       {
         text: 'Advanced',

--- a/docs/agentic/index.md
+++ b/docs/agentic/index.md
@@ -104,6 +104,21 @@ as the first discovery step. It returns the structure list enriched with
 associated templates in one call, so agents can route directly to the correct
 export/import commands.
 
+## MCP as an acceleration layer
+
+`ldev` MCP tools are optional structured shortcuts over selected `ldev`
+workflows. They make agents faster and less error-prone when available, but the
+CLI remains the canonical fallback.
+
+Use this decision route:
+
+- skills decide the workflow and guardrails
+- MCP tools execute structured discovery and diagnosis when visible
+- CLI commands with `--json` remain the fallback for every workflow
+
+See [MCP Decision Route](./mcp-decision-route.md) for the maintained mapping of
+MCP tools to CLI fallbacks.
+
 ## Keeping rules and skills up to date
 
 After pulling a new version of `ldev`, refresh skills and rules in the project:

--- a/docs/agentic/mcp-decision-route.md
+++ b/docs/agentic/mcp-decision-route.md
@@ -1,0 +1,116 @@
+---
+title: MCP Decision Route
+description: When agents should use ldev MCP tools, CLI fallbacks, and installed skills.
+---
+
+# MCP Decision Route
+
+`ldev` has three agent-facing layers:
+
+| Layer | Role | Required? |
+| --- | --- | --- |
+| CLI | Canonical execution contract and universal fallback | Yes |
+| MCP tools | Structured acceleration over selected `ldev` workflows | No |
+| Skills | Decision playbooks, guardrails, and domain workflow memory | Yes |
+
+The rule is:
+
+```text
+Skills decide what should happen.
+MCP tools execute structured diagnosis/discovery when available.
+CLI remains the source of truth and fallback for every workflow.
+```
+
+## Default Decision Route
+
+1. Start from the task-specific skill when one applies.
+2. For discovery or diagnosis, use an MCP tool if it is visible in the client.
+3. If the MCP tool is not visible, use the equivalent CLI command with `--json`.
+4. For mutations or artifact-generating diagnosis, prefer CLI workflows and skill guardrails unless a tool documents the write explicitly.
+5. If a client is expected to expose MCP tools but does not, run `ldev mcp doctor`.
+
+## MCP Server Practice
+
+The local `ldev` MCP server follows the current MCP shape for CLI projects:
+
+- use stdio for local editor-launched tools; a background process is only useful
+  once an HTTP transport exists
+- keep tool names stable, unique, and namespaced by domain
+- validate tool inputs through the SDK schema layer and keep additional runtime
+  guards where a tool can write artifacts or run for a long time
+- return JSON as both structured content and serialized text so newer clients
+  get typed payloads while older clients still receive readable output
+- report tool execution failures with MCP tool errors, not protocol failures, so
+  agents can self-correct
+- keep sensitive or mutating workflows CLI-first unless the tool has explicit
+  apply semantics and user-visible approval expectations
+
+## MCP to CLI Fallbacks
+
+| Intent | Prefer MCP tool | CLI fallback |
+| --- | --- | --- |
+| Project snapshot | `ldev_context` | `ldev context --json` |
+| Portal auth/reachability | `liferay_check` | `ldev portal check --json` |
+| Runtime status | `ldev_status` | `ldev status --json` |
+| Log diagnosis | `ldev_logs_diagnose` | `ldev logs diagnose --since 10m --json` |
+| Site discovery | `liferay_inventory_sites` | `ldev portal inventory sites --json` |
+| Page tree | `liferay_inventory_pages` | `ldev portal inventory pages --site /<site> --json` |
+| Page inspection | `liferay_inventory_page` | `ldev portal inventory page --url <url> --json` |
+| Structures | `liferay_inventory_structures` | `ldev portal inventory structures --site /<site> --json` |
+| Templates | `liferay_inventory_templates` | `ldev portal inventory templates --site /<site> --json` |
+| Deploy state | `liferay_deploy_status` | `ldev deploy status --json` |
+| Bundle status | `liferay_osgi_status` | `ldev osgi status <bundle> --json` |
+| Bundle diagnosis | `liferay_osgi_diag` | `ldev osgi diag <bundle> --json` |
+| Thread dumps | `liferay_osgi_thread_dump` | `ldev osgi thread-dump --json` |
+| Local diagnostics | `liferay_doctor` | `ldev doctor --json` |
+
+`liferay_osgi_thread_dump` is diagnostic, but it writes dump artifacts under the
+project's configured dump directory. Treat it as CLI-first when the user has not
+asked for runtime artifacts or when workspace writes are restricted.
+
+## What MCP Should Not Replace
+
+Do not move these decisions into MCP tools:
+
+- whether a task needs an isolated worktree
+- whether a portal resource change is safe as a direct import or needs a migration
+- whether a broad deploy or plural resource import is acceptable
+- whether destructive commands are allowed
+- project-specific conventions, review process, and issue handling
+- browser-visible verification criteria
+
+Those belong in skills and project context.
+
+## Mutating Workflows
+
+MCP tools can eventually expose carefully bounded mutations, but the default
+practice is CLI-first for mutation:
+
+- `ldev resource import-*`
+- `ldev resource migration-pipeline`
+- `ldev deploy module`
+- `ldev deploy theme`
+- `ldev env ...`
+- `ldev db ...`
+- `ldev worktree ...`
+
+The skills define the safe order: discovery, check-only, mutation, read-back
+verification, logs/OSGi checks, and browser validation when needed.
+
+## Diagnosing Missing MCP Tools
+
+Use setup once per project/client:
+
+```bash
+ldev ai mcp-setup --target . --tool all
+```
+
+Then validate:
+
+```bash
+ldev mcp doctor --target . --tool all
+```
+
+If doctor passes but the editor still does not show tools, restart the editor or
+AI assistant. If doctor fails, use the CLI fallbacks above while fixing the MCP
+configuration.

--- a/docs/agentic/mcp-server-inventory.md
+++ b/docs/agentic/mcp-server-inventory.md
@@ -1,0 +1,139 @@
+---
+title: MCP Server Inventory
+description: Candidate ldev commands for MCP tools and more convenient MCP server startup models.
+---
+
+# MCP Server Inventory
+
+This inventory classifies the existing `ldev` command surface by how well it fits
+the local MCP server.
+
+## Current MCP Surface
+
+The current server registers 15 tools:
+
+| Tool | Source command area | Fit |
+| --- | --- | --- |
+| `ldev_context` | `context --json` | Strong |
+| `liferay_check` | `portal check --json` | Strong |
+| `ldev_status` | `status --json` | Strong |
+| `ldev_logs_diagnose` | `logs diagnose --json` | Strong |
+| `liferay_inventory_sites` | `portal inventory sites` | Strong |
+| `liferay_inventory_pages` | `portal inventory pages` | Strong |
+| `liferay_inventory_page` | `portal inventory page` | Strong |
+| `liferay_inventory_structures` | `portal inventory structures` | Strong |
+| `liferay_inventory_templates` | `portal inventory templates` | Strong |
+| `liferay_doctor` | `doctor` | Strong |
+| `liferay_deploy_status` | `deploy status` | Strong |
+| `liferay_osgi_status` | `osgi status` | Strong |
+| `liferay_osgi_diag` | `osgi diag <bundle>` | Strong |
+| `liferay_osgi_thread_dump` | `osgi thread-dump` | Strong |
+| `liferay_mcp_check` | `mcp check` | Strong |
+
+These are good first tools because they return structured results, answer common
+agent questions without requiring shell parsing, and keep mutating workflows
+CLI-first. `liferay_osgi_thread_dump` is the exception that writes diagnostic
+dump artifacts.
+
+## Best Next MCP Tools
+
+These commands should be the next candidates because they are read-only or
+diagnostic, have stable JSON output, and are useful before an agent mutates
+anything.
+
+| Priority | MCP tool | Backing command/function | Why |
+| --- | --- | --- | --- |
+| P0 | `ldev_ai_bootstrap` | `ai bootstrap --intent ... --json` / `runAiBootstrap` | Higher-level context plus targeted doctor checks. Useful for discover/develop/deploy/troubleshoot intents. |
+| P0 | `liferay_inventory_preflight` | `portal inventory preflight` / `runLiferayPreflight` | Explicit API-surface readiness for inventory/resource workflows. |
+| P1 | `reindex_status` | `portal reindex status` / `runReindexStatus` | Common runtime diagnostic after imports or content shrink work. |
+| P1 | `reindex_tasks` | `portal reindex tasks` / `runReindexTasks` | Complements `reindex_status` with active task detail. |
+| P1 | `liferay_search_indices` | `portal search indices` / `runLiferaySearchIndices` | Good read-only Elasticsearch inventory. |
+| P1 | `liferay_search_mappings` | `portal search mappings --index` / `runLiferaySearchMappings` | Helpful for diagnosing indexing/schema issues. |
+| P1 | `page_layout_export` | `portal page-layout export` / `runLiferayPageLayoutExport` | Read-only normalized page JSON for page debugging. Prefer returning JSON directly rather than writing `--output`. |
+| P1 | `page_layout_diff` | `portal page-layout diff` / `runLiferayPageLayoutDiff` | Strong verification tool for before/after page checks. |
+| P1 | `resource_get_structure` | `resource structure` / `runLiferayResourceGetStructure` | Read one resource without filesystem writes. |
+| P1 | `resource_get_template` | `resource template` / `runLiferayResourceGetTemplate` | Read one template without filesystem writes. |
+| P1 | `resource_get_adt` | `resource adt` / `runLiferayResourceGetAdt` | Read one ADT without filesystem writes. |
+| P1 | `resource_list_adts` | `resource adts` / `runLiferayResourceListAdts` | Discovery for ADT work. |
+| P1 | `resource_list_fragments` | `resource fragments` / `runLiferayResourceListFragments` | Discovery for fragment work. |
+
+## Conditional MCP Tools
+
+These are useful, but they write files, call external services, run longer
+operations, or need stricter guardrails.
+
+| MCP tool | Backing command/function | Suggested rule |
+| --- | --- | --- |
+| `resource_export_structure` | `resource export-structure` | Allow with explicit output path or return-only mode. |
+| `resource_export_template` | `resource export-template` | Allow with explicit output path or return-only mode. |
+| `resource_export_structures` | `resource export-structures` | Require explicit `allSites` and cap/error strategy. |
+| `resource_export_templates` | `resource export-templates` | Require explicit `allSites`, `continueOnError`, and output directory. |
+| `resource_export_adts` | `resource export-adts` | Same as template exports. |
+| `resource_export_fragments` | `resource export-fragments` | Same as template exports. |
+| `resource_import_*` | `resource import-*` | Expose check-only first. Mutating imports should require a separate `apply: true` input and should reject plural imports unless explicit. |
+| `resource_migration_init` | `resource migration-init` | OK as a file-generation tool if `output` is explicit. |
+| `resource_migration_run` | `resource migration-run` | Prefer check-only/dry-run first. Mutating mode should require explicit approval input. |
+| `resource_migration_pipeline` | `resource migration-pipeline` | Powerful but high-blast-radius; expose after import guardrails exist. |
+| `deploy_prepare` | `deploy prepare` | Writes build artifacts but does not touch runtime. Useful after explicit user intent. |
+| `deploy_module` / `deploy_theme` | `deploy module`, `deploy theme` | Mutating build/deploy flow; require exact target. |
+| `deploy_watch` | `deploy watch` | Long-running; expose only with bounded iterations. |
+| `env_wait` | `env wait` | OK as bounded diagnostic with timeout. |
+| `env_diff` | `env diff` | Read-only unless `writeBaseline`; reject `writeBaseline` by default. |
+| `db_query` | `db query` | Useful but risky; allow read-only `SELECT` first, reject files/mutations unless an explicit unsafe mode exists. |
+
+## Poor MCP Fits
+
+These commands are interactive, destructive, secret-bearing, or better handled by
+the human-facing CLI.
+
+| Command | Reason |
+| --- | --- |
+| `shell` | Interactive terminal session, no structured return. |
+| `logs` without `diagnose` | Streaming terminal output; use `logs diagnose` instead. |
+| `osgi gogo` | Interactive terminal session. |
+| `env clean`, `worktree clean`, `worktree gc --apply` | Destructive local cleanup. |
+| `db import --force`, `db sync --force` | Replaces local database state. |
+| `db download`, `db sync`, `files-download` | External downloads, credentials, long-running operations. Better as CLI workflows. |
+| `project init`, `ai install`, `ai update` | Bootstrap/configuration flows, not normal runtime tools. |
+| `auth token` | Secret-bearing result. Prefer health checks that do not return tokens. |
+| `config set`, `feature-flags enable/disable`, `reindex speedup-on/off` | Mutates local/portal configuration; expose later only with explicit apply semantics. |
+| `content prune` | Potentially destructive portal content operation; keep CLI-first. |
+
+## Startup Options
+
+The current local server uses stdio. In that model the MCP client starts
+`ldev-mcp-server` itself, so a separate background daemon is not required and can
+actually be the wrong abstraction: stdio needs a process connected to the
+client's stdin/stdout.
+
+Implemented improvements:
+
+1. `ldev ai mcp-setup --tool all`.
+   This writes `.vscode/mcp.json`, `.claude/mcp.json`, and `.cursor/mcp.json` in
+   one run. It solves the real daily friction without changing transport.
+
+2. `ldev ai mcp-setup --target . --tool vscode --strategy local|global|npx`.
+   Today strategy is auto-detected. An explicit strategy lets a developer force a
+   local project dependency for reproducible worktrees or force global for speed.
+
+3. `ldev mcp doctor`.
+   This should validate the generated config file, resolve the command on PATH,
+   run `ldev-mcp-server --version`, and optionally perform a minimal MCP
+   initialize/list-tools handshake. This is more valuable than a background
+   process for stdio clients.
+
+Future option:
+
+1. Add a non-stdio transport later: `ldev serve --transport http --port 0`.
+   This would make a background server meaningful. It should write a pid/log file
+   under a project-local runtime directory and expose `ldev serve status` and
+   `ldev serve stop`. Only do this if target clients support connecting to an
+   HTTP MCP server in the desired config format.
+
+2. If background stdio is still desired for manual testing, add a bounded helper,
+   not a production path: `ldev serve test-client --list-tools`. It can spawn the
+   stdio server, run the MCP handshake, print the available tools, then exit.
+
+Best near-term path: keep stdio client-managed and use `ldev mcp doctor` when a
+client does not load the expected tools. Defer background mode until there is an
+HTTP transport use case.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "@mordonezdev/ldev",
       "version": "0.5.4",
       "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "commander": "^14.0.0",
         "execa": "^9.6.0",
         "fs-extra": "^11.3.0",
@@ -19,7 +20,8 @@
         "zod": "^4.1.5"
       },
       "bin": {
-        "ldev": "dist/index.js"
+        "ldev": "dist/index.js",
+        "ldev-mcp-server": "dist/mcp-server.js"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -1098,6 +1100,18 @@
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1233,6 +1247,68 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.2",
@@ -2816,6 +2892,19 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2855,6 +2944,45 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/algoliasearch": {
       "version": "5.50.0",
@@ -3035,6 +3163,30 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
@@ -3048,6 +3200,15 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -3056,6 +3217,35 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/ccount": {
@@ -3171,6 +3361,46 @@
         "node": ">=20"
       }
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
     "node_modules/copy-anything": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
@@ -3192,6 +3422,23 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -3218,7 +3465,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3255,6 +3501,15 @@
       "integrity": "sha512-f8mefEW4WIVg4LckePx3mALjQSPQgFlg9U8yaPdlsbdYcHQyj9n2zL2LJEA52smeYxOvmd/nB7TpMtHGMTHcug==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/dequal": {
       "version": "2.0.3",
@@ -3373,11 +3628,31 @@
         }
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
     "node_modules/emoji-regex": {
@@ -3404,6 +3679,15 @@
         "node": ">=14"
       }
     },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/entities": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
@@ -3417,12 +3701,42 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.27.4",
@@ -3470,7 +3784,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
@@ -3648,6 +3961,36 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/execa": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
@@ -3684,11 +4027,71 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
+      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -3704,6 +4107,22 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -3749,6 +4168,27 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/find-up": {
@@ -3816,6 +4256,24 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fs-extra": {
       "version": "11.3.4",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
@@ -3843,6 +4301,52 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -3949,6 +4453,18 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -3963,6 +4479,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/hast-util-to-html": {
@@ -4001,6 +4541,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.15",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
+      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
       }
     },
     "node_modules/hookable": {
@@ -4048,6 +4597,26 @@
         "entities": "^7.0.1"
       }
     },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/human-signals": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
@@ -4055,6 +4624,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ignore": {
@@ -4101,6 +4686,24 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -4158,6 +4761,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
     },
     "node_modules/is-stream": {
       "version": "4.0.1",
@@ -4278,6 +4887,15 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
@@ -4311,6 +4929,12 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -4547,6 +5171,15 @@
         "marked": ">=13 <18"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/mdast-util-to-hast": {
       "version": "13.2.1",
       "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
@@ -4569,6 +5202,15 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/meow": {
       "version": "14.1.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-14.1.0.tgz",
@@ -4577,6 +5219,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4692,6 +5346,31 @@
         "node": ">=16"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
@@ -4736,7 +5415,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -4764,6 +5442,15 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/npm-run-path": {
       "version": "6.0.0",
@@ -4793,6 +5480,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -4803,6 +5511,27 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
     },
     "node_modules/oniguruma-to-es": {
       "version": "3.1.1",
@@ -4918,6 +5647,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -4952,6 +5690,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/pathe": {
@@ -4995,6 +5743,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/postcss": {
@@ -5095,6 +5852,19 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5103,6 +5873,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/quansync": {
@@ -5121,6 +5906,30 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/readable-stream": {
       "version": "2.3.8",
@@ -5163,6 +5972,15 @@
       "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
@@ -5366,10 +6184,32 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
     "node_modules/search-insights": {
@@ -5393,11 +6233,62 @@
         "node": ">=10"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
       "license": "MIT"
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -5435,6 +6326,78 @@
         "@shikijs/types": "2.5.0",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/siginfo": {
@@ -5506,6 +6469,15 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/std-env": {
       "version": "3.10.0",
@@ -5776,6 +6748,15 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/tree-kill": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -5944,6 +6925,20 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -6107,6 +7102,15 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/unrun": {
       "version": "0.2.34",
       "resolved": "https://registry.npmjs.org/unrun/-/unrun-0.2.34.tgz",
@@ -6149,6 +7153,15 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/vfile": {
       "version": "6.0.3",
@@ -6970,6 +7983,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
     "node_modules/yaml": {
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
@@ -7017,6 +8036,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Advanced developer workflows for Liferay local environments",
   "type": "module",
   "bin": {
-    "ldev": "./dist/index.js"
+    "ldev": "./dist/index.js",
+    "ldev-mcp-server": "./dist/mcp-server.js"
   },
   "files": [
     "dist",
@@ -96,6 +97,7 @@
     "developer-experience"
   ],
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "commander": "^14.0.0",
     "execa": "^9.6.0",
     "fs-extra": "^11.3.0",

--- a/src/cli/command-groups.ts
+++ b/src/cli/command-groups.ts
@@ -15,6 +15,7 @@ import {
 } from '../commands/env/env-public.commands.js';
 import {createPortalCommand} from '../commands/liferay/liferay.command.js';
 import {createMcpCommand} from '../commands/mcp/mcp.command.js';
+import {createServeCommand} from '../commands/serve/serve.command.js';
 import {createOsgiCommand} from '../commands/osgi/osgi.command.js';
 import {createOAuthCommand} from '../commands/oauth/oauth.command.js';
 import {createProjectCommand} from '../commands/project/project.command.js';
@@ -48,6 +49,7 @@ export const portalGroup: CommandGroup = {
   register(program) {
     program.addCommand(createPortalCommand().helpGroup(this.group!));
     program.addCommand(createMcpCommand().helpGroup(this.group!));
+    program.addCommand(createServeCommand().helpGroup(this.group!));
     program.addCommand(createOAuthCommand().helpGroup(this.group!));
   },
 };

--- a/src/commands/ai/ai.command.ts
+++ b/src/commands/ai/ai.command.ts
@@ -5,6 +5,7 @@ import {formatAiResult, runAiInstall} from '../../features/ai/ai-install.js';
 import {formatAiStatus, runAiStatus} from '../../features/ai/ai-status.js';
 import {runAiUpdate} from '../../features/ai/ai-update.js';
 import {parseBootstrapCacheTtl, runAiBootstrap} from '../../features/agent/agent-bootstrap.js';
+import {formatMcpSetup, runMcpSetup, type McpTool} from '../../features/mcp-server/mcp-server-setup.js';
 
 function collectSkillOption(value: string, previous: string[]): string[] {
   const skill = value.trim();
@@ -36,6 +37,11 @@ type AiStatusCommandOptions = {
 type AiBootstrapCommandOptions = {
   intent: string;
   cache?: string;
+};
+
+type AiMcpSetupCommandOptions = {
+  target: string;
+  tool: McpTool;
 };
 
 export function createAiCommand(): Command {
@@ -88,6 +94,17 @@ export function createAiCommand(): Command {
       .requiredOption('--target <target>', 'Project root'),
     'json',
   );
+  const mcpSetupCommand = addOutputFormatOption(
+    command
+      .command('mcp-setup')
+      .description('Write the ldev MCP server config for your AI assistant')
+      .requiredOption('--target <target>', 'Project root to write the config into')
+      .requiredOption(
+        '--tool <tool>',
+        'AI assistant to configure: claude-code (.claude/mcp.json) or cursor (.cursor/mcp.json)',
+      ),
+  );
+
   const bootstrapCommand = addOutputFormatOption(
     command
       .command('bootstrap')
@@ -175,6 +192,15 @@ Potentially mutating:
         cacheTtlSeconds: parseBootstrapCacheTtl(options.cache),
       });
     }),
+  );
+
+  mcpSetupCommand.action(
+    createFormattedAction(
+      async (_context, options: AiMcpSetupCommandOptions) => {
+        return runMcpSetup({targetDir: options.target, tool: options.tool});
+      },
+      {text: formatMcpSetup},
+    ),
   );
 
   return command;

--- a/src/commands/ai/ai.command.ts
+++ b/src/commands/ai/ai.command.ts
@@ -5,7 +5,12 @@ import {formatAiResult, runAiInstall} from '../../features/ai/ai-install.js';
 import {formatAiStatus, runAiStatus} from '../../features/ai/ai-status.js';
 import {runAiUpdate} from '../../features/ai/ai-update.js';
 import {parseBootstrapCacheTtl, runAiBootstrap} from '../../features/agent/agent-bootstrap.js';
-import {formatMcpSetup, runMcpSetup, type McpTool} from '../../features/mcp-server/mcp-server-setup.js';
+import {
+  formatMcpSetup,
+  runMcpSetup,
+  type McpStrategy,
+  type McpTool,
+} from '../../features/mcp-server/mcp-server-setup.js';
 
 function collectSkillOption(value: string, previous: string[]): string[] {
   const skill = value.trim();
@@ -42,6 +47,7 @@ type AiBootstrapCommandOptions = {
 type AiMcpSetupCommandOptions = {
   target: string;
   tool: McpTool;
+  strategy?: McpStrategy;
 };
 
 export function createAiCommand(): Command {
@@ -101,8 +107,11 @@ export function createAiCommand(): Command {
       .requiredOption('--target <target>', 'Project root to write the config into')
       .requiredOption(
         '--tool <tool>',
-        'AI assistant to configure: claude-code (.claude/mcp.json) or cursor (.cursor/mcp.json)',
+        'AI assistant to configure: all, claude-code (.claude/mcp.json), cursor (.cursor/mcp.json), or vscode (.vscode/mcp.json)',
       ),
+  ).option(
+    '--strategy <strategy>',
+    'Server launch strategy: global (ldev-mcp-server), local (node ./node_modules/...), or npx',
   );
 
   const bootstrapCommand = addOutputFormatOption(
@@ -197,7 +206,7 @@ Potentially mutating:
   mcpSetupCommand.action(
     createFormattedAction(
       async (_context, options: AiMcpSetupCommandOptions) => {
-        return runMcpSetup({targetDir: options.target, tool: options.tool});
+        return runMcpSetup({targetDir: options.target, tool: options.tool, strategy: options.strategy});
       },
       {text: formatMcpSetup},
     ),

--- a/src/commands/mcp/mcp.command.ts
+++ b/src/commands/mcp/mcp.command.ts
@@ -9,11 +9,20 @@ import {
   runMcpOpenApis,
   runMcpProbe,
 } from '../../features/mcp/mcp.js';
+import {formatMcpDoctor, runMcpDoctor} from '../../features/mcp-server/mcp-server-doctor.js';
+import type {McpTool} from '../../features/mcp-server/mcp-server-setup.js';
 
 type McpAuthCommandOptions = {
   authorizationHeader?: string;
   username?: string;
   password?: string;
+};
+
+type McpDoctorCommandOptions = {
+  target: string;
+  tool?: McpTool;
+  skipHandshake?: boolean;
+  timeout: string;
 };
 
 export function createMcpCommand(): Command {
@@ -26,6 +35,7 @@ Recommended order:
   mcp check      Detect endpoint candidates and feature flag state
   mcp probe      Run a real MCP initialize handshake
   mcp openapis   Query the MCP get-openapis tool after initialize
+  mcp doctor     Validate local ldev MCP client config and list registered tools
 
 Auth options:
   --authorization-header 'Basic ...'
@@ -71,6 +81,30 @@ Environment fallbacks:
       async (context, options: McpAuthCommandOptions) => runMcpOpenApis(context.config, toMcpAuthOptions(options)),
       {
         text: formatMcpOpenApis,
+      },
+    ),
+  );
+
+  addOutputFormatOption(
+    command
+      .command('doctor')
+      .description('Validate local ldev MCP client config, command resolution and stdio list-tools handshake')
+      .option('--target <target>', 'Project root containing MCP client config', '.')
+      .option('--tool <tool>', 'Client config to check: all, claude-code, cursor, or vscode', 'all')
+      .option('--skip-handshake', 'Only validate config and command resolution')
+      .option('--timeout <milliseconds>', 'Timeout for command and MCP handshake checks', '10000'),
+  ).action(
+    createFormattedAction(
+      async (_context, options: McpDoctorCommandOptions) =>
+        runMcpDoctor({
+          targetDir: options.target,
+          tool: options.tool,
+          handshake: !options.skipHandshake,
+          timeoutMs: Number.parseInt(options.timeout, 10) || 10000,
+        }),
+      {
+        text: formatMcpDoctor,
+        exitCode: (result) => (result.ok ? 0 : 1),
       },
     ),
   );

--- a/src/commands/serve/serve.command.ts
+++ b/src/commands/serve/serve.command.ts
@@ -3,7 +3,7 @@ import {startMcpServer} from '../../features/mcp-server/mcp-server.js';
 
 export function createServeCommand(): Command {
   return new Command('serve')
-    .description('Start the ldev MCP server on stdio (for Claude Code, Cursor, Claude Desktop)')
+    .description('Start the ldev MCP server on stdio (for VS Code, Claude Code, Cursor, Claude Desktop)')
     .addHelpText(
       'after',
       `
@@ -15,8 +15,11 @@ Config examples:
   Cursor (.cursor/mcp.json):
     {"mcpServers":{"ldev":{"command":"ldev-mcp-server"}}}
 
+  VS Code (.vscode/mcp.json):
+    {"servers":{"ldev":{"type":"stdio","command":"ldev-mcp-server"}}}
+
   npx (no global install):
-    {"mcpServers":{"ldev":{"command":"npx","args":["--package","@mordonezdev/ldev","-y","ldev-mcp-server"]}}}
+    {"servers":{"ldev":{"type":"stdio","command":"npx","args":["--package","@mordonezdev/ldev","-y","ldev-mcp-server"]}}}
 `,
     )
     .action(async () => {

--- a/src/commands/serve/serve.command.ts
+++ b/src/commands/serve/serve.command.ts
@@ -1,0 +1,25 @@
+import {Command} from 'commander';
+import {startMcpServer} from '../../features/mcp-server/mcp-server.js';
+
+export function createServeCommand(): Command {
+  return new Command('serve')
+    .description('Start the ldev MCP server on stdio (for Claude Code, Cursor, Claude Desktop)')
+    .addHelpText(
+      'after',
+      `
+Config examples:
+
+  Claude Code (.claude/mcp.json):
+    {"mcpServers":{"ldev":{"command":"ldev-mcp-server"}}}
+
+  Cursor (.cursor/mcp.json):
+    {"mcpServers":{"ldev":{"command":"ldev-mcp-server"}}}
+
+  npx (no global install):
+    {"mcpServers":{"ldev":{"command":"npx","args":["--package","@mordonezdev/ldev","-y","ldev-mcp-server"]}}}
+`,
+    )
+    .action(async () => {
+      await startMcpServer();
+    });
+}

--- a/src/features/mcp-server/mcp-server-doctor.ts
+++ b/src/features/mcp-server/mcp-server-doctor.ts
@@ -1,0 +1,279 @@
+import path from 'node:path';
+
+import {Client} from '@modelcontextprotocol/sdk/client/index.js';
+import {StdioClientTransport} from '@modelcontextprotocol/sdk/client/stdio.js';
+import fs from 'fs-extra';
+
+import {runProcess, type RunProcessResult} from '../../core/platform/process.js';
+import {
+  getMcpConfigRoot,
+  isMcpTool,
+  MCP_SETUP_TOOLS,
+  type McpServerConfig,
+  type McpSetupTool,
+  type McpTool,
+  resolveMcpConfigPath,
+} from './mcp-server-setup.js';
+
+type McpDoctorToolResult = {
+  tool: McpSetupTool;
+  configPath: string;
+  configExists: boolean;
+  configValid: boolean;
+  configFormat: 'mcpServers' | 'servers' | null;
+  command?: string;
+  args?: string[];
+  commandCheck?: {
+    ok: boolean;
+    command: string;
+    exitCode: number;
+    stdout?: string;
+    stderr?: string;
+  };
+  handshake?: {
+    ok: boolean;
+    serverName?: string;
+    serverVersion?: string;
+    toolCount?: number;
+    tools?: string[];
+    stderr?: string;
+    error?: string;
+  };
+  error?: string;
+};
+
+export type McpDoctorResult = {
+  ok: boolean;
+  targetDir: string;
+  checkedTools: McpSetupTool[];
+  results: McpDoctorToolResult[];
+};
+
+type McpDoctorOptions = {
+  targetDir: string;
+  tool?: McpTool;
+  handshake?: boolean;
+  timeoutMs?: number;
+};
+
+export async function runMcpDoctor(options: McpDoctorOptions): Promise<McpDoctorResult> {
+  const tool = options.tool ?? 'all';
+  if (!isMcpTool(tool)) {
+    throw new Error(`--tool must be one of: all, ${MCP_SETUP_TOOLS.join(', ')}`);
+  }
+
+  const checkedTools = tool === 'all' ? MCP_SETUP_TOOLS : [tool];
+  const results = [];
+  for (const checkedTool of checkedTools) {
+    results.push(await checkToolConfig(options.targetDir, checkedTool, options));
+  }
+
+  return {
+    ok: results.every((result) => result.configValid && result.commandCheck?.ok && result.handshake?.ok !== false),
+    targetDir: options.targetDir,
+    checkedTools,
+    results,
+  };
+}
+
+async function checkToolConfig(
+  targetDir: string,
+  tool: McpSetupTool,
+  options: McpDoctorOptions,
+): Promise<McpDoctorToolResult> {
+  const configPath = resolveMcpConfigPath(targetDir, tool);
+  const base: McpDoctorToolResult = {
+    tool,
+    configPath,
+    configExists: false,
+    configValid: false,
+    configFormat: null,
+  };
+
+  if (!(await fs.pathExists(configPath))) {
+    return {...base, error: 'Config file does not exist.'};
+  }
+
+  let serverConfig: McpServerConfig;
+  try {
+    const raw = (await fs.readJson(configPath)) as unknown;
+    const extracted = extractLdevServerConfig(raw, tool);
+    if (!extracted) {
+      return {...base, configExists: true, error: 'Could not find ldev server config.'};
+    }
+    serverConfig = extracted.serverConfig;
+    base.configFormat = extracted.configFormat;
+  } catch (error) {
+    return {...base, configExists: true, error: error instanceof Error ? error.message : String(error)};
+  }
+
+  const commandCheck = await checkCommand(targetDir, serverConfig, options.timeoutMs ?? 5000);
+  const result: McpDoctorToolResult = {
+    ...base,
+    configExists: true,
+    configValid: true,
+    command: serverConfig.command,
+    args: serverConfig.args,
+    commandCheck: toCommandCheck(commandCheck),
+  };
+
+  if (options.handshake === false || !commandCheck.ok) {
+    return result;
+  }
+
+  return {
+    ...result,
+    handshake: await listToolsViaHandshake(targetDir, serverConfig, options.timeoutMs ?? 10000),
+  };
+}
+
+function extractLdevServerConfig(
+  raw: unknown,
+  tool: McpSetupTool,
+): {configFormat: 'mcpServers' | 'servers'; serverConfig: McpServerConfig} | null {
+  if (!raw || typeof raw !== 'object') {
+    return null;
+  }
+
+  const configFormat = getMcpConfigRoot(tool);
+  const servers = (raw as Record<string, unknown>)[configFormat];
+  if (servers && typeof servers === 'object') {
+    const ldev = (servers as Record<string, unknown>).ldev;
+    return isMcpServerConfig(ldev, configFormat) ? {configFormat, serverConfig: ldev} : null;
+  }
+
+  return null;
+}
+
+function isMcpServerConfig(value: unknown, configFormat: 'mcpServers' | 'servers'): value is McpServerConfig {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const config = value as {command?: unknown; args?: unknown; type?: unknown};
+  return (
+    (configFormat !== 'servers' || config.type === 'stdio') &&
+    typeof config.command === 'string' &&
+    (config.args === undefined || (Array.isArray(config.args) && config.args.every((arg) => typeof arg === 'string')))
+  );
+}
+
+async function checkCommand(
+  targetDir: string,
+  serverConfig: McpServerConfig,
+  timeoutMs: number,
+): Promise<RunProcessResult> {
+  const scriptPath = getNodeScriptPath(targetDir, serverConfig);
+  if (scriptPath && !(await fs.pathExists(scriptPath))) {
+    return {
+      command: [serverConfig.command, ...(serverConfig.args ?? [])].join(' '),
+      stdout: '',
+      stderr: `Configured MCP server script does not exist: ${scriptPath}`,
+      exitCode: 1,
+      ok: false,
+    };
+  }
+
+  return runProcess(serverConfig.command, [...(serverConfig.args ?? []), '--version'], {timeoutMs, reject: false});
+}
+
+function getNodeScriptPath(targetDir: string, serverConfig: McpServerConfig): string | null {
+  if (serverConfig.command !== 'node') {
+    return null;
+  }
+  const [scriptArg] = serverConfig.args ?? [];
+  if (!scriptArg || scriptArg.startsWith('-')) {
+    return null;
+  }
+  return path.isAbsolute(scriptArg) ? scriptArg : path.resolve(targetDir, scriptArg);
+}
+
+function toCommandCheck(result: RunProcessResult): NonNullable<McpDoctorToolResult['commandCheck']> {
+  return {
+    ok: result.ok,
+    command: result.command,
+    exitCode: result.exitCode,
+    stdout: result.stdout.trim() || undefined,
+    stderr: result.stderr.trim() || undefined,
+  };
+}
+
+async function listToolsViaHandshake(
+  targetDir: string,
+  serverConfig: McpServerConfig,
+  timeoutMs: number,
+): Promise<NonNullable<McpDoctorToolResult['handshake']>> {
+  const client = new Client({name: 'ldev-mcp-doctor', version: '0.0.0'});
+  const transport = new StdioClientTransport({
+    command: serverConfig.command,
+    args: serverConfig.args ?? [],
+    cwd: targetDir,
+    stderr: 'pipe',
+  });
+  const stderrChunks: Buffer[] = [];
+  transport.stderr?.on('data', (chunk: Buffer | string) => {
+    stderrChunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  });
+
+  try {
+    await client.connect(transport, {timeout: timeoutMs});
+    const toolsResult = await client.listTools(undefined, {timeout: timeoutMs});
+    const serverVersion = client.getServerVersion();
+    return {
+      ok: true,
+      serverName: serverVersion?.name,
+      serverVersion: serverVersion?.version,
+      toolCount: toolsResult.tools.length,
+      tools: toolsResult.tools.map((tool) => tool.name).sort(),
+      stderr: formatStderr(stderrChunks),
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+      stderr: formatStderr(stderrChunks),
+    };
+  } finally {
+    await client.close().catch(() => undefined);
+  }
+}
+
+function formatStderr(chunks: Buffer[]): string | undefined {
+  const stderr = Buffer.concat(chunks).toString('utf8').trim();
+  return stderr.length > 0 ? stderr : undefined;
+}
+
+export function formatMcpDoctor(result: McpDoctorResult): string {
+  const lines = [result.ok ? 'MCP doctor passed' : 'MCP doctor found issues', `  target: ${result.targetDir}`, ''];
+
+  for (const item of result.results) {
+    lines.push(`${item.tool}:`);
+    lines.push(`  config: ${item.configExists ? 'found' : 'missing'} (${item.configPath})`);
+    if (item.configFormat) {
+      lines.push(`  format: ${item.configFormat}`);
+    }
+    if (item.command) {
+      lines.push(`  command: ${[item.command, ...(item.args ?? [])].join(' ')}`);
+    }
+    if (item.commandCheck) {
+      lines.push(`  command check: ${item.commandCheck.ok ? 'ok' : `failed (${item.commandCheck.exitCode})`}`);
+    }
+    if (item.handshake) {
+      lines.push(`  handshake: ${item.handshake.ok ? 'ok' : 'failed'}`);
+      if (item.handshake.ok) {
+        lines.push(
+          `  server: ${item.handshake.serverName ?? 'unknown'} ${item.handshake.serverVersion ?? ''}`.trimEnd(),
+        );
+        lines.push(`  tools: ${item.handshake.toolCount ?? 0}`);
+      }
+    }
+    if (item.error) {
+      lines.push(`  error: ${item.error}`);
+    }
+    if (item.handshake?.error) {
+      lines.push(`  error: ${item.handshake.error}`);
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n').trimEnd();
+}

--- a/src/features/mcp-server/mcp-server-setup.ts
+++ b/src/features/mcp-server/mcp-server-setup.ts
@@ -1,0 +1,106 @@
+import path from 'node:path';
+
+import fs from 'fs-extra';
+
+import {runProcess} from '../../core/platform/process.js';
+
+export type McpTool = 'claude-code' | 'cursor';
+
+export type McpSetupResult = {
+  ok: true;
+  tool: McpTool;
+  configPath: string;
+  strategy: 'global' | 'local' | 'npx';
+  merged: boolean;
+};
+
+type McpServerConfig = {
+  command: string;
+  args?: string[];
+};
+
+type McpConfig = {
+  mcpServers: Record<string, McpServerConfig>;
+};
+
+async function resolveStrategy(targetDir: string): Promise<'global' | 'local' | 'npx'> {
+  const result = await runProcess('ldev-mcp-server', ['--version'], {timeoutMs: 3000, reject: false});
+  if (result.ok) {
+    return 'global';
+  }
+  const localBin = path.join(targetDir, 'node_modules', '@mordonezdev', 'ldev', 'dist', 'mcp-server.js');
+  if (fs.existsSync(localBin)) {
+    return 'local';
+  }
+  return 'npx';
+}
+
+function buildServerConfig(strategy: 'global' | 'local' | 'npx'): McpServerConfig {
+  if (strategy === 'global') {
+    return {command: 'ldev-mcp-server'};
+  }
+  if (strategy === 'local') {
+    return {command: 'node', args: ['./node_modules/@mordonezdev/ldev/dist/mcp-server.js']};
+  }
+  return {command: 'npx', args: ['--package', '@mordonezdev/ldev', '-y', 'ldev-mcp-server']};
+}
+
+function resolveConfigPath(targetDir: string, tool: McpTool): string {
+  if (tool === 'claude-code') {
+    return path.join(targetDir, '.claude', 'mcp.json');
+  }
+  return path.join(targetDir, '.cursor', 'mcp.json');
+}
+
+export async function runMcpSetup(options: {targetDir: string; tool: McpTool}): Promise<McpSetupResult> {
+  const {targetDir, tool} = options;
+  const strategy = await resolveStrategy(targetDir);
+  const configPath = resolveConfigPath(targetDir, tool);
+  const serverConfig = buildServerConfig(strategy);
+
+  await fs.ensureDir(path.dirname(configPath));
+
+  let merged = false;
+  let existing: McpConfig = {mcpServers: {}};
+
+  if (await fs.pathExists(configPath)) {
+    try {
+      const raw: unknown = await fs.readJson(configPath);
+      if (raw && typeof raw === 'object' && 'mcpServers' in raw) {
+        existing = raw as McpConfig;
+        merged = true;
+      }
+    } catch {
+      // overwrite corrupt file
+    }
+  }
+
+  const updated: McpConfig = {
+    ...existing,
+    mcpServers: {
+      ...existing.mcpServers,
+      ldev: serverConfig,
+    },
+  };
+
+  await fs.writeJson(configPath, updated, {spaces: 2});
+
+  return {ok: true, tool, configPath, strategy, merged};
+}
+
+export function formatMcpSetup(result: McpSetupResult): string {
+  const action = result.merged ? 'Updated' : 'Created';
+  const strategyLabel =
+    result.strategy === 'global'
+      ? 'ldev-mcp-server (global)'
+      : result.strategy === 'local'
+        ? 'node ./node_modules/... (local devDependency)'
+        : 'npx --package @mordonezdev/ldev';
+  return [
+    `${action} ${result.configPath}`,
+    `  tool: ${result.tool}`,
+    `  strategy: ${strategyLabel}`,
+    '',
+    'Restart your AI assistant to pick up the new MCP server.',
+  ].join('\n');
+}

--- a/src/features/mcp-server/mcp-server-setup.ts
+++ b/src/features/mcp-server/mcp-server-setup.ts
@@ -4,26 +4,47 @@ import fs from 'fs-extra';
 
 import {runProcess} from '../../core/platform/process.js';
 
-export type McpTool = 'claude-code' | 'cursor';
+export type McpSetupTool = 'claude-code' | 'cursor' | 'vscode';
+export type McpTool = McpSetupTool | 'all';
+export type McpStrategy = 'global' | 'local' | 'npx';
+
+export const MCP_SETUP_TOOLS: McpSetupTool[] = ['claude-code', 'cursor', 'vscode'];
 
 export type McpSetupResult = {
   ok: true;
-  tool: McpTool;
+  tool: McpSetupTool;
   configPath: string;
-  strategy: 'global' | 'local' | 'npx';
+  strategy: McpStrategy;
   merged: boolean;
 };
 
-type McpServerConfig = {
+export type McpSetupAllResult = {
+  ok: true;
+  tool: 'all';
+  strategy: McpStrategy;
+  results: McpSetupResult[];
+};
+
+export type McpSetupCommandResult = McpSetupResult | McpSetupAllResult;
+
+export type McpServerConfig = {
   command: string;
   args?: string[];
 };
 
-type McpConfig = {
-  mcpServers: Record<string, McpServerConfig>;
+export type McpConfigRoot = 'mcpServers' | 'servers';
+
+type VsCodeMcpServerConfig = McpServerConfig & {
+  type: 'stdio';
 };
 
-async function resolveStrategy(targetDir: string): Promise<'global' | 'local' | 'npx'> {
+type ToolServerConfig = McpServerConfig | VsCodeMcpServerConfig;
+
+async function resolveStrategy(targetDir: string, requestedStrategy?: McpStrategy): Promise<McpStrategy> {
+  if (requestedStrategy) {
+    return requestedStrategy;
+  }
+
   const result = await runProcess('ldev-mcp-server', ['--version'], {timeoutMs: 3000, reject: false});
   if (result.ok) {
     return 'global';
@@ -35,7 +56,7 @@ async function resolveStrategy(targetDir: string): Promise<'global' | 'local' | 
   return 'npx';
 }
 
-function buildServerConfig(strategy: 'global' | 'local' | 'npx'): McpServerConfig {
+export function buildMcpServerConfig(strategy: McpStrategy): McpServerConfig {
   if (strategy === 'global') {
     return {command: 'ldev-mcp-server'};
   }
@@ -45,29 +66,103 @@ function buildServerConfig(strategy: 'global' | 'local' | 'npx'): McpServerConfi
   return {command: 'npx', args: ['--package', '@mordonezdev/ldev', '-y', 'ldev-mcp-server']};
 }
 
-function resolveConfigPath(targetDir: string, tool: McpTool): string {
+export function buildVsCodeServerConfig(strategy: McpStrategy): VsCodeMcpServerConfig {
+  return {type: 'stdio', ...buildMcpServerConfig(strategy)};
+}
+
+export function resolveMcpConfigPath(targetDir: string, tool: McpSetupTool): string {
   if (tool === 'claude-code') {
     return path.join(targetDir, '.claude', 'mcp.json');
+  }
+  if (tool === 'vscode') {
+    return path.join(targetDir, '.vscode', 'mcp.json');
   }
   return path.join(targetDir, '.cursor', 'mcp.json');
 }
 
-export async function runMcpSetup(options: {targetDir: string; tool: McpTool}): Promise<McpSetupResult> {
+export function runMcpSetup(options: {
+  targetDir: string;
+  tool: McpSetupTool;
+  strategy?: McpStrategy;
+}): Promise<McpSetupResult>;
+export function runMcpSetup(options: {
+  targetDir: string;
+  tool: 'all';
+  strategy?: McpStrategy;
+}): Promise<McpSetupAllResult>;
+export function runMcpSetup(options: {
+  targetDir: string;
+  tool: McpTool;
+  strategy?: McpStrategy;
+}): Promise<McpSetupCommandResult>;
+export async function runMcpSetup(options: {
+  targetDir: string;
+  tool: McpTool;
+  strategy?: McpStrategy;
+}): Promise<McpSetupCommandResult> {
   const {targetDir, tool} = options;
-  const strategy = await resolveStrategy(targetDir);
-  const configPath = resolveConfigPath(targetDir, tool);
-  const serverConfig = buildServerConfig(strategy);
+  if (!isMcpTool(tool)) {
+    throw new Error(`--tool must be one of: all, ${MCP_SETUP_TOOLS.join(', ')}`);
+  }
+  if (options.strategy && !isMcpStrategy(options.strategy)) {
+    throw new Error('--strategy must be one of: global, local, npx');
+  }
+
+  const strategy = await resolveStrategy(targetDir, options.strategy);
+
+  if (tool === 'all') {
+    const results = [];
+    for (const setupTool of MCP_SETUP_TOOLS) {
+      results.push(await writeMcpSetupForTool({targetDir, tool: setupTool, strategy}));
+    }
+    return {ok: true, tool, strategy, results};
+  }
+
+  return writeMcpSetupForTool({targetDir, tool, strategy});
+}
+
+export function isMcpTool(value: string): value is McpTool {
+  return value === 'all' || MCP_SETUP_TOOLS.includes(value as McpSetupTool);
+}
+
+export function isMcpStrategy(value: string): value is McpStrategy {
+  return ['global', 'local', 'npx'].includes(value);
+}
+
+async function writeMcpSetupForTool(options: {
+  targetDir: string;
+  tool: McpSetupTool;
+  strategy: McpStrategy;
+}): Promise<McpSetupResult> {
+  const {targetDir, tool, strategy} = options;
+  const configPath = resolveMcpConfigPath(targetDir, tool);
 
   await fs.ensureDir(path.dirname(configPath));
 
+  const rootKey = getMcpConfigRoot(tool);
+  const serverConfig = tool === 'vscode' ? buildVsCodeServerConfig(strategy) : buildMcpServerConfig(strategy);
+  const merged = await writeMcpConfig(configPath, rootKey, serverConfig);
+
+  return {ok: true, tool, configPath, strategy, merged};
+}
+
+export function getMcpConfigRoot(tool: McpSetupTool): McpConfigRoot {
+  return tool === 'vscode' ? 'servers' : 'mcpServers';
+}
+
+async function writeMcpConfig(
+  configPath: string,
+  rootKey: McpConfigRoot,
+  serverConfig: ToolServerConfig,
+): Promise<boolean> {
   let merged = false;
-  let existing: McpConfig = {mcpServers: {}};
+  let existing: Record<string, unknown> = {[rootKey]: {}};
 
   if (await fs.pathExists(configPath)) {
     try {
       const raw: unknown = await fs.readJson(configPath);
-      if (raw && typeof raw === 'object' && 'mcpServers' in raw) {
-        existing = raw as McpConfig;
+      if (raw && typeof raw === 'object' && rootKey in raw) {
+        existing = raw as Record<string, unknown>;
         merged = true;
       }
     } catch {
@@ -75,32 +170,51 @@ export async function runMcpSetup(options: {targetDir: string; tool: McpTool}): 
     }
   }
 
-  const updated: McpConfig = {
+  const servers = existing[rootKey];
+  const updated = {
     ...existing,
-    mcpServers: {
-      ...existing.mcpServers,
+    [rootKey]: {
+      ...(servers && typeof servers === 'object' ? (servers as Record<string, unknown>) : {}),
       ldev: serverConfig,
     },
   };
 
   await fs.writeJson(configPath, updated, {spaces: 2});
 
-  return {ok: true, tool, configPath, strategy, merged};
+  return merged;
 }
 
-export function formatMcpSetup(result: McpSetupResult): string {
+export function formatMcpSetup(result: McpSetupCommandResult): string {
+  if (result.tool === 'all') {
+    return [
+      `Configured ${result.results.length} MCP client configs`,
+      `  strategy: ${formatStrategyLabel(result.strategy)}`,
+      '',
+      ...result.results.map((entry) => {
+        const action = entry.merged ? 'Updated' : 'Created';
+        return `${action} ${entry.configPath} (${entry.tool})`;
+      }),
+      '',
+      'Restart your AI assistant to pick up the new MCP server.',
+    ].join('\n');
+  }
+
   const action = result.merged ? 'Updated' : 'Created';
-  const strategyLabel =
-    result.strategy === 'global'
-      ? 'ldev-mcp-server (global)'
-      : result.strategy === 'local'
-        ? 'node ./node_modules/... (local devDependency)'
-        : 'npx --package @mordonezdev/ldev';
   return [
     `${action} ${result.configPath}`,
     `  tool: ${result.tool}`,
-    `  strategy: ${strategyLabel}`,
+    `  strategy: ${formatStrategyLabel(result.strategy)}`,
     '',
     'Restart your AI assistant to pick up the new MCP server.',
   ].join('\n');
+}
+
+function formatStrategyLabel(strategy: McpStrategy): string {
+  if (strategy === 'global') {
+    return 'ldev-mcp-server (global)';
+  }
+  if (strategy === 'local') {
+    return 'node ./node_modules/... (local devDependency)';
+  }
+  return 'npx --package @mordonezdev/ldev';
 }

--- a/src/features/mcp-server/mcp-server-tools.ts
+++ b/src/features/mcp-server/mcp-server-tools.ts
@@ -1,13 +1,19 @@
 import type {CallToolResult} from '@modelcontextprotocol/sdk/types.js';
 import type {AppConfig} from '../../core/config/schema.js';
+import * as contextTool from './tools/tool-ldev-context.js';
+import * as statusTool from './tools/tool-ldev-status.js';
+import * as logsDiagnoseTool from './tools/tool-ldev-logs-diagnose.js';
 import * as sitesTool from './tools/tool-liferay-inventory-sites.js';
 import * as structuresTool from './tools/tool-liferay-inventory-structures.js';
 import * as pagesTool from './tools/tool-liferay-inventory-pages.js';
 import * as pageTool from './tools/tool-liferay-inventory-page.js';
+import * as checkTool from './tools/tool-liferay-check.js';
 import * as doctorTool from './tools/tool-liferay-doctor.js';
 import * as templatesTool from './tools/tool-liferay-inventory-templates.js';
 import * as deployStatusTool from './tools/tool-liferay-deploy-status.js';
+import * as osgiDiagTool from './tools/tool-liferay-osgi-diag.js';
 import * as osgiStatusTool from './tools/tool-liferay-osgi-status.js';
+import * as osgiThreadDumpTool from './tools/tool-liferay-osgi-thread-dump.js';
 import * as mcpCheckTool from './tools/tool-liferay-mcp-check.js';
 
 export type McpToolModule = {
@@ -19,6 +25,10 @@ export type McpToolModule = {
 };
 
 export const ALL_TOOLS: McpToolModule[] = [
+  contextTool,
+  checkTool,
+  statusTool,
+  logsDiagnoseTool,
   sitesTool,
   structuresTool,
   pagesTool,
@@ -27,5 +37,7 @@ export const ALL_TOOLS: McpToolModule[] = [
   templatesTool,
   deployStatusTool,
   osgiStatusTool,
+  osgiDiagTool,
+  osgiThreadDumpTool,
   mcpCheckTool,
 ];

--- a/src/features/mcp-server/mcp-server-tools.ts
+++ b/src/features/mcp-server/mcp-server-tools.ts
@@ -1,0 +1,31 @@
+import type {CallToolResult} from '@modelcontextprotocol/sdk/types.js';
+import type {AppConfig} from '../../core/config/schema.js';
+import * as sitesTool from './tools/tool-liferay-inventory-sites.js';
+import * as structuresTool from './tools/tool-liferay-inventory-structures.js';
+import * as pagesTool from './tools/tool-liferay-inventory-pages.js';
+import * as pageTool from './tools/tool-liferay-inventory-page.js';
+import * as doctorTool from './tools/tool-liferay-doctor.js';
+import * as templatesTool from './tools/tool-liferay-inventory-templates.js';
+import * as deployStatusTool from './tools/tool-liferay-deploy-status.js';
+import * as osgiStatusTool from './tools/tool-liferay-osgi-status.js';
+import * as mcpCheckTool from './tools/tool-liferay-mcp-check.js';
+
+export type McpToolModule = {
+  TOOL_NAME: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  handleTool: (input: any, config: AppConfig, cwd: string) => Promise<CallToolResult>;
+};
+
+export const ALL_TOOLS: McpToolModule[] = [
+  sitesTool,
+  structuresTool,
+  pagesTool,
+  pageTool,
+  doctorTool,
+  templatesTool,
+  deployStatusTool,
+  osgiStatusTool,
+  mcpCheckTool,
+];

--- a/src/features/mcp-server/mcp-server.ts
+++ b/src/features/mcp-server/mcp-server.ts
@@ -21,12 +21,17 @@ function registerTool(server: McpServer, tool: McpToolModule, config: AppConfig,
 }
 /* eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment */
 
-function readPackageVersion(): string {
+export function readMcpPackageVersion(): string {
   let dir = path.dirname(fileURLToPath(import.meta.url));
   for (let i = 0; i < 5; i++) {
     try {
       const pkg = parseJsonUnknown(readFileSync(path.join(dir, 'package.json'), 'utf8'));
-      if (pkg && typeof pkg === 'object' && 'version' in pkg && typeof (pkg as {version: unknown}).version === 'string') {
+      if (
+        pkg &&
+        typeof pkg === 'object' &&
+        'version' in pkg &&
+        typeof (pkg as {version: unknown}).version === 'string'
+      ) {
         return (pkg as {version: string}).version;
       }
     } catch {
@@ -39,7 +44,7 @@ function readPackageVersion(): string {
 
 export async function startMcpServer(): Promise<void> {
   const {config, cwd} = resolveProjectContext();
-  const server = new McpServer({name: 'ldev', version: readPackageVersion()});
+  const server = new McpServer({name: 'ldev', version: readMcpPackageVersion()});
 
   for (const tool of ALL_TOOLS) {
     registerTool(server, tool, config, cwd);

--- a/src/features/mcp-server/mcp-server.ts
+++ b/src/features/mcp-server/mcp-server.ts
@@ -1,0 +1,50 @@
+import {readFileSync} from 'node:fs';
+import {fileURLToPath} from 'node:url';
+import path from 'node:path';
+
+import {McpServer} from '@modelcontextprotocol/sdk/server/mcp.js';
+import {StdioServerTransport} from '@modelcontextprotocol/sdk/server/stdio.js';
+
+import {resolveProjectContext} from '../../core/config/project-context.js';
+import {parseJsonUnknown} from '../../core/utils/json.js';
+import {type McpToolModule, ALL_TOOLS} from './mcp-server-tools.js';
+import type {AppConfig} from '../../core/config/schema.js';
+
+// Isolated function to contain the eslint-disable scope to just the SDK interop call.
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment */
+function registerTool(server: McpServer, tool: McpToolModule, config: AppConfig, cwd: string): void {
+  server.registerTool(
+    tool.TOOL_NAME,
+    {description: tool.description, inputSchema: tool.inputSchema as any},
+    (input: Record<string, unknown>) => tool.handleTool(input, config, cwd),
+  );
+}
+/* eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment */
+
+function readPackageVersion(): string {
+  let dir = path.dirname(fileURLToPath(import.meta.url));
+  for (let i = 0; i < 5; i++) {
+    try {
+      const pkg = parseJsonUnknown(readFileSync(path.join(dir, 'package.json'), 'utf8'));
+      if (pkg && typeof pkg === 'object' && 'version' in pkg && typeof (pkg as {version: unknown}).version === 'string') {
+        return (pkg as {version: string}).version;
+      }
+    } catch {
+      // not found, go up
+    }
+    dir = path.dirname(dir);
+  }
+  return '0.0.0';
+}
+
+export async function startMcpServer(): Promise<void> {
+  const {config, cwd} = resolveProjectContext();
+  const server = new McpServer({name: 'ldev', version: readPackageVersion()});
+
+  for (const tool of ALL_TOOLS) {
+    registerTool(server, tool, config, cwd);
+  }
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}

--- a/src/features/mcp-server/tools/tool-ldev-context.ts
+++ b/src/features/mcp-server/tools/tool-ldev-context.ts
@@ -1,0 +1,14 @@
+import type {AppConfig} from '../../../core/config/schema.js';
+import {runAgentContext} from '../../agent/agent-context.js';
+import {runJsonTool} from './tool-result.js';
+
+export const TOOL_NAME = 'ldev_context';
+
+export const inputSchema = {};
+
+export const description =
+  'Return the same structured project/runtime snapshot as `ldev context --json`: repo, portal URL, paths, inventory, platform tools, and command readiness.';
+
+export async function handleTool(_input: Record<string, unknown>, config: AppConfig, cwd: string) {
+  return runJsonTool(() => runAgentContext(cwd, {config}));
+}

--- a/src/features/mcp-server/tools/tool-ldev-logs-diagnose.ts
+++ b/src/features/mcp-server/tools/tool-ldev-logs-diagnose.ts
@@ -1,0 +1,29 @@
+import {z} from 'zod';
+import type {AppConfig} from '../../../core/config/schema.js';
+import {runEnvLogsDiagnose} from '../../env/env-logs-diagnose.js';
+import {runJsonTool} from './tool-result.js';
+
+export const TOOL_NAME = 'ldev_logs_diagnose';
+
+export const inputSchema = {
+  service: z.string().optional().describe('Docker compose service to inspect. Defaults to liferay.'),
+  since: z.string().optional().describe('Limit logs to a duration or timestamp. Defaults to 10m.'),
+};
+
+export const description =
+  'Analyze recent Docker logs like `ldev logs diagnose --json`, grouping exceptions and warning counts for agents.';
+
+export async function handleTool(input: {service?: string; since?: string}, config: AppConfig) {
+  return runJsonTool(() =>
+    runEnvLogsDiagnose(config, {
+      service: textOrDefault(input.service, 'liferay'),
+      since: textOrDefault(input.since, '10m'),
+      processEnv: process.env,
+    }),
+  );
+}
+
+function textOrDefault(value: string | undefined, fallback: string): string {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : fallback;
+}

--- a/src/features/mcp-server/tools/tool-ldev-status.ts
+++ b/src/features/mcp-server/tools/tool-ldev-status.ts
@@ -1,0 +1,14 @@
+import type {AppConfig} from '../../../core/config/schema.js';
+import {createRuntimeAdapter} from '../../../core/runtime/runtime-adapter-factory.js';
+import {runJsonTool} from './tool-result.js';
+
+export const TOOL_NAME = 'ldev_status';
+
+export const inputSchema = {};
+
+export const description =
+  'Return the same local runtime status as `ldev status --json`: container state, health and portal reachability.';
+
+export async function handleTool(_input: Record<string, unknown>, config: AppConfig) {
+  return runJsonTool(() => createRuntimeAdapter(config).status());
+}

--- a/src/features/mcp-server/tools/tool-liferay-check.ts
+++ b/src/features/mcp-server/tools/tool-liferay-check.ts
@@ -1,0 +1,14 @@
+import type {AppConfig} from '../../../core/config/schema.js';
+import {runLiferayHealth} from '../../liferay/liferay-health.js';
+import {runJsonTool} from './tool-result.js';
+
+export const TOOL_NAME = 'liferay_check';
+
+export const inputSchema = {};
+
+export const description =
+  'Run the same OAuth and basic API reachability check as `ldev portal check --json`. Does not return access tokens.';
+
+export async function handleTool(_input: Record<string, unknown>, config: AppConfig) {
+  return runJsonTool(() => runLiferayHealth(config));
+}

--- a/src/features/mcp-server/tools/tool-liferay-deploy-status.ts
+++ b/src/features/mcp-server/tools/tool-liferay-deploy-status.ts
@@ -1,21 +1,14 @@
-import type {CallToolResult} from '@modelcontextprotocol/sdk/types.js';
 import type {AppConfig} from '../../../core/config/schema.js';
 import {runDeployStatus} from '../../deploy/deploy-status.js';
+import {runJsonTool} from './tool-result.js';
 
 export const TOOL_NAME = 'liferay_deploy_status';
 
 export const inputSchema = {};
 
-export const description = 'Show the status of locally deployed Liferay modules (artifact name, state, last deploy time).';
+export const description =
+  'Show the status of locally deployed Liferay modules (artifact name, state, last deploy time).';
 
-export async function handleTool(
-  _input: Record<string, unknown>,
-  config: AppConfig,
-): Promise<CallToolResult> {
-  try {
-    const result = await runDeployStatus(config);
-    return {content: [{type: 'text', text: JSON.stringify(result, null, 2)}]};
-  } catch (err) {
-    return {isError: true, content: [{type: 'text', text: err instanceof Error ? err.message : String(err)}]};
-  }
+export async function handleTool(_input: Record<string, unknown>, config: AppConfig) {
+  return runJsonTool(() => runDeployStatus(config));
 }

--- a/src/features/mcp-server/tools/tool-liferay-deploy-status.ts
+++ b/src/features/mcp-server/tools/tool-liferay-deploy-status.ts
@@ -1,0 +1,21 @@
+import type {CallToolResult} from '@modelcontextprotocol/sdk/types.js';
+import type {AppConfig} from '../../../core/config/schema.js';
+import {runDeployStatus} from '../../deploy/deploy-status.js';
+
+export const TOOL_NAME = 'liferay_deploy_status';
+
+export const inputSchema = {};
+
+export const description = 'Show the status of locally deployed Liferay modules (artifact name, state, last deploy time).';
+
+export async function handleTool(
+  _input: Record<string, unknown>,
+  config: AppConfig,
+): Promise<CallToolResult> {
+  try {
+    const result = await runDeployStatus(config);
+    return {content: [{type: 'text', text: JSON.stringify(result, null, 2)}]};
+  } catch (err) {
+    return {isError: true, content: [{type: 'text', text: err instanceof Error ? err.message : String(err)}]};
+  }
+}

--- a/src/features/mcp-server/tools/tool-liferay-doctor.ts
+++ b/src/features/mcp-server/tools/tool-liferay-doctor.ts
@@ -1,0 +1,29 @@
+import type {CallToolResult} from '@modelcontextprotocol/sdk/types.js';
+import {z} from 'zod';
+import {runDoctor} from '../../doctor/doctor.service.js';
+import type {DoctorCheckScope} from '../../doctor/doctor-types.js';
+
+export const TOOL_NAME = 'liferay_doctor';
+
+export const inputSchema = {
+  scopes: z
+    .array(z.enum(['basic', 'deep', 'runtime', 'portal', 'osgi']))
+    .optional()
+    .describe('Checks to run. Defaults to basic. Options: basic, deep, runtime, portal, osgi'),
+};
+
+export const description =
+  'Run ldev diagnostics: checks environment, Docker runtime, portal reachability, and OSGi bundle health.';
+
+export async function handleTool(
+  input: {scopes?: DoctorCheckScope[]},
+  _config: unknown,
+  cwd: string,
+): Promise<CallToolResult> {
+  try {
+    const result = await runDoctor(cwd, {scopes: input.scopes});
+    return {content: [{type: 'text', text: JSON.stringify(result, null, 2)}]};
+  } catch (err) {
+    return {isError: true, content: [{type: 'text', text: err instanceof Error ? err.message : String(err)}]};
+  }
+}

--- a/src/features/mcp-server/tools/tool-liferay-doctor.ts
+++ b/src/features/mcp-server/tools/tool-liferay-doctor.ts
@@ -1,7 +1,8 @@
-import type {CallToolResult} from '@modelcontextprotocol/sdk/types.js';
 import {z} from 'zod';
+import type {AppConfig} from '../../../core/config/schema.js';
 import {runDoctor} from '../../doctor/doctor.service.js';
 import type {DoctorCheckScope} from '../../doctor/doctor-types.js';
+import {runJsonTool} from './tool-result.js';
 
 export const TOOL_NAME = 'liferay_doctor';
 
@@ -15,15 +16,6 @@ export const inputSchema = {
 export const description =
   'Run ldev diagnostics: checks environment, Docker runtime, portal reachability, and OSGi bundle health.';
 
-export async function handleTool(
-  input: {scopes?: DoctorCheckScope[]},
-  _config: unknown,
-  cwd: string,
-): Promise<CallToolResult> {
-  try {
-    const result = await runDoctor(cwd, {scopes: input.scopes});
-    return {content: [{type: 'text', text: JSON.stringify(result, null, 2)}]};
-  } catch (err) {
-    return {isError: true, content: [{type: 'text', text: err instanceof Error ? err.message : String(err)}]};
-  }
+export async function handleTool(input: {scopes?: DoctorCheckScope[]}, config: AppConfig, cwd: string) {
+  return runJsonTool(() => runDoctor(cwd, {config, env: process.env, scopes: input.scopes}));
 }

--- a/src/features/mcp-server/tools/tool-liferay-inventory-page.ts
+++ b/src/features/mcp-server/tools/tool-liferay-inventory-page.ts
@@ -1,7 +1,7 @@
-import type {CallToolResult} from '@modelcontextprotocol/sdk/types.js';
 import {z} from 'zod';
 import type {AppConfig} from '../../../core/config/schema.js';
 import {runLiferayInventoryPage} from '../../liferay/inventory/liferay-inventory-page.js';
+import {runJsonTool} from './tool-result.js';
 
 export const TOOL_NAME = 'liferay_inventory_page';
 
@@ -19,17 +19,14 @@ export const description =
 export async function handleTool(
   input: {url?: string; site?: string; friendlyUrl?: string; privateLayout?: boolean; verbose?: boolean},
   config: AppConfig,
-): Promise<CallToolResult> {
-  try {
-    const result = await runLiferayInventoryPage(config, {
+) {
+  return runJsonTool(() =>
+    runLiferayInventoryPage(config, {
       url: input.url,
       site: input.site,
       friendlyUrl: input.friendlyUrl,
       privateLayout: input.privateLayout,
       verbose: input.verbose,
-    });
-    return {content: [{type: 'text', text: JSON.stringify(result, null, 2)}]};
-  } catch (err) {
-    return {isError: true, content: [{type: 'text', text: err instanceof Error ? err.message : String(err)}]};
-  }
+    }),
+  );
 }

--- a/src/features/mcp-server/tools/tool-liferay-inventory-page.ts
+++ b/src/features/mcp-server/tools/tool-liferay-inventory-page.ts
@@ -1,0 +1,35 @@
+import type {CallToolResult} from '@modelcontextprotocol/sdk/types.js';
+import {z} from 'zod';
+import type {AppConfig} from '../../../core/config/schema.js';
+import {runLiferayInventoryPage} from '../../liferay/inventory/liferay-inventory-page.js';
+
+export const TOOL_NAME = 'liferay_inventory_page';
+
+export const inputSchema = {
+  url: z.string().optional().describe('Full page URL or path (e.g. http://localhost:8080/web/guest/home)'),
+  site: z.string().optional().describe('Site friendly URL path (e.g. /guest)'),
+  friendlyUrl: z.string().optional().describe('Page friendly URL relative to site (e.g. /home)'),
+  privateLayout: z.boolean().optional().describe('True if the page is a private layout'),
+  verbose: z.boolean().optional().describe('Include fragment and widget details'),
+};
+
+export const description =
+  'Inspect a specific Liferay page: returns portlets, fragments, configuration tabs, and SEO settings.';
+
+export async function handleTool(
+  input: {url?: string; site?: string; friendlyUrl?: string; privateLayout?: boolean; verbose?: boolean},
+  config: AppConfig,
+): Promise<CallToolResult> {
+  try {
+    const result = await runLiferayInventoryPage(config, {
+      url: input.url,
+      site: input.site,
+      friendlyUrl: input.friendlyUrl,
+      privateLayout: input.privateLayout,
+      verbose: input.verbose,
+    });
+    return {content: [{type: 'text', text: JSON.stringify(result, null, 2)}]};
+  } catch (err) {
+    return {isError: true, content: [{type: 'text', text: err instanceof Error ? err.message : String(err)}]};
+  }
+}

--- a/src/features/mcp-server/tools/tool-liferay-inventory-page.ts
+++ b/src/features/mcp-server/tools/tool-liferay-inventory-page.ts
@@ -1,6 +1,9 @@
 import {z} from 'zod';
 import type {AppConfig} from '../../../core/config/schema.js';
-import {runLiferayInventoryPage} from '../../liferay/inventory/liferay-inventory-page.js';
+import {
+  projectLiferayInventoryPageJson,
+  runLiferayInventoryPage,
+} from '../../liferay/inventory/liferay-inventory-page.js';
 import {runJsonTool} from './tool-result.js';
 
 export const TOOL_NAME = 'liferay_inventory_page';
@@ -10,23 +13,23 @@ export const inputSchema = {
   site: z.string().optional().describe('Site friendly URL path (e.g. /guest)'),
   friendlyUrl: z.string().optional().describe('Page friendly URL relative to site (e.g. /home)'),
   privateLayout: z.boolean().optional().describe('True if the page is a private layout'),
-  verbose: z.boolean().optional().describe('Include fragment and widget details'),
+  full: z.boolean().optional().describe('Include expanded inspection details'),
 };
 
 export const description =
   'Inspect a specific Liferay page: returns portlets, fragments, configuration tabs, and SEO settings.';
 
 export async function handleTool(
-  input: {url?: string; site?: string; friendlyUrl?: string; privateLayout?: boolean; verbose?: boolean},
+  input: {url?: string; site?: string; friendlyUrl?: string; privateLayout?: boolean; full?: boolean},
   config: AppConfig,
 ) {
-  return runJsonTool(() =>
-    runLiferayInventoryPage(config, {
+  return runJsonTool(async () => {
+    const result = await runLiferayInventoryPage(config, {
       url: input.url,
       site: input.site,
       friendlyUrl: input.friendlyUrl,
       privateLayout: input.privateLayout,
-      verbose: input.verbose,
-    }),
-  );
+    });
+    return projectLiferayInventoryPageJson(result, {full: Boolean(input.full)});
+  });
 }

--- a/src/features/mcp-server/tools/tool-liferay-inventory-pages.ts
+++ b/src/features/mcp-server/tools/tool-liferay-inventory-pages.ts
@@ -1,7 +1,7 @@
-import type {CallToolResult} from '@modelcontextprotocol/sdk/types.js';
 import {z} from 'zod';
 import type {AppConfig} from '../../../core/config/schema.js';
 import {runLiferayInventoryPages} from '../../liferay/inventory/liferay-inventory-pages.js';
+import {runJsonTool} from './tool-result.js';
 
 export const TOOL_NAME = 'liferay_inventory_pages';
 
@@ -16,15 +16,12 @@ export const description = 'List the page tree for a Liferay site, including hie
 export async function handleTool(
   input: {site?: string; privateLayout?: boolean; maxDepth?: number},
   config: AppConfig,
-): Promise<CallToolResult> {
-  try {
-    const result = await runLiferayInventoryPages(config, {
+) {
+  return runJsonTool(() =>
+    runLiferayInventoryPages(config, {
       site: input.site,
       privateLayout: input.privateLayout,
       maxDepth: input.maxDepth,
-    });
-    return {content: [{type: 'text', text: JSON.stringify(result, null, 2)}]};
-  } catch (err) {
-    return {isError: true, content: [{type: 'text', text: err instanceof Error ? err.message : String(err)}]};
-  }
+    }),
+  );
 }

--- a/src/features/mcp-server/tools/tool-liferay-inventory-pages.ts
+++ b/src/features/mcp-server/tools/tool-liferay-inventory-pages.ts
@@ -1,0 +1,30 @@
+import type {CallToolResult} from '@modelcontextprotocol/sdk/types.js';
+import {z} from 'zod';
+import type {AppConfig} from '../../../core/config/schema.js';
+import {runLiferayInventoryPages} from '../../liferay/inventory/liferay-inventory-pages.js';
+
+export const TOOL_NAME = 'liferay_inventory_pages';
+
+export const inputSchema = {
+  site: z.string().optional().describe('Site friendly URL path (e.g. /guest)'),
+  privateLayout: z.boolean().optional().describe('Inspect private pages instead of public pages'),
+  maxDepth: z.number().optional().describe('Max recursion depth for nested pages'),
+};
+
+export const description = 'List the page tree for a Liferay site, including hierarchy and friendly URLs.';
+
+export async function handleTool(
+  input: {site?: string; privateLayout?: boolean; maxDepth?: number},
+  config: AppConfig,
+): Promise<CallToolResult> {
+  try {
+    const result = await runLiferayInventoryPages(config, {
+      site: input.site,
+      privateLayout: input.privateLayout,
+      maxDepth: input.maxDepth,
+    });
+    return {content: [{type: 'text', text: JSON.stringify(result, null, 2)}]};
+  } catch (err) {
+    return {isError: true, content: [{type: 'text', text: err instanceof Error ? err.message : String(err)}]};
+  }
+}

--- a/src/features/mcp-server/tools/tool-liferay-inventory-sites.ts
+++ b/src/features/mcp-server/tools/tool-liferay-inventory-sites.ts
@@ -1,7 +1,7 @@
-import type {CallToolResult} from '@modelcontextprotocol/sdk/types.js';
 import {z} from 'zod';
 import type {AppConfig} from '../../../core/config/schema.js';
 import {runLiferayInventorySites} from '../../liferay/inventory/liferay-inventory-sites.js';
+import {runJsonTool} from './tool-result.js';
 
 export const TOOL_NAME = 'liferay_inventory_sites';
 
@@ -11,14 +11,6 @@ export const inputSchema = {
 
 export const description = 'List all accessible Liferay sites with their group IDs and friendly URLs.';
 
-export async function handleTool(
-  input: {pageSize?: number},
-  config: AppConfig,
-): Promise<CallToolResult> {
-  try {
-    const result = await runLiferayInventorySites(config, {pageSize: input.pageSize});
-    return {content: [{type: 'text', text: JSON.stringify(result, null, 2)}]};
-  } catch (err) {
-    return {isError: true, content: [{type: 'text', text: err instanceof Error ? err.message : String(err)}]};
-  }
+export async function handleTool(input: {pageSize?: number}, config: AppConfig) {
+  return runJsonTool(() => runLiferayInventorySites(config, {pageSize: input.pageSize}));
 }

--- a/src/features/mcp-server/tools/tool-liferay-inventory-sites.ts
+++ b/src/features/mcp-server/tools/tool-liferay-inventory-sites.ts
@@ -1,0 +1,24 @@
+import type {CallToolResult} from '@modelcontextprotocol/sdk/types.js';
+import {z} from 'zod';
+import type {AppConfig} from '../../../core/config/schema.js';
+import {runLiferayInventorySites} from '../../liferay/inventory/liferay-inventory-sites.js';
+
+export const TOOL_NAME = 'liferay_inventory_sites';
+
+export const inputSchema = {
+  pageSize: z.number().optional().describe('Max sites per request (default 200)'),
+};
+
+export const description = 'List all accessible Liferay sites with their group IDs and friendly URLs.';
+
+export async function handleTool(
+  input: {pageSize?: number},
+  config: AppConfig,
+): Promise<CallToolResult> {
+  try {
+    const result = await runLiferayInventorySites(config, {pageSize: input.pageSize});
+    return {content: [{type: 'text', text: JSON.stringify(result, null, 2)}]};
+  } catch (err) {
+    return {isError: true, content: [{type: 'text', text: err instanceof Error ? err.message : String(err)}]};
+  }
+}

--- a/src/features/mcp-server/tools/tool-liferay-inventory-structures.ts
+++ b/src/features/mcp-server/tools/tool-liferay-inventory-structures.ts
@@ -1,10 +1,10 @@
-import type {CallToolResult} from '@modelcontextprotocol/sdk/types.js';
 import {z} from 'zod';
 import type {AppConfig} from '../../../core/config/schema.js';
 import {
   runLiferayInventoryStructures,
   runLiferayInventoryStructuresAllSites,
 } from '../../liferay/inventory/liferay-inventory-structures.js';
+import {runJsonTool} from './tool-result.js';
 
 export const TOOL_NAME = 'liferay_inventory_structures';
 
@@ -15,17 +15,11 @@ export const inputSchema = {
 
 export const description = 'List journal structures for a site or all sites, optionally including template references.';
 
-export async function handleTool(
-  input: {site?: string; withTemplates?: boolean},
-  config: AppConfig,
-): Promise<CallToolResult> {
-  try {
+export async function handleTool(input: {site?: string; withTemplates?: boolean}, config: AppConfig) {
+  return runJsonTool(async () => {
     const options = {withTemplates: input.withTemplates};
-    const result = input.site
+    return input.site
       ? await runLiferayInventoryStructures(config, {...options, site: input.site})
       : await runLiferayInventoryStructuresAllSites(config, options);
-    return {content: [{type: 'text', text: JSON.stringify(result, null, 2)}]};
-  } catch (err) {
-    return {isError: true, content: [{type: 'text', text: err instanceof Error ? err.message : String(err)}]};
-  }
+  });
 }

--- a/src/features/mcp-server/tools/tool-liferay-inventory-structures.ts
+++ b/src/features/mcp-server/tools/tool-liferay-inventory-structures.ts
@@ -1,0 +1,31 @@
+import type {CallToolResult} from '@modelcontextprotocol/sdk/types.js';
+import {z} from 'zod';
+import type {AppConfig} from '../../../core/config/schema.js';
+import {
+  runLiferayInventoryStructures,
+  runLiferayInventoryStructuresAllSites,
+} from '../../liferay/inventory/liferay-inventory-structures.js';
+
+export const TOOL_NAME = 'liferay_inventory_structures';
+
+export const inputSchema = {
+  site: z.string().optional().describe('Site friendly URL path (e.g. /guest). Omit to scan all sites.'),
+  withTemplates: z.boolean().optional().describe('Include associated templates in the result'),
+};
+
+export const description = 'List journal structures for a site or all sites, optionally including template references.';
+
+export async function handleTool(
+  input: {site?: string; withTemplates?: boolean},
+  config: AppConfig,
+): Promise<CallToolResult> {
+  try {
+    const options = {withTemplates: input.withTemplates};
+    const result = input.site
+      ? await runLiferayInventoryStructures(config, {...options, site: input.site})
+      : await runLiferayInventoryStructuresAllSites(config, options);
+    return {content: [{type: 'text', text: JSON.stringify(result, null, 2)}]};
+  } catch (err) {
+    return {isError: true, content: [{type: 'text', text: err instanceof Error ? err.message : String(err)}]};
+  }
+}

--- a/src/features/mcp-server/tools/tool-liferay-inventory-templates.ts
+++ b/src/features/mcp-server/tools/tool-liferay-inventory-templates.ts
@@ -1,7 +1,7 @@
-import type {CallToolResult} from '@modelcontextprotocol/sdk/types.js';
 import {z} from 'zod';
 import type {AppConfig} from '../../../core/config/schema.js';
 import {runLiferayInventoryTemplates} from '../../liferay/inventory/liferay-inventory-templates.js';
+import {runJsonTool} from './tool-result.js';
 
 export const TOOL_NAME = 'liferay_inventory_templates';
 
@@ -11,14 +11,6 @@ export const inputSchema = {
 
 export const description = 'List web content templates for a Liferay site, including structure associations.';
 
-export async function handleTool(
-  input: {site: string},
-  config: AppConfig,
-): Promise<CallToolResult> {
-  try {
-    const result = await runLiferayInventoryTemplates(config, {site: input.site});
-    return {content: [{type: 'text', text: JSON.stringify(result, null, 2)}]};
-  } catch (err) {
-    return {isError: true, content: [{type: 'text', text: err instanceof Error ? err.message : String(err)}]};
-  }
+export async function handleTool(input: {site: string}, config: AppConfig) {
+  return runJsonTool(() => runLiferayInventoryTemplates(config, {site: input.site}));
 }

--- a/src/features/mcp-server/tools/tool-liferay-inventory-templates.ts
+++ b/src/features/mcp-server/tools/tool-liferay-inventory-templates.ts
@@ -1,0 +1,24 @@
+import type {CallToolResult} from '@modelcontextprotocol/sdk/types.js';
+import {z} from 'zod';
+import type {AppConfig} from '../../../core/config/schema.js';
+import {runLiferayInventoryTemplates} from '../../liferay/inventory/liferay-inventory-templates.js';
+
+export const TOOL_NAME = 'liferay_inventory_templates';
+
+export const inputSchema = {
+  site: z.string().describe('Site friendly URL path (e.g. /guest)'),
+};
+
+export const description = 'List web content templates for a Liferay site, including structure associations.';
+
+export async function handleTool(
+  input: {site: string},
+  config: AppConfig,
+): Promise<CallToolResult> {
+  try {
+    const result = await runLiferayInventoryTemplates(config, {site: input.site});
+    return {content: [{type: 'text', text: JSON.stringify(result, null, 2)}]};
+  } catch (err) {
+    return {isError: true, content: [{type: 'text', text: err instanceof Error ? err.message : String(err)}]};
+  }
+}

--- a/src/features/mcp-server/tools/tool-liferay-mcp-check.ts
+++ b/src/features/mcp-server/tools/tool-liferay-mcp-check.ts
@@ -1,0 +1,22 @@
+import type {CallToolResult} from '@modelcontextprotocol/sdk/types.js';
+import type {AppConfig} from '../../../core/config/schema.js';
+import {runMcpCheck} from '../../mcp/mcp.js';
+
+export const TOOL_NAME = 'liferay_mcp_check';
+
+export const inputSchema = {};
+
+export const description =
+  "Check whether Liferay's built-in MCP server is reachable and the feature flag is enabled.";
+
+export async function handleTool(
+  _input: Record<string, unknown>,
+  config: AppConfig,
+): Promise<CallToolResult> {
+  try {
+    const result = await runMcpCheck(config);
+    return {content: [{type: 'text', text: JSON.stringify(result, null, 2)}]};
+  } catch (err) {
+    return {isError: true, content: [{type: 'text', text: err instanceof Error ? err.message : String(err)}]};
+  }
+}

--- a/src/features/mcp-server/tools/tool-liferay-mcp-check.ts
+++ b/src/features/mcp-server/tools/tool-liferay-mcp-check.ts
@@ -1,22 +1,13 @@
-import type {CallToolResult} from '@modelcontextprotocol/sdk/types.js';
 import type {AppConfig} from '../../../core/config/schema.js';
 import {runMcpCheck} from '../../mcp/mcp.js';
+import {runJsonTool} from './tool-result.js';
 
 export const TOOL_NAME = 'liferay_mcp_check';
 
 export const inputSchema = {};
 
-export const description =
-  "Check whether Liferay's built-in MCP server is reachable and the feature flag is enabled.";
+export const description = "Check whether Liferay's built-in MCP server is reachable and the feature flag is enabled.";
 
-export async function handleTool(
-  _input: Record<string, unknown>,
-  config: AppConfig,
-): Promise<CallToolResult> {
-  try {
-    const result = await runMcpCheck(config);
-    return {content: [{type: 'text', text: JSON.stringify(result, null, 2)}]};
-  } catch (err) {
-    return {isError: true, content: [{type: 'text', text: err instanceof Error ? err.message : String(err)}]};
-  }
+export async function handleTool(_input: Record<string, unknown>, config: AppConfig) {
+  return runJsonTool(() => runMcpCheck(config));
 }

--- a/src/features/mcp-server/tools/tool-liferay-osgi-diag.ts
+++ b/src/features/mcp-server/tools/tool-liferay-osgi-diag.ts
@@ -1,0 +1,16 @@
+import {z} from 'zod';
+import type {AppConfig} from '../../../core/config/schema.js';
+import {runOsgiDiag} from '../../osgi/osgi-diag.js';
+import {runJsonTool} from './tool-result.js';
+
+export const TOOL_NAME = 'liferay_osgi_diag';
+
+export const inputSchema = {
+  bundle: z.string().describe('Bundle symbolic name or partial name to diagnose.'),
+};
+
+export const description = 'Run `ldev osgi diag <bundle>` and return the raw Gogo diag output plus resolved bundle id.';
+
+export async function handleTool(input: {bundle: string}, config: AppConfig) {
+  return runJsonTool(() => runOsgiDiag(config, {bundle: input.bundle}));
+}

--- a/src/features/mcp-server/tools/tool-liferay-osgi-status.ts
+++ b/src/features/mcp-server/tools/tool-liferay-osgi-status.ts
@@ -1,0 +1,24 @@
+import type {CallToolResult} from '@modelcontextprotocol/sdk/types.js';
+import {z} from 'zod';
+import type {AppConfig} from '../../../core/config/schema.js';
+import {runOsgiStatus} from '../../osgi/osgi-status.js';
+
+export const TOOL_NAME = 'liferay_osgi_status';
+
+export const inputSchema = {
+  bundle: z.string().describe('Bundle symbolic name or partial name to filter (e.g. com.example.mymodule)'),
+};
+
+export const description = 'Query the OSGi runtime for bundle state via the Gogo shell (lb -s filter).';
+
+export async function handleTool(
+  input: {bundle: string},
+  config: AppConfig,
+): Promise<CallToolResult> {
+  try {
+    const result = await runOsgiStatus(config, {bundle: input.bundle});
+    return {content: [{type: 'text', text: JSON.stringify(result, null, 2)}]};
+  } catch (err) {
+    return {isError: true, content: [{type: 'text', text: err instanceof Error ? err.message : String(err)}]};
+  }
+}

--- a/src/features/mcp-server/tools/tool-liferay-osgi-status.ts
+++ b/src/features/mcp-server/tools/tool-liferay-osgi-status.ts
@@ -1,7 +1,7 @@
-import type {CallToolResult} from '@modelcontextprotocol/sdk/types.js';
 import {z} from 'zod';
 import type {AppConfig} from '../../../core/config/schema.js';
 import {runOsgiStatus} from '../../osgi/osgi-status.js';
+import {runJsonTool} from './tool-result.js';
 
 export const TOOL_NAME = 'liferay_osgi_status';
 
@@ -11,14 +11,6 @@ export const inputSchema = {
 
 export const description = 'Query the OSGi runtime for bundle state via the Gogo shell (lb -s filter).';
 
-export async function handleTool(
-  input: {bundle: string},
-  config: AppConfig,
-): Promise<CallToolResult> {
-  try {
-    const result = await runOsgiStatus(config, {bundle: input.bundle});
-    return {content: [{type: 'text', text: JSON.stringify(result, null, 2)}]};
-  } catch (err) {
-    return {isError: true, content: [{type: 'text', text: err instanceof Error ? err.message : String(err)}]};
-  }
+export async function handleTool(input: {bundle: string}, config: AppConfig) {
+  return runJsonTool(() => runOsgiStatus(config, {bundle: input.bundle}));
 }

--- a/src/features/mcp-server/tools/tool-liferay-osgi-thread-dump.ts
+++ b/src/features/mcp-server/tools/tool-liferay-osgi-thread-dump.ts
@@ -1,0 +1,30 @@
+import {z} from 'zod';
+import type {AppConfig} from '../../../core/config/schema.js';
+import {runOsgiThreadDump} from '../../osgi/osgi-thread-dump.js';
+import {runJsonTool} from './tool-result.js';
+
+export const TOOL_NAME = 'liferay_osgi_thread_dump';
+
+export const inputSchema = {
+  count: z.number().int().min(1).max(20).optional().describe('Number of thread dumps to collect. Defaults to 6.'),
+  intervalSeconds: z.number().int().min(1).max(60).optional().describe('Seconds between dumps. Defaults to 3.'),
+};
+
+export const description =
+  'Run `ldev osgi thread-dump` and return where the generated thread dumps were written in the local project.';
+
+export async function handleTool(input: {count?: number; intervalSeconds?: number}, config: AppConfig) {
+  return runJsonTool(() =>
+    runOsgiThreadDump(config, {
+      count: clampInt(input.count, 6, 1, 20),
+      intervalSeconds: clampInt(input.intervalSeconds, 3, 1, 60),
+    }),
+  );
+}
+
+function clampInt(value: number | undefined, fallback: number, min: number, max: number): number {
+  if (value === undefined || !Number.isFinite(value)) {
+    return fallback;
+  }
+  return Math.max(min, Math.min(max, Math.trunc(value)));
+}

--- a/src/features/mcp-server/tools/tool-result.ts
+++ b/src/features/mcp-server/tools/tool-result.ts
@@ -1,0 +1,22 @@
+import type {CallToolResult} from '@modelcontextprotocol/sdk/types.js';
+
+export function jsonToolResult(value: unknown): CallToolResult {
+  const content = [{type: 'text' as const, text: JSON.stringify(value, null, 2)}];
+  return isStructuredContent(value) ? {structuredContent: value, content} : {content};
+}
+
+export function errorToolResult(error: unknown): CallToolResult {
+  return {isError: true, content: [{type: 'text', text: error instanceof Error ? error.message : String(error)}]};
+}
+
+export async function runJsonTool(action: () => Promise<unknown>): Promise<CallToolResult> {
+  try {
+    return jsonToolResult(await action());
+  } catch (error) {
+    return errorToolResult(error);
+  }
+}
+
+function isStructuredContent(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+import {startMcpServer} from './features/mcp-server/mcp-server.js';
+
+startMcpServer().catch((err: unknown) => {
+  process.stderr.write(`ldev-mcp-server: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1,5 +1,25 @@
 #!/usr/bin/env node
-import {startMcpServer} from './features/mcp-server/mcp-server.js';
+import {readMcpPackageVersion, startMcpServer} from './features/mcp-server/mcp-server.js';
+
+if (process.argv.includes('--version') || process.argv.includes('-v')) {
+  process.stdout.write(`${readMcpPackageVersion()}\n`);
+  process.exit(0);
+}
+
+if (process.argv.includes('--help') || process.argv.includes('-h')) {
+  process.stdout.write(
+    [
+      'Usage: ldev-mcp-server [options]',
+      '',
+      'Start the ldev MCP server on stdio.',
+      '',
+      'Options:',
+      '  -v, --version  Print version',
+      '  -h, --help     Print help',
+    ].join('\n') + '\n',
+  );
+  process.exit(0);
+}
 
 startMcpServer().catch((err: unknown) => {
   process.stderr.write(`ldev-mcp-server: ${err instanceof Error ? err.message : String(err)}\n`);

--- a/templates/ai/install/AGENTS.md
+++ b/templates/ai/install/AGENTS.md
@@ -17,8 +17,9 @@ Before changing code or runtime state:
 1. Run `ldev ai bootstrap --intent=develop --cache=60 --json`.
 2. Run `ldev doctor --json` only when the task needs extra runtime health,
    installed tooling, browser automation, deploy verification, or diagnosis.
-3. Run `ldev mcp check --json` only when the task depends on MCP or no direct
-   `ldev` command covers the required portal surface.
+3. Use local `ldev` MCP tools for structured discovery/diagnosis when they are
+   visible in the active assistant. If they are not visible, continue with the
+   CLI fallback commands in this file; do not block the task.
 4. Read `CLAUDE.md`.
 5. Read the task-specific skill under `.agents/skills/` if one applies.
 6. If `.agents/skills/project-issue-engineering/SKILL.md` exists and the task
@@ -87,7 +88,9 @@ Do not stop on `CommandNotFound` for `ldev` until this fallback has been tried.
   boundary for the whole task.
 - Use `--cache=60` for read-only bootstrap intents. Omit it only when the task
   explicitly requires fresh runtime or portal state.
-- Prefer the task-shaped public contract first:
+- Prefer the task-shaped public contract first. If the equivalent local `ldev`
+  MCP tool is visible, use it for structured discovery/diagnosis; otherwise use
+  the CLI fallback:
   - `ldev ai bootstrap --intent=discover --cache=60 --json` for read-only discovery
   - `ldev ai bootstrap --intent=develop --cache=60 --json` before code/resource changes
   - `ldev ai bootstrap --intent=deploy --json` before deploy verification
@@ -118,25 +121,50 @@ Do not stop on `CommandNotFound` for `ldev` until this fallback has been tried.
 
 ## MCP Usage
 
-- Treat MCP as optional. Do not assume it is enabled in every runtime.
-- Run `ldev mcp check --json` before planning around MCP, not as universal bootstrap.
-- For agents and reusable skills, prefer OAuth2 via `ldev oauth install --write-env` instead of MCP Basic auth with a human username/password.
-- Treat MCP username/password auth as a quick manual test path, not as the default agent bootstrap.
-- If MCP is available and the task is generic OpenAPI discovery or generic endpoint execution, MCP can be the shortest path.
-- If the task is local-runtime diagnosis or opinionated portal discovery, prefer `ldev` commands first.
+There are two different MCP surfaces:
 
-Use MCP for:
+- **Local ldev MCP server:** optional acceleration layer for agent-facing
+  `ldev` workflows.
+- **Liferay portal MCP server:** optional portal feature checked by
+  `ldev mcp check --json`.
 
-- discovering available OpenAPIs
-- retrieving one OpenAPI spec
-- calling a generic portal endpoint when no higher-level `ldev` command exists
+Treat local `ldev` MCP as optional. Do not assume it is enabled in every editor
+or assistant. If the tool is visible, prefer it for structured discovery and
+diagnosis; if not, use the CLI fallback and continue. `liferay_osgi_thread_dump`
+writes dump artifacts, so use it only when runtime artifacts are part of the
+diagnosis.
 
-Prefer `ldev` for:
+MCP-to-CLI fallbacks:
 
-- runtime diagnosis
-- OAuth/bootstrap
-- site and page discovery
-- page inspection and other task-shaped workflows
+- `ldev_context` -> `ldev context --json`
+- `liferay_check` -> `ldev portal check --json`
+- `ldev_status` -> `ldev status --json`
+- `ldev_logs_diagnose` -> `ldev logs diagnose --since 10m --json`
+- `liferay_inventory_sites` -> `ldev portal inventory sites --json`
+- `liferay_inventory_pages` -> `ldev portal inventory pages --site /<site> --json`
+- `liferay_inventory_page` -> `ldev portal inventory page --url <url> --json`
+- `liferay_inventory_structures` -> `ldev portal inventory structures --site /<site> --json`
+- `liferay_inventory_templates` -> `ldev portal inventory templates --site /<site> --json`
+- `liferay_deploy_status` -> `ldev deploy status --json`
+- `liferay_osgi_status` -> `ldev osgi status <bundle> --json`
+- `liferay_osgi_diag` -> `ldev osgi diag <bundle> --json`
+- `liferay_osgi_thread_dump` -> `ldev osgi thread-dump --json`
+- `liferay_doctor` -> `ldev doctor --json`
+
+When the user reports that MCP tools are missing or stale, run:
+
+```bash
+ldev mcp doctor --target . --tool all
+```
+
+Keep mutating workflows CLI-first unless a skill explicitly documents a bounded
+MCP mutation path. Skills decide the workflow and guardrails; MCP only executes
+the structured operation when available.
+
+Use the Liferay portal MCP server for generic OpenAPI discovery or endpoint
+execution only when no higher-level `ldev` command covers the portal surface.
+For agents and reusable skills, prefer OAuth2 via `ldev oauth install --write-env`
+instead of MCP Basic auth with a human username/password.
 
 ## Project-Specific Knowledge
 

--- a/templates/ai/mcp/claude-code-mcp-local.json
+++ b/templates/ai/mcp/claude-code-mcp-local.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "ldev": {
+      "command": "node",
+      "args": ["./node_modules/@mordonezdev/ldev/dist/mcp-server.js"]
+    }
+  }
+}

--- a/templates/ai/mcp/claude-code-mcp.json
+++ b/templates/ai/mcp/claude-code-mcp.json
@@ -1,0 +1,7 @@
+{
+  "mcpServers": {
+    "ldev": {
+      "command": "ldev-mcp-server"
+    }
+  }
+}

--- a/templates/ai/mcp/cursor-mcp-local.json
+++ b/templates/ai/mcp/cursor-mcp-local.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "ldev": {
+      "command": "node",
+      "args": ["./node_modules/@mordonezdev/ldev/dist/mcp-server.js"]
+    }
+  }
+}

--- a/templates/ai/mcp/cursor-mcp.json
+++ b/templates/ai/mcp/cursor-mcp.json
@@ -1,0 +1,7 @@
+{
+  "mcpServers": {
+    "ldev": {
+      "command": "ldev-mcp-server"
+    }
+  }
+}

--- a/templates/ai/mcp/vscode-mcp-local.json
+++ b/templates/ai/mcp/vscode-mcp-local.json
@@ -1,0 +1,9 @@
+{
+  "servers": {
+    "ldev": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["./node_modules/@mordonezdev/ldev/dist/mcp-server.js"]
+    }
+  }
+}

--- a/templates/ai/mcp/vscode-mcp.json
+++ b/templates/ai/mcp/vscode-mcp.json
@@ -1,0 +1,8 @@
+{
+  "servers": {
+    "ldev": {
+      "type": "stdio",
+      "command": "ldev-mcp-server"
+    }
+  }
+}

--- a/templates/ai/skills/deploying-liferay/SKILL.md
+++ b/templates/ai/skills/deploying-liferay/SKILL.md
@@ -143,6 +143,8 @@ ldev osgi status <bundle-symbolic-name> --json
 ldev osgi diag <bundle-symbolic-name> --json
 ```
 
+MCP equivalents when visible: `liferay_osgi_status`, `liferay_osgi_diag`.
+
 Use logs after any deploy or import:
 
 ```bash
@@ -155,6 +157,8 @@ Prefer the task-shaped diagnosis summary when checking for fresh regressions:
 ldev logs diagnose --since 5m --json
 ```
 
+MCP equivalent when visible: `ldev_logs_diagnose`.
+
 Use portal reachability checks when the fix affects page rendering, portal
 availability, or resource-backed behavior:
 
@@ -162,6 +166,8 @@ availability, or resource-backed behavior:
 ldev portal check --json
 ldev portal inventory page --url <fullUrl> --json
 ```
+
+MCP equivalents when visible: `liferay_check`, `liferay_inventory_page`.
 
 Then use `playwright-cli` for the affected page or flow so the runtime result
 is validated in a browser, not only through CLI output.
@@ -178,6 +184,8 @@ Minimum done criteria:
 ## Guardrails
 
 - Do not use a wider deploy than necessary.
+- Use local `ldev` MCP tools only for read-only verification and diagnosis.
+  Deploys, resource imports, and migrations remain CLI-first workflows.
 - Do not use `ldev deploy theme` unless the theme changed.
 - Do not use `ldev deploy module` unless a module or deployable Gradle unit changed.
 - Do not use plural resource commands or a broad deploy unless a human

--- a/templates/ai/skills/developing-liferay/SKILL.md
+++ b/templates/ai/skills/developing-liferay/SKILL.md
@@ -56,7 +56,8 @@ ldev ai bootstrap --intent=deploy --json
 ## Discovery first
 
 If the task mentions a site, page, structure, template, ADT or fragment, start
-with portal discovery before editing code:
+with portal discovery before editing code. Prefer local `ldev` MCP discovery
+tools when visible; otherwise use the CLI fallbacks:
 
 ```bash
 ldev portal inventory sites --json
@@ -70,6 +71,17 @@ For cross-site structure/template incidents, use:
 ```bash
 ldev portal inventory structures --with-templates --all-sites --json
 ```
+
+MCP equivalents for the inventory commands:
+
+- `liferay_inventory_sites`
+- `liferay_inventory_pages`
+- `liferay_inventory_page`
+- `liferay_inventory_structures`
+- `liferay_inventory_templates`
+
+There is no MCP replacement for every resource read/export/import workflow.
+Use the CLI for resource commands and all mutations.
 
 If you are inside a worktree and the main runtime is still the source of truth
 for discovery, keep your shell in the worktree and call the global form:
@@ -211,6 +223,8 @@ has been read back or otherwise verified.
 ## Guardrails
 
 - Use `ldev` as the entrypoint.
+- Use local `ldev` MCP tools only as an optional read-only discovery and
+  diagnosis layer. Fall back to CLI with `--json` without blocking the task.
 - Prefer the smallest deploy or import that proves the change.
 - Use `ldev deploy theme` only for theme changes.
 - Use `ldev deploy module <module-name>` only for modules or deployable Gradle units.

--- a/templates/ai/skills/liferay-expert/SKILL.md
+++ b/templates/ai/skills/liferay-expert/SKILL.md
@@ -12,7 +12,8 @@ specialist skill quickly.
 
 ## Start here
 
-Run this bootstrap first:
+Run this bootstrap first. If the local `ldev_context` MCP tool is visible, it
+can provide the fast context snapshot; otherwise use the CLI command below.
 
 ```bash
 ldev ai bootstrap --intent=discover --cache=60 --json
@@ -42,6 +43,8 @@ If the site is not known, discover it:
 ldev portal inventory sites --json
 ```
 
+MCP equivalent when visible: `liferay_inventory_sites`.
+
 If the task involves a portal URL or resource, resolve that context first:
 
 ```bash
@@ -62,6 +65,12 @@ requires content fields, all template candidates, or the raw page definition:
 ```bash
 ldev portal inventory page --url <fullUrl> --json --full
 ```
+
+MCP equivalents when visible:
+
+- `liferay_inventory_page`
+- `liferay_inventory_structures`
+- `liferay_inventory_templates`
 
 ## Routing rules
 
@@ -141,8 +150,13 @@ ldev oauth admin-unblock
 - Use `ldev` as the official interface.
 - Use `ldev context --json` for offline routing; use `ldev status --json` only
   to confirm runtime state. They are not interchangeable.
+- Prefer local `ldev` MCP tools for read-only discovery/diagnosis when visible.
+  Fall back to CLI with `--json` without blocking the task.
+- Prefer `ldev context --json`, `ldev doctor --json` and `ldev status --json`
+  for automation and agents when MCP is not available.
 - Prefer the smallest deploy or import that proves the change.
 - Do not invent portal mutations if an `ldev resource ...` workflow already exists.
-- For site-level objects without dedicated `ldev` commands, verify MCP with
-  `ldev mcp check --json` before assembling low-level API calls manually.
+- For site-level objects without dedicated `ldev` commands, verify the Liferay
+  portal MCP server with `ldev mcp check --json` before assembling low-level API
+  calls manually.
 - Keep deep guidance in the specialist skill references; do not duplicate it here.

--- a/templates/ai/skills/migrating-journal-structures/SKILL.md
+++ b/templates/ai/skills/migrating-journal-structures/SKILL.md
@@ -68,6 +68,11 @@ ldev resource structure --site /<site> --structure <STRUCTURE_KEY> --json
 ldev resource template --site /<site> --template <TEMPLATE_ID> --json
 ```
 
+Use local `ldev` MCP tools for the inventory commands when visible:
+`liferay_inventory_structures` and `liferay_inventory_templates`. Resource
+reads, descriptor creation, validation, and migration execution remain CLI-first
+because they are file-backed or mutating workflows.
+
 ### 2. Scaffold a migration descriptor
 
 Use `migration-init` to generate a base descriptor from the current portal state
@@ -165,6 +170,9 @@ ldev portal reindex tasks --json
 - **Never run migrations against the main environment.** Always use the vendor
   skill `isolating-worktrees` first so the portal state can be restored or
   discarded if the migration fails or produces unexpected results.
+- Use MCP only for read-only inventory/diagnosis during migration work. Do not
+  use MCP as a shortcut around worktree isolation, `--check-only`, or explicit
+  migration approval.
 - Never treat a live content migration as a plain import.
 - Always keep a descriptor file under version control.
 - Always use `migration-init` to scaffold the descriptor; do not write it from scratch.

--- a/templates/ai/skills/troubleshooting-liferay/SKILL.md
+++ b/templates/ai/skills/troubleshooting-liferay/SKILL.md
@@ -52,12 +52,18 @@ ldev start
 
 ## Core diagnosis flow
 
+Use local `ldev` MCP tools for these structured diagnosis steps when visible.
+If they are not visible, use the CLI fallback commands shown below and keep
+going.
+
 ### Runtime health and logs
 
 ```bash
 ldev status --json
 ldev logs diagnose --since 10m --json
 ```
+
+MCP equivalents: `ldev_status`, `ldev_logs_diagnose`.
 
 Use raw logs only after the diagnosis report points to something that needs
 deeper inspection:
@@ -73,11 +79,16 @@ ldev osgi status <bundle-symbolic-name> --json
 ldev osgi diag <bundle-symbolic-name> --json
 ```
 
+MCP equivalents: `liferay_osgi_status`, `liferay_osgi_diag`.
+
 For a hanging or slow portal, collect a thread dump:
 
 ```bash
 ldev osgi thread-dump
 ```
+
+MCP equivalent: `liferay_osgi_thread_dump`. This writes dump artifacts under
+the configured dump directory, just like the CLI command.
 
 ### Portal discovery issues
 
@@ -91,6 +102,9 @@ ldev portal inventory page --url <fullUrl> --json
 ldev portal inventory structures --site /<site> --with-templates --json
 ldev portal inventory templates --site /<site> --json
 ```
+
+MCP equivalents: `liferay_inventory_page`, `liferay_inventory_structures`,
+`liferay_inventory_templates`.
 
 For structure/template incidents, treat `--with-templates` as the default
 discovery path to avoid separate lookup rounds.
@@ -172,6 +186,8 @@ ldev worktree env --json
 
 - Do not jump straight to rebuild or clean unless logs and status suggest local state corruption.
 - Do not assume a portal API problem when the env is simply down; `ldev status --json` is the first check.
+- If local `ldev` MCP tools are not available, use CLI fallbacks; MCP absence is
+  not a blocker for troubleshooting.
 - Do not parse human text if a stable JSON variant exists.
 - Prefer `ldev logs diagnose --json` as the first diagnosis surface; use raw logs as a follow-up tool.
 - If the issue depends on production data, reproduce that state locally before proposing fixes.

--- a/tests/unit/mcp-server-setup.test.ts
+++ b/tests/unit/mcp-server-setup.test.ts
@@ -1,0 +1,214 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {describe, expect, test, vi} from 'vitest';
+
+import {runMcpDoctor} from '../../src/features/mcp-server/mcp-server-doctor.js';
+import {runMcpSetup} from '../../src/features/mcp-server/mcp-server-setup.js';
+import {createTempDir} from '../../src/testing/temp-repo.js';
+
+vi.mock('../../src/core/platform/process.js', () => ({
+  runProcess: vi.fn((command: string, args: string[]) => {
+    if (command === 'node' || command === 'npx') {
+      return {
+        command: [command, ...args].join(' '),
+        stdout: command === 'node' ? 'v22.0.0' : '10.0.0',
+        stderr: '',
+        exitCode: 0,
+        ok: true,
+      };
+    }
+
+    return {
+      command: [command, ...args].join(' '),
+      stdout: '',
+      stderr: '',
+      exitCode: 1,
+      ok: false,
+    };
+  }),
+}));
+
+describe('mcp server setup', () => {
+  test('writes VS Code MCP config with servers format', async () => {
+    const targetDir = createTempDir('ldev-vscode-mcp-');
+
+    const result = await runMcpSetup({targetDir, tool: 'vscode'});
+
+    expect(result.configPath).toBe(path.join(targetDir, '.vscode', 'mcp.json'));
+    expect(result.strategy).toBe('npx');
+    expect(JSON.parse(fs.readFileSync(result.configPath, 'utf8'))).toEqual({
+      servers: {
+        ldev: {
+          type: 'stdio',
+          command: 'npx',
+          args: ['--package', '@mordonezdev/ldev', '-y', 'ldev-mcp-server'],
+        },
+      },
+    });
+  });
+
+  test('merges VS Code MCP config without dropping existing servers', async () => {
+    const targetDir = createTempDir('ldev-vscode-mcp-merge-');
+    const configPath = path.join(targetDir, '.vscode', 'mcp.json');
+    fs.mkdirSync(path.dirname(configPath), {recursive: true});
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({
+        servers: {
+          memory: {
+            type: 'stdio',
+            command: 'npx',
+            args: ['-y', '@modelcontextprotocol/server-memory'],
+          },
+        },
+      }),
+    );
+
+    const result = await runMcpSetup({targetDir, tool: 'vscode'});
+
+    expect(result.merged).toBe(true);
+    expect(JSON.parse(fs.readFileSync(configPath, 'utf8'))).toMatchObject({
+      servers: {
+        memory: {
+          type: 'stdio',
+          command: 'npx',
+          args: ['-y', '@modelcontextprotocol/server-memory'],
+        },
+        ldev: {
+          type: 'stdio',
+          command: 'npx',
+        },
+      },
+    });
+  });
+
+  test('keeps Claude Code config in legacy mcpServers format', async () => {
+    const targetDir = createTempDir('ldev-claude-mcp-');
+
+    const result = await runMcpSetup({targetDir, tool: 'claude-code'});
+
+    expect(result.configPath).toBe(path.join(targetDir, '.claude', 'mcp.json'));
+    expect(JSON.parse(fs.readFileSync(result.configPath, 'utf8'))).toEqual({
+      mcpServers: {
+        ldev: {
+          command: 'npx',
+          args: ['--package', '@mordonezdev/ldev', '-y', 'ldev-mcp-server'],
+        },
+      },
+    });
+  });
+
+  test('writes all client configs with an explicit local strategy', async () => {
+    const targetDir = createTempDir('ldev-all-mcp-');
+    fs.mkdirSync(path.join(targetDir, 'node_modules', '@mordonezdev', 'ldev', 'dist'), {recursive: true});
+
+    const result = await runMcpSetup({targetDir, tool: 'all', strategy: 'local'});
+
+    expect(result.tool).toBe('all');
+    expect(result.strategy).toBe('local');
+    expect(result.results).toHaveLength(3);
+    expect(JSON.parse(fs.readFileSync(path.join(targetDir, '.vscode', 'mcp.json'), 'utf8'))).toEqual({
+      servers: {
+        ldev: {
+          type: 'stdio',
+          command: 'node',
+          args: ['./node_modules/@mordonezdev/ldev/dist/mcp-server.js'],
+        },
+      },
+    });
+    expect(JSON.parse(fs.readFileSync(path.join(targetDir, '.claude', 'mcp.json'), 'utf8'))).toEqual({
+      mcpServers: {
+        ldev: {
+          command: 'node',
+          args: ['./node_modules/@mordonezdev/ldev/dist/mcp-server.js'],
+        },
+      },
+    });
+    expect(JSON.parse(fs.readFileSync(path.join(targetDir, '.cursor', 'mcp.json'), 'utf8'))).toEqual({
+      mcpServers: {
+        ldev: {
+          command: 'node',
+          args: ['./node_modules/@mordonezdev/ldev/dist/mcp-server.js'],
+        },
+      },
+    });
+  });
+
+  test('doctor validates all generated configs and command resolution without handshake', async () => {
+    const targetDir = createTempDir('ldev-mcp-doctor-');
+    fs.mkdirSync(path.join(targetDir, 'node_modules', '@mordonezdev', 'ldev', 'dist'), {recursive: true});
+    fs.writeFileSync(path.join(targetDir, 'node_modules', '@mordonezdev', 'ldev', 'dist', 'mcp-server.js'), '');
+    await runMcpSetup({targetDir, tool: 'all', strategy: 'local'});
+
+    const result = await runMcpDoctor({targetDir, tool: 'all', handshake: false});
+
+    expect(result.ok).toBe(true);
+    expect(result.checkedTools).toEqual(['claude-code', 'cursor', 'vscode']);
+    const vscodeResult = result.results.find((entry) => entry.tool === 'vscode');
+    const claudeResult = result.results.find((entry) => entry.tool === 'claude-code');
+    expect(vscodeResult?.configExists).toBe(true);
+    expect(vscodeResult?.configValid).toBe(true);
+    expect(vscodeResult?.configFormat).toBe('servers');
+    expect(vscodeResult?.command).toBe('node');
+    expect(vscodeResult?.commandCheck?.ok).toBe(true);
+    expect(vscodeResult?.commandCheck?.command).toBe(
+      'node ./node_modules/@mordonezdev/ldev/dist/mcp-server.js --version',
+    );
+    expect(claudeResult?.configExists).toBe(true);
+    expect(claudeResult?.configValid).toBe(true);
+    expect(claudeResult?.configFormat).toBe('mcpServers');
+    expect(claudeResult?.command).toBe('node');
+    expect(claudeResult?.commandCheck?.ok).toBe(true);
+    expect(claudeResult?.commandCheck?.command).toBe(
+      'node ./node_modules/@mordonezdev/ldev/dist/mcp-server.js --version',
+    );
+  });
+
+  test('doctor fails local strategy when configured script is missing', async () => {
+    const targetDir = createTempDir('ldev-mcp-doctor-missing-local-');
+    await runMcpSetup({targetDir, tool: 'vscode', strategy: 'local'});
+
+    const result = await runMcpDoctor({targetDir, tool: 'vscode', handshake: false});
+
+    expect(result.ok).toBe(false);
+    expect(result.results[0]?.commandCheck?.ok).toBe(false);
+    expect(result.results[0]?.commandCheck?.stderr).toContain('Configured MCP server script does not exist');
+    expect(result.results[0]?.handshake).toBeUndefined();
+  });
+
+  test('doctor validates npx strategy by running the configured command', async () => {
+    const targetDir = createTempDir('ldev-mcp-doctor-npx-');
+    await runMcpSetup({targetDir, tool: 'vscode', strategy: 'npx'});
+
+    const result = await runMcpDoctor({targetDir, tool: 'vscode', handshake: false});
+
+    expect(result.ok).toBe(true);
+    expect(result.results[0]?.commandCheck?.command).toBe(
+      'npx --package @mordonezdev/ldev -y ldev-mcp-server --version',
+    );
+  });
+
+  test('doctor rejects VS Code configs without stdio transport type', async () => {
+    const targetDir = createTempDir('ldev-mcp-doctor-invalid-vscode-');
+    const configPath = path.join(targetDir, '.vscode', 'mcp.json');
+    fs.mkdirSync(path.dirname(configPath), {recursive: true});
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({
+        servers: {
+          ldev: {
+            command: 'npx',
+            args: ['--package', '@mordonezdev/ldev', '-y', 'ldev-mcp-server'],
+          },
+        },
+      }),
+    );
+
+    const result = await runMcpDoctor({targetDir, tool: 'vscode', handshake: false});
+
+    expect(result.ok).toBe(false);
+    expect(result.results[0]?.configValid).toBe(false);
+    expect(result.results[0]?.error).toBe('Could not find ldev server config.');
+  });
+});

--- a/tests/unit/mcp-server-tools.test.ts
+++ b/tests/unit/mcp-server-tools.test.ts
@@ -1,0 +1,36 @@
+import {describe, expect, test} from 'vitest';
+
+import {ALL_TOOLS} from '../../src/features/mcp-server/mcp-server-tools.js';
+import {jsonToolResult} from '../../src/features/mcp-server/tools/tool-result.js';
+
+describe('mcp server tools', () => {
+  test('registers the primary agent-facing tools', () => {
+    const toolNames = ALL_TOOLS.map((tool) => tool.TOOL_NAME);
+
+    expect(new Set(toolNames).size).toBe(toolNames.length);
+    expect(toolNames).toEqual([
+      'ldev_context',
+      'liferay_check',
+      'ldev_status',
+      'ldev_logs_diagnose',
+      'liferay_inventory_sites',
+      'liferay_inventory_structures',
+      'liferay_inventory_pages',
+      'liferay_inventory_page',
+      'liferay_doctor',
+      'liferay_inventory_templates',
+      'liferay_deploy_status',
+      'liferay_osgi_status',
+      'liferay_osgi_diag',
+      'liferay_osgi_thread_dump',
+      'liferay_mcp_check',
+    ]);
+  });
+
+  test('returns structured content while keeping text JSON compatibility', () => {
+    const result = jsonToolResult({ok: true, count: 2});
+
+    expect(result.structuredContent).toEqual({ok: true, count: 2});
+    expect(result.content[0]).toEqual({type: 'text', text: '{\n  "ok": true,\n  "count": 2\n}'});
+  });
+});

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,7 +1,7 @@
 import {defineConfig} from 'tsdown';
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  entry: ['src/index.ts', 'src/mcp-server.ts'],
   format: ['esm'],
   platform: 'node',
   clean: true,


### PR DESCRIPTION
## Summary

- expand the local ldev MCP server with setup support for VS Code, `--tool all`, launch strategies, and `ldev mcp doctor`
- add primary agent-facing MCP tools for context, portal checks, status, log diagnosis, OSGi diagnosis, and thread dumps
- return structured MCP tool content while preserving JSON text compatibility
- document the MCP decision route, command inventory, and README usage flow

## Validation

- `npm run typecheck`
- `npm run lint` (passes with existing `agent-context.ts` max-lines warning)
- `npm run format:check`
- `npm run build`
- `npm run test:unit`
- `npm run test:smoke`
- `npm run docs:build`
- `npm run verify:ai-templates`
- `node dist/index.js mcp doctor --target C:\Users\mordonez\Development\GitHub\labweb.worktrees\testworktree --tool vscode --json`