### PR TITLE
feat(resource): fall back to cwd for file paths when no repo root

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -197,6 +197,29 @@ All errors should flow through CLI error normalization. Domain error factories p
 
 Do not put plaintext OAuth secrets or passwords in versioned project files.
 
+### Remote portal (no local repo)
+
+`ldev` can operate against a remote Liferay instance without a local project repository. Set the three required environment variables and run from any directory:
+
+```bash
+export LIFERAY_CLI_URL=https://remote.portal.com
+export LIFERAY_CLI_OAUTH2_CLIENT_ID=<client-id>
+export LIFERAY_CLI_OAUTH2_CLIENT_SECRET=<client-secret>
+
+ldev portal inventory sites
+ldev portal inventory structures --site /global
+ldev resource structure --site /global --structure BASIC
+ldev resource template --site /global --template NEWS_TEMPLATE
+ldev resource adt --site /global --adt SEARCH_RESULTS --widget-type search-result-summary
+```
+
+For resource commands that read from or write to local files (export, import, sync), pass an absolute path with `--file` or `--dir`. When no `--file` is given, relative paths are resolved against `cwd` instead of a repo root:
+
+```bash
+ldev resource export-structure --site /global --structure BASIC --file /tmp/BASIC.json
+ldev resource import-structure --site /global --structure BASIC --file /tmp/BASIC.json
+```
+
 ## Safety Invariants
 
 - Always discover the target project and portal before mutating state.

--- a/README.md
+++ b/README.md
@@ -152,6 +152,19 @@ ldev oauth install --write-env
 To use it on top of an existing Liferay Workspace, just run `ldev` from the
 workspace root — it detects Blade workspaces and adapts.
 
+To query a remote portal without a local repo, set three environment variables
+and run from any directory:
+
+```bash
+export LIFERAY_CLI_URL=https://remote.portal.com
+export LIFERAY_CLI_OAUTH2_CLIENT_ID=<client-id>
+export LIFERAY_CLI_OAUTH2_CLIENT_SECRET=<client-secret>
+
+ldev portal inventory sites
+ldev resource structure --site /global --structure BASIC
+ldev resource export-structure --site /global --structure BASIC --file /tmp/BASIC.json
+```
+
 ## Dashboard
 
 `ldev dashboard` gives you a local control surface for the operational loop:

--- a/src/features/liferay/portal/artifact-paths.ts
+++ b/src/features/liferay/portal/artifact-paths.ts
@@ -43,6 +43,15 @@ export function resolveRepoPath(config: AppConfig, relativePath: string): string
   return path.resolve(requireRepoRoot(config), relativePath);
 }
 
+/**
+ * Resolves a path relative to the repo root when available, falling back to cwd.
+ * Use this instead of resolveRepoPath for resource file paths that should work
+ * even when ldev is invoked outside a project repository (remote portal mode).
+ */
+export function resolveBasePath(config: AppConfig, relativePath: string): string {
+  return path.resolve(config.repoRoot ?? config.cwd, relativePath);
+}
+
 export function tryResolveRepoPath(config: AppConfig, relativePath: string): string | undefined {
   if (!config.repoRoot) {
     return undefined;
@@ -52,19 +61,19 @@ export function tryResolveRepoPath(config: AppConfig, relativePath: string): str
 }
 
 export function resolveStructuresBaseDir(config: AppConfig): string {
-  return resolveRepoPath(config, config.paths?.structures ?? LIFERAY_RESOURCE_PATH_DEFAULTS.structures);
+  return resolveBasePath(config, config.paths?.structures ?? LIFERAY_RESOURCE_PATH_DEFAULTS.structures);
 }
 
 export function resolveTemplatesBaseDir(config: AppConfig): string {
-  return resolveRepoPath(config, config.paths?.templates ?? LIFERAY_RESOURCE_PATH_DEFAULTS.templates);
+  return resolveBasePath(config, config.paths?.templates ?? LIFERAY_RESOURCE_PATH_DEFAULTS.templates);
 }
 
 export function resolveAdtsBaseDir(config: AppConfig): string {
-  return resolveRepoPath(config, config.paths?.adts ?? LIFERAY_RESOURCE_PATH_DEFAULTS.adts);
+  return resolveBasePath(config, config.paths?.adts ?? LIFERAY_RESOURCE_PATH_DEFAULTS.adts);
 }
 
 export function resolveFragmentsBaseDir(config: AppConfig): string {
-  return resolveRepoPath(config, config.paths?.fragments ?? LIFERAY_RESOURCE_PATH_DEFAULTS.fragments);
+  return resolveBasePath(config, config.paths?.fragments ?? LIFERAY_RESOURCE_PATH_DEFAULTS.fragments);
 }
 
 export function tryResolveFragmentsBaseDir(config: AppConfig): string | undefined {
@@ -72,7 +81,7 @@ export function tryResolveFragmentsBaseDir(config: AppConfig): string | undefine
 }
 
 export function resolveMigrationsBaseDir(config: AppConfig): string {
-  return resolveRepoPath(config, config.paths?.migrations ?? LIFERAY_RESOURCE_PATH_DEFAULTS.migrations);
+  return resolveBasePath(config, config.paths?.migrations ?? LIFERAY_RESOURCE_PATH_DEFAULTS.migrations);
 }
 
 type ResolveArtifactFileOptions =
@@ -104,7 +113,7 @@ export function sanitizeArtifactToken(value: string): string {
 
 export function resolveArtifactBaseDir(config: AppConfig, type: ArtifactType, dirOverride?: string): string {
   if (dirOverride?.trim()) {
-    return path.resolve(resolveRepoPath(config, dirOverride));
+    return path.resolve(resolveBasePath(config, dirOverride));
   }
   switch (type) {
     case 'template':
@@ -184,7 +193,7 @@ export function resolveArtifactSiteDir(
 ): string {
   if (type === 'fragment') {
     if (dirOverride?.trim()) {
-      return path.resolve(resolveRepoPath(config, dirOverride));
+      return path.resolve(resolveBasePath(config, dirOverride));
     }
     return path.join(resolveFragmentsBaseDir(config), 'sites', siteToken);
   }
@@ -216,7 +225,7 @@ export function resolveFragmentProjectDir(config: AppConfig, siteToken: string, 
   }
 
   const configuredDir = (dirOverride ?? '').trim();
-  const configured = path.resolve(resolveRepoPath(config, configuredDir));
+  const configured = path.resolve(resolveBasePath(config, configuredDir));
   const detectedFromConfigured = detectFragmentsProjectRoot(configured);
   if (detectedFromConfigured) {
     return detectedFromConfigured;
@@ -324,15 +333,14 @@ async function resolveAdtArtifactFile(config: AppConfig, key: string, widgetType
 }
 
 async function resolveExistingArtifactFile(config: AppConfig, fileOverride: string): Promise<string> {
-  const repoRoot = requireRepoRoot(config);
   const direct = path.resolve(fileOverride);
   if (await fs.pathExists(direct)) {
     return direct;
   }
 
-  const relativeToRepo = path.resolve(repoRoot, fileOverride);
-  if (await fs.pathExists(relativeToRepo)) {
-    return relativeToRepo;
+  const relativeToBase = path.resolve(config.repoRoot ?? config.cwd, fileOverride);
+  if (await fs.pathExists(relativeToBase)) {
+    return relativeToBase;
   }
 
   for (const baseDir of [

--- a/tests/unit/liferay-artifact-paths.test.ts
+++ b/tests/unit/liferay-artifact-paths.test.ts
@@ -13,6 +13,11 @@ import {
   tryResolveArtifactBaseDir,
   tryResolveArtifactSiteDir,
   tryResolveFragmentsBaseDir,
+  resolveStructuresBaseDir,
+  resolveTemplatesBaseDir,
+  resolveAdtsBaseDir,
+  resolveFragmentsBaseDir,
+  resolveMigrationsBaseDir,
   type ArtifactType,
 } from '../../src/features/liferay/portal/artifact-paths.js';
 import {createTempDir} from '../../src/testing/temp-repo.js';
@@ -462,5 +467,103 @@ describe('resolveFragmentProjectDir', () => {
     config.cwd = repoRoot;
 
     expect(resolveFragmentProjectDir(config, 'guest', 'custom-fragments')).toBe(siteDir);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// No-repo mode: repoRoot is null, cwd is used as fallback base
+// ---------------------------------------------------------------------------
+
+const CWD = path.resolve('/work');
+
+function makeConfigNoRepo(cwd = CWD) {
+  return {
+    repoRoot: null,
+    cwd,
+    paths: {
+      templates: 'liferay/resources/journal/templates',
+      structures: 'liferay/resources/journal/structures',
+      adts: 'liferay/resources/templates/application_display',
+      fragments: 'liferay/fragments',
+      migrations: 'liferay/resources/journal/migrations',
+    },
+  } as Parameters<typeof resolveArtifactBaseDir>[0];
+}
+
+describe('no-repo fallback: base dir functions use cwd when repoRoot is null', () => {
+  const cfg = makeConfigNoRepo();
+
+  test('resolveStructuresBaseDir falls back to cwd', () => {
+    expect(resolveStructuresBaseDir(cfg)).toBe(path.join(CWD, 'liferay/resources/journal/structures'));
+  });
+
+  test('resolveTemplatesBaseDir falls back to cwd', () => {
+    expect(resolveTemplatesBaseDir(cfg)).toBe(path.join(CWD, 'liferay/resources/journal/templates'));
+  });
+
+  test('resolveAdtsBaseDir falls back to cwd', () => {
+    expect(resolveAdtsBaseDir(cfg)).toBe(path.join(CWD, 'liferay/resources/templates/application_display'));
+  });
+
+  test('resolveFragmentsBaseDir falls back to cwd', () => {
+    expect(resolveFragmentsBaseDir(cfg)).toBe(path.join(CWD, 'liferay/fragments'));
+  });
+
+  test('resolveMigrationsBaseDir falls back to cwd', () => {
+    expect(resolveMigrationsBaseDir(cfg)).toBe(path.join(CWD, 'liferay/resources/journal/migrations'));
+  });
+});
+
+describe('no-repo fallback: resolveArtifactBaseDir uses cwd when repoRoot is null', () => {
+  const cfg = makeConfigNoRepo();
+
+  test.each(['template', 'structure', 'adt', 'fragment'] as ArtifactType[])(
+    '%s: default dir is resolved against cwd',
+    (type) => {
+      const result = resolveArtifactBaseDir(cfg, type);
+      expect(result.startsWith(CWD)).toBe(true);
+    },
+  );
+
+  test.each(['template', 'structure', 'adt', 'fragment'] as ArtifactType[])(
+    '%s: relative dirOverride resolved against cwd',
+    (type) => {
+      expect(resolveArtifactBaseDir(cfg, type, 'out/resources')).toBe(path.join(CWD, 'out/resources'));
+    },
+  );
+
+  test.each(['template', 'structure', 'adt', 'fragment'] as ArtifactType[])(
+    '%s: absolute dirOverride still used as-is',
+    (type) => {
+      const override = path.resolve('/absolute/dir');
+      expect(resolveArtifactBaseDir(cfg, type, override)).toBe(override);
+    },
+  );
+});
+
+describe('no-repo fallback: resolveArtifactFile with fileOverride resolves against cwd', () => {
+  test('absolute fileOverride is found without a repo', async () => {
+    const cwd = createTempDir('artifact-paths-no-repo-abs-');
+    const filePath = path.join(cwd, 'NEWS.json');
+    await fs.writeFile(filePath, '{}');
+
+    const cfg = makeConfigNoRepo(cwd);
+
+    await expect(resolveArtifactFile(cfg, {type: 'structure', key: 'NEWS', fileOverride: filePath})).resolves.toBe(
+      filePath,
+    );
+  });
+
+  test('relative fileOverride is resolved against cwd when repoRoot is null', async () => {
+    const cwd = createTempDir('artifact-paths-no-repo-rel-');
+    const filePath = path.join(cwd, 'custom', 'NEWS.json');
+    await fs.ensureDir(path.dirname(filePath));
+    await fs.writeFile(filePath, '{}');
+
+    const cfg = makeConfigNoRepo(cwd);
+
+    await expect(
+      resolveArtifactFile(cfg, {type: 'structure', key: 'NEWS', fileOverride: 'custom/NEWS.json'}),
+    ).resolves.toBe(filePath);
   });
 });


### PR DESCRIPTION
## Summary

Allows `ldev portal` and `ldev resource` commands to work against a remote Liferay instance without a local project repository.

## Problem

Resource file path functions called `requireRepoRoot`, which throws when `repoRoot` is `null`. This blocked any file-based resource operation when running outside a Blade workspace.

## Solution

Add `resolveBasePath(config, relativePath)` that picks `config.repoRoot ?? config.cwd`. All base-dir functions (`resolveStructuresBaseDir`, `resolveTemplatesBaseDir`, `resolveAdtsBaseDir`, `resolveFragmentsBaseDir`, `resolveMigrationsBaseDir`) and `resolveExistingArtifactFile` now use this helper instead of `requireRepoRoot`.

`requireRepoRoot` is kept where a Blade workspace is genuinely required (runtime adapter).

## Usage

```bash
export LIFERAY_CLI_URL=https://remote.portal.com
export LIFERAY_CLI_OAUTH2_CLIENT_ID=<client-id>
export LIFERAY_CLI_OAUTH2_CLIENT_SECRET=<client-secret>

ldev portal inventory sites
ldev resource structure --site /global --structure BASIC
ldev resource export-structure --site /global --structure BASIC --file /tmp/BASIC.json
```

## Changes

- `artifact-paths.ts` — add `resolveBasePath`, update path resolution functions
- `liferay-artifact-paths.test.ts` — 19 new tests for no-repo fallback (1331 total)
- `CONTEXT.md` / `README.md` — remote portal documentation