### PR TITLE
feat(worktree): add inspection commands

### DIFF
--- a/docs/advanced/worktrees.md
+++ b/docs/advanced/worktrees.md
@@ -20,6 +20,17 @@ cd .worktrees/incident-123
 ldev start
 ```
 
+Inspect registered worktrees without guessing from port scans:
+
+```bash
+ldev worktree list
+ldev worktree status incident-123
+```
+
+`list` and `status` report the configured ports, Compose project name, portal
+URL and whether Docker currently has running containers for that worktree's
+`com.docker.compose.project` label.
+
 If you already created a linked git worktree manually outside `.worktrees/`, run
 `ldev worktree setup` from inside that checkout to wire its local environment in
 place:

--- a/docs/commands/advanced.md
+++ b/docs/commands/advanced.md
@@ -36,6 +36,8 @@ ldev start
 
 ldev worktree start incident-123
 ldev worktree env --name incident-123
+ldev worktree list
+ldev worktree status incident-123
 ldev worktree clean incident-123 --force
 ldev worktree clean incident-123 --force --delete-branch
 ldev worktree gc --days 14
@@ -48,6 +50,8 @@ ldev worktree gc --days 14 --apply
 - `setup --restart-main-after-clone` — opt-in: after an automatic stop, start main again without waiting for full portal readiness
 - `start` — prepare and start the worktree's local env
 - `env` — prepare or inspect the worktree's local env wiring
+- `list` — show registered worktrees with Compose project, runtime status and ports
+- `status` — inspect one worktree without relying on generic port scans
 - `clean` — destructive; requires `--force`; optionally deletes `fix/<name>` branch
 - `gc` — preview (default) or `--apply` removal of stale worktrees older than `--days`
 

--- a/src/commands/worktree/worktree-commands-maintenance.ts
+++ b/src/commands/worktree/worktree-commands-maintenance.ts
@@ -11,6 +11,12 @@ import {
 } from '../../features/worktree/worktree-btrfs-refresh-base.js';
 import {formatWorktreeClean, runWorktreeClean} from '../../features/worktree/worktree-clean.js';
 import {formatWorktreeGc, runWorktreeGc} from '../../features/worktree/worktree-gc.js';
+import {
+  formatWorktreeList,
+  formatWorktreeStatus,
+  runWorktreeList,
+  runWorktreeStatus,
+} from '../../features/worktree/worktree-inspect.js';
 
 type WorktreeCleanCommandOptions = {
   force?: boolean;
@@ -23,6 +29,40 @@ type WorktreeGcCommandOptions = {
 };
 
 export function registerWorktreeMaintenanceCommands(command: Command): void {
+  addOutputFormatOption(
+    command
+      .command('list')
+      .helpGroup('Inspection commands:')
+      .description('List registered worktrees with runtime ownership and port summary'),
+  ).action(
+    createFormattedAction(
+      async (context) =>
+        runWorktreeList({
+          cwd: context.cwd,
+          processEnv: process.env,
+        }),
+      {text: formatWorktreeList},
+    ),
+  );
+
+  addOutputFormatOption(
+    command
+      .command('status')
+      .helpGroup('Inspection commands:')
+      .description('Show runtime ownership and ports for one registered worktree')
+      .argument('[name]', 'Worktree name; optional when running inside the target worktree'),
+  ).action(
+    createFormattedArgumentAction(
+      async (context, name: string | undefined) =>
+        runWorktreeStatus({
+          cwd: context.cwd,
+          name,
+          processEnv: process.env,
+        }),
+      {text: formatWorktreeStatus},
+    ),
+  );
+
   addOutputFormatOption(
     command
       .command('clean')

--- a/src/commands/worktree/worktree.command.ts
+++ b/src/commands/worktree/worktree.command.ts
@@ -18,7 +18,11 @@ Typical flow:
   cd .worktrees/issue-123
   ldev start
 
-Destructive commands:
+Inspection commands:
+  list            Show registered worktrees, ports, and runtime ownership
+  status          Inspect one registered worktree
+
+Maintenance commands:
   clean           Remove runtime data and the git worktree; requires --force
   gc --apply      Remove stale worktrees selected by age
 `,

--- a/src/features/worktree/worktree-flow.ts
+++ b/src/features/worktree/worktree-flow.ts
@@ -1,6 +1,6 @@
 import {loadConfig, type AppConfig} from '../../core/config/load-config.js';
 import {detectCapabilities} from '../../core/platform/capabilities.js';
-import {isGitRepository} from '../../core/platform/git.js';
+import {getRepoRoot, isGitRepository} from '../../core/platform/git.js';
 
 import {WorktreeErrors} from './errors/worktree-error-factory.js';
 import {resolveWorktreeContext, type WorktreeContext} from './worktree-paths.js';
@@ -12,7 +12,8 @@ export type WorktreeFlowContext = {
 
 export async function prepareWorktreeFlow(options: {cwd: string; commandName: string}): Promise<WorktreeFlowContext> {
   const config = loadConfig({cwd: options.cwd, env: process.env});
-  if (!config.repoRoot || !(await isGitRepository(config.repoRoot))) {
+  const repoRoot = config.repoRoot ?? (await getRepoRoot(options.cwd));
+  if (!repoRoot || !(await isGitRepository(repoRoot))) {
     throw WorktreeErrors.repoNotFound(`worktree ${options.commandName} must be run inside a valid git repository.`);
   }
 
@@ -22,7 +23,10 @@ export async function prepareWorktreeFlow(options: {cwd: string; commandName: st
   }
 
   return {
-    config,
-    context: resolveWorktreeContext(config.repoRoot),
+    config: {
+      ...config,
+      repoRoot,
+    },
+    context: resolveWorktreeContext(repoRoot),
   };
 }

--- a/src/features/worktree/worktree-inspect.ts
+++ b/src/features/worktree/worktree-inspect.ts
@@ -1,0 +1,254 @@
+import path from 'node:path';
+
+import fs from 'fs-extra';
+
+import {readEnvFile} from '../../core/config/env-file.js';
+import {CliError} from '../../core/errors.js';
+import {areSamePath, listGitWorktreeDetails, type GitWorktreeInfo} from '../../core/platform/git.js';
+import {runDocker} from '../../core/platform/docker.js';
+import {prepareWorktreeFlow} from './worktree-flow.js';
+import {resolvePortSet, resolveWorktreeTargetForContext} from './worktree-paths.js';
+
+type DockerRunner = typeof runDocker;
+
+export type WorktreeRuntimeStatus = 'running' | 'stopped' | 'unknown';
+
+export type WorktreeInspectEntry = {
+  name: string;
+  path: string;
+  branch: string | null;
+  isMain: boolean;
+  detached: boolean;
+  prunable: boolean;
+  envFile: string;
+  envConfigured: boolean;
+  composeProjectName: string | null;
+  runtimeStatus: WorktreeRuntimeStatus;
+  runningContainers: number;
+  portalUrl: string | null;
+  ports: {
+    httpPort: string | null;
+    debugPort: string | null;
+    gogoPort: string | null;
+    postgresPort: string | null;
+    esHttpPort: string | null;
+  };
+};
+
+export type WorktreeListResult = {
+  ok: true;
+  worktrees: WorktreeInspectEntry[];
+};
+
+export type WorktreeStatusResult = {
+  ok: true;
+  worktree: WorktreeInspectEntry;
+};
+
+export async function runWorktreeList(options: {
+  cwd: string;
+  processEnv?: NodeJS.ProcessEnv;
+  docker?: DockerRunner;
+}): Promise<WorktreeListResult> {
+  const {context} = await prepareWorktreeFlow({cwd: options.cwd, commandName: 'list'});
+  const registered = await listGitWorktreeDetails(context.mainRepoRoot);
+  const mainEnvValues = await readOptionalEnvFile(path.join(context.mainRepoRoot, 'docker', '.env'));
+  const mainComposeProject = mainEnvValues.COMPOSE_PROJECT_NAME || 'liferay';
+
+  const worktrees = await Promise.all(
+    registered.map((worktree) =>
+      inspectRegisteredWorktree({
+        worktree,
+        mainRepoRoot: context.mainRepoRoot,
+        mainComposeProject,
+        processEnv: options.processEnv,
+        docker: options.docker ?? runDocker,
+      }),
+    ),
+  );
+
+  return {ok: true, worktrees};
+}
+
+export async function runWorktreeStatus(options: {
+  cwd: string;
+  name?: string;
+  processEnv?: NodeJS.ProcessEnv;
+  docker?: DockerRunner;
+}): Promise<WorktreeStatusResult> {
+  const {context} = await prepareWorktreeFlow({cwd: options.cwd, commandName: 'status'});
+  const registered = await listGitWorktreeDetails(context.mainRepoRoot);
+  const explicitName = options.name?.trim();
+  const namedWorktree = explicitName
+    ? registered.find((worktree) => resolveDisplayName(worktree, context.mainRepoRoot) === explicitName)
+    : undefined;
+  const target =
+    explicitName && !namedWorktree
+      ? resolveWorktreeTargetForContext(context, explicitName, registered)
+      : !explicitName && context.isWorktree
+        ? resolveWorktreeTargetForContext(context, undefined, registered)
+        : null;
+
+  const selected =
+    namedWorktree ??
+    (target
+      ? registered.find((worktree) => areSamePath(worktree.path, target.worktreeDir))
+      : registered.find((worktree) => areSamePath(worktree.path, context.currentRepoRoot)));
+
+  if (!selected) {
+    const label = options.name ?? context.currentWorktreeName ?? path.basename(context.currentRepoRoot);
+    throw new CliError(`Worktree '${label}' is not registered.`, {code: 'WORKTREE_NOT_REGISTERED'});
+  }
+
+  const mainEnvValues = await readOptionalEnvFile(path.join(context.mainRepoRoot, 'docker', '.env'));
+  const mainComposeProject = mainEnvValues.COMPOSE_PROJECT_NAME || 'liferay';
+  const worktree = await inspectRegisteredWorktree({
+    worktree: selected,
+    mainRepoRoot: context.mainRepoRoot,
+    mainComposeProject,
+    processEnv: options.processEnv,
+    docker: options.docker ?? runDocker,
+  });
+
+  return {ok: true, worktree};
+}
+
+export function formatWorktreeList(result: WorktreeListResult): string {
+  if (result.worktrees.length === 0) {
+    return 'No registered worktrees found.';
+  }
+
+  return formatTable(
+    ['Name', 'Branch', 'Runtime', 'HTTP', 'Compose project', 'Path'],
+    result.worktrees.map((entry) => [
+      entry.name,
+      entry.branch ?? (entry.detached ? '(detached)' : '-'),
+      formatRuntime(entry),
+      entry.ports.httpPort ?? '-',
+      entry.composeProjectName ?? '-',
+      entry.path,
+    ]),
+  );
+}
+
+export function formatWorktreeStatus(result: WorktreeStatusResult): string {
+  const entry = result.worktree;
+  const lines = [
+    `Worktree: ${entry.name}`,
+    `Path: ${entry.path}`,
+    `Branch: ${entry.branch ?? (entry.detached ? '(detached)' : '-')}`,
+    `Runtime: ${formatRuntime(entry)}`,
+    `Compose project: ${entry.composeProjectName ?? '-'}`,
+    `Portal URL: ${entry.portalUrl ?? '-'}`,
+    `Env file: ${entry.envConfigured ? entry.envFile : 'not configured'}`,
+  ];
+
+  lines.push(
+    `Ports: http=${entry.ports.httpPort ?? '-'} debug=${entry.ports.debugPort ?? '-'} gogo=${
+      entry.ports.gogoPort ?? '-'
+    } postgres=${entry.ports.postgresPort ?? '-'} es=${entry.ports.esHttpPort ?? '-'}`,
+  );
+
+  return lines.join('\n');
+}
+
+async function inspectRegisteredWorktree(options: {
+  worktree: GitWorktreeInfo;
+  mainRepoRoot: string;
+  mainComposeProject: string;
+  processEnv?: NodeJS.ProcessEnv;
+  docker: DockerRunner;
+}): Promise<WorktreeInspectEntry> {
+  const isMain = areSamePath(options.worktree.path, options.mainRepoRoot);
+  const name = resolveDisplayName(options.worktree, options.mainRepoRoot);
+  const envFile = path.join(options.worktree.path, 'docker', '.env');
+  const hasEnvFile = await fs.pathExists(envFile);
+  const envValues = await readOptionalEnvFile(envFile);
+  const envConfigured = Object.keys(envValues).length > 0 || hasEnvFile;
+  const fallbackPorts = !isMain && hasEnvFile ? resolvePortSet(name) : null;
+  const httpPort = envValues.LIFERAY_HTTP_PORT ?? fallbackPorts?.httpPort ?? null;
+  const bindIp = envValues.BIND_IP || '127.0.0.1';
+  const composeProjectName = envValues.COMPOSE_PROJECT_NAME ?? (isMain ? options.mainComposeProject : null);
+  const runningContainers = composeProjectName
+    ? await countRunningComposeContainers(composeProjectName, options.docker, options.processEnv)
+    : null;
+
+  return {
+    name,
+    path: options.worktree.path,
+    branch: options.worktree.branch,
+    isMain,
+    detached: options.worktree.detached,
+    prunable: options.worktree.prunable,
+    envFile,
+    envConfigured,
+    composeProjectName,
+    runtimeStatus: runningContainers === null ? 'unknown' : runningContainers > 0 ? 'running' : 'stopped',
+    runningContainers: runningContainers ?? 0,
+    portalUrl: httpPort ? `http://${bindIp}:${httpPort}` : null,
+    ports: {
+      httpPort,
+      debugPort: envValues.LIFERAY_DEBUG_PORT ?? fallbackPorts?.debugPort ?? null,
+      gogoPort: envValues.GOGO_PORT ?? fallbackPorts?.gogoPort ?? null,
+      postgresPort: envValues.POSTGRES_PORT ?? fallbackPorts?.postgresPort ?? null,
+      esHttpPort: envValues.ES_HTTP_PORT ?? fallbackPorts?.esHttpPort ?? null,
+    },
+  };
+}
+
+function resolveDisplayName(worktree: GitWorktreeInfo, mainRepoRoot: string): string {
+  return areSamePath(worktree.path, mainRepoRoot) ? path.basename(mainRepoRoot) : path.basename(worktree.path);
+}
+
+async function readOptionalEnvFile(filePath: string): Promise<Partial<Record<string, string>>> {
+  if (!(await fs.pathExists(filePath))) {
+    return {};
+  }
+
+  return readEnvFile(filePath);
+}
+
+async function countRunningComposeContainers(
+  composeProjectName: string,
+  docker: DockerRunner,
+  processEnv?: NodeJS.ProcessEnv,
+): Promise<number | null> {
+  const result = await docker(['ps', '-q', '--filter', `label=com.docker.compose.project=${composeProjectName}`], {
+    env: processEnv,
+    reject: false,
+  });
+
+  if (!result.ok) {
+    return null;
+  }
+
+  return result.stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean).length;
+}
+
+function formatRuntime(entry: WorktreeInspectEntry): string {
+  if (entry.runtimeStatus === 'running') {
+    return `running (${entry.runningContainers})`;
+  }
+
+  if (entry.runtimeStatus === 'unknown') {
+    return 'unknown';
+  }
+
+  return 'stopped';
+}
+
+function formatTable(headers: string[], rows: string[][]): string {
+  const widths = headers.map((header, index) =>
+    Math.max(header.length, ...rows.map((row) => (row[index] ?? '').length)),
+  );
+  const formatRow = (row: string[]) =>
+    row
+      .map((cell, index) => cell.padEnd(widths[index]))
+      .join('  ')
+      .trimEnd();
+
+  return [formatRow(headers), formatRow(widths.map((width) => '-'.repeat(width))), ...rows.map(formatRow)].join('\n');
+}

--- a/templates/ai/skills/isolating-worktrees/SKILL.md
+++ b/templates/ai/skills/isolating-worktrees/SKILL.md
@@ -36,7 +36,8 @@ Do not use this skill when:
 6. Immediately after creating a new worktree, `cd .worktrees/<worktree-name>` and confirm the root with `git rev-parse --show-toplevel`. Do not run any further commands until the root is confirmed. If you cannot confirm that the current directory is inside `.worktrees/<worktree-name>`, stop and ask the user to confirm the working directory before continuing.
 7. For runtime-backed worktrees, run `ldev start` **from inside the active worktree directory**, then `ldev status --json`, and wait for startup logs before portal-facing actions. If `ldev start` would run from the main checkout, stop and ask the user which runtime to start instead of proceeding autonomously.
 8. Keep the confirmed root as an active edit boundary for the whole task.
-9. Clean up only after explicit human approval.
+9. Use `ldev worktree status --json` or `ldev worktree list --json` to inspect runtime ownership and ports. Do not infer worktree ownership from port reachability alone.
+10. Clean up only after explicit human approval.
 
 ## Reference
 

--- a/templates/ai/skills/isolating-worktrees/references/worktree-flow.md
+++ b/templates/ai/skills/isolating-worktrees/references/worktree-flow.md
@@ -93,9 +93,15 @@ logs confirm startup completion.
 
 ```bash
 ldev context --json
+ldev worktree list --json
+ldev worktree status --json
 ldev logs --since 5m --no-follow
 ldev worktree env --json
 ```
+
+Use `ldev worktree list/status` for ownership and port inspection. They report
+the configured Compose project and running containers for that worktree; do not
+use generic port scans to decide which worktree owns a runtime.
 
 If read-only discovery must target the main runtime while you stay inside the
 worktree, prefix commands with `ldev --repo-root <main-root>` instead of

--- a/tests/unit/worktree-flow.test.ts
+++ b/tests/unit/worktree-flow.test.ts
@@ -1,0 +1,56 @@
+import path from 'node:path';
+
+import {beforeEach, describe, expect, test, vi} from 'vitest';
+
+const loadConfigMock = vi.fn();
+const detectCapabilitiesMock = vi.fn();
+const getRepoRootMock = vi.fn();
+const isGitRepositoryMock = vi.fn();
+
+vi.mock('../../src/core/config/load-config.js', () => ({
+  loadConfig: loadConfigMock,
+}));
+
+vi.mock('../../src/core/platform/capabilities.js', () => ({
+  detectCapabilities: detectCapabilitiesMock,
+}));
+
+vi.mock('../../src/core/platform/git.js', () => ({
+  getRepoRoot: getRepoRootMock,
+  isGitRepository: isGitRepositoryMock,
+  resolveLinkedGitWorktree: () => null,
+}));
+
+const {prepareWorktreeFlow} = await import('../../src/features/worktree/worktree-flow.js');
+
+describe('prepareWorktreeFlow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    detectCapabilitiesMock.mockResolvedValue({supportsWorktrees: true});
+    isGitRepositoryMock.mockResolvedValue(true);
+  });
+
+  test('falls back to git repo root when ldev config has no repo root', async () => {
+    loadConfigMock.mockReturnValue({cwd: '/repo/subdir', repoRoot: null});
+    getRepoRootMock.mockResolvedValue('/repo');
+
+    const result = await prepareWorktreeFlow({cwd: '/repo/subdir', commandName: 'list'});
+
+    expect(getRepoRootMock).toHaveBeenCalledWith('/repo/subdir');
+    expect(result.config.repoRoot).toBe('/repo');
+    expect(result.context).toMatchObject({
+      currentRepoRoot: path.resolve('/repo'),
+      mainRepoRoot: path.resolve('/repo'),
+      isWorktree: false,
+    });
+  });
+
+  test('uses the configured repo root when present', async () => {
+    loadConfigMock.mockReturnValue({cwd: '/repo', repoRoot: '/repo'});
+
+    const result = await prepareWorktreeFlow({cwd: '/repo', commandName: 'setup'});
+
+    expect(getRepoRootMock).not.toHaveBeenCalled();
+    expect(result.config.repoRoot).toBe('/repo');
+  });
+});

--- a/tests/unit/worktree-inspect.test.ts
+++ b/tests/unit/worktree-inspect.test.ts
@@ -1,0 +1,186 @@
+import os from 'node:os';
+import path from 'node:path';
+
+import fs from 'fs-extra';
+import {beforeEach, describe, expect, test, vi} from 'vitest';
+
+const prepareWorktreeFlowMock = vi.fn();
+const listGitWorktreeDetailsMock = vi.fn();
+
+vi.mock('../../src/features/worktree/worktree-flow.js', () => ({
+  prepareWorktreeFlow: prepareWorktreeFlowMock,
+}));
+
+vi.mock('../../src/core/platform/git.js', () => ({
+  areSamePath: (left: string, right: string) => path.resolve(left) === path.resolve(right),
+  listGitWorktreeDetails: listGitWorktreeDetailsMock,
+}));
+
+const {formatWorktreeList, runWorktreeList, runWorktreeStatus} =
+  await import('../../src/features/worktree/worktree-inspect.js');
+
+describe('worktree inspection', () => {
+  let repoRoot: string;
+  let worktreeRoot: string;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'ldev-worktree-inspect-main-'));
+    worktreeRoot = path.join(repoRoot, '.worktrees', 'issue-42');
+    await fs.ensureDir(path.join(repoRoot, 'docker'));
+    await fs.ensureDir(path.join(worktreeRoot, 'docker'));
+    await fs.writeFile(
+      path.join(repoRoot, 'docker', '.env'),
+      ['COMPOSE_PROJECT_NAME=labweb', 'BIND_IP=127.0.0.1', 'LIFERAY_HTTP_PORT=8080'].join('\n'),
+    );
+    await fs.writeFile(
+      path.join(worktreeRoot, 'docker', '.env'),
+      [
+        'COMPOSE_PROJECT_NAME=labweb-issue-42',
+        'BIND_IP=127.0.0.1',
+        'LIFERAY_HTTP_PORT=8188',
+        'LIFERAY_DEBUG_PORT=9188',
+        'GOGO_PORT=12188',
+        'POSTGRES_PORT=5588',
+        'ES_HTTP_PORT=9288',
+      ].join('\n'),
+    );
+
+    prepareWorktreeFlowMock.mockResolvedValue({
+      context: {
+        currentRepoRoot: repoRoot,
+        mainRepoRoot: repoRoot,
+        isWorktree: false,
+        currentWorktreeName: null,
+      },
+    });
+    listGitWorktreeDetailsMock.mockResolvedValue([
+      {path: repoRoot, branch: 'main', detached: false, prunable: false},
+      {path: worktreeRoot, branch: 'fix/issue-42', detached: false, prunable: false},
+    ]);
+  });
+
+  test('lists registered worktrees with compose-owned running status and ports', async () => {
+    const docker = vi.fn((args: string[]) =>
+      Promise.resolve({
+        command: `docker ${args.join(' ')}`,
+        stdout: args.includes('label=com.docker.compose.project=labweb-issue-42') ? 'container-a\ncontainer-b\n' : '',
+        stderr: '',
+        exitCode: 0,
+        ok: true,
+      }),
+    );
+
+    const result = await runWorktreeList({cwd: repoRoot, docker});
+
+    expect(result.worktrees).toHaveLength(2);
+    expect(result.worktrees[0]).toMatchObject({
+      name: path.basename(repoRoot),
+      composeProjectName: 'labweb',
+      runtimeStatus: 'stopped',
+      runningContainers: 0,
+      portalUrl: 'http://127.0.0.1:8080',
+    });
+    expect(result.worktrees[1]).toMatchObject({
+      name: 'issue-42',
+      composeProjectName: 'labweb-issue-42',
+      runtimeStatus: 'running',
+      runningContainers: 2,
+      portalUrl: 'http://127.0.0.1:8188',
+      ports: {
+        httpPort: '8188',
+        debugPort: '9188',
+        gogoPort: '12188',
+        postgresPort: '5588',
+        esHttpPort: '9288',
+      },
+    });
+    expect(formatWorktreeList(result)).toContain('running (2)');
+  });
+
+  test('returns status for a named worktree without relying on port scanning', async () => {
+    const docker = vi.fn(() =>
+      Promise.resolve({
+        command: 'docker ps',
+        stdout: 'container-a\n',
+        stderr: '',
+        exitCode: 0,
+        ok: true,
+      }),
+    );
+
+    const result = await runWorktreeStatus({cwd: repoRoot, name: 'issue-42', docker});
+
+    expect(result.worktree.name).toBe('issue-42');
+    expect(result.worktree.runtimeStatus).toBe('running');
+    expect(docker).toHaveBeenCalledWith(['ps', '-q', '--filter', 'label=com.docker.compose.project=labweb-issue-42'], {
+      env: undefined,
+      reject: false,
+    });
+  });
+
+  test('returns status for the main checkout by the name shown in list', async () => {
+    const docker = vi.fn(() =>
+      Promise.resolve({
+        command: 'docker ps',
+        stdout: '',
+        stderr: '',
+        exitCode: 0,
+        ok: true,
+      }),
+    );
+
+    const result = await runWorktreeStatus({cwd: repoRoot, name: path.basename(repoRoot), docker});
+
+    expect(result.worktree.isMain).toBe(true);
+    expect(result.worktree.name).toBe(path.basename(repoRoot));
+    expect(result.worktree.branch).toBe('main');
+    expect(result.worktree.composeProjectName).toBe('labweb');
+  });
+
+  test('marks runtime as unknown when Docker cannot report compose ownership', async () => {
+    const docker = vi.fn(() =>
+      Promise.resolve({
+        command: 'docker ps',
+        stdout: '',
+        stderr: 'Cannot connect to Docker daemon',
+        exitCode: 1,
+        ok: false,
+      }),
+    );
+
+    const result = await runWorktreeStatus({cwd: repoRoot, name: 'issue-42', docker});
+
+    expect(result.worktree.runtimeStatus).toBe('unknown');
+    expect(result.worktree.runningContainers).toBe(0);
+  });
+
+  test('does not invent ports for git-only worktrees without env files', async () => {
+    const gitOnlyRoot = path.join(repoRoot, '.claude', 'worktrees', 'agent-demo');
+    await fs.ensureDir(gitOnlyRoot);
+    listGitWorktreeDetailsMock.mockResolvedValue([
+      {path: repoRoot, branch: 'main', detached: false, prunable: false},
+      {path: gitOnlyRoot, branch: 'worktree-agent-demo', detached: false, prunable: false},
+    ]);
+
+    const docker = vi.fn(() =>
+      Promise.resolve({
+        command: 'docker ps',
+        stdout: '',
+        stderr: '',
+        exitCode: 0,
+        ok: true,
+      }),
+    );
+
+    const result = await runWorktreeStatus({cwd: repoRoot, name: 'agent-demo', docker});
+
+    expect(result.worktree.envConfigured).toBe(false);
+    expect(result.worktree.composeProjectName).toBeNull();
+    expect(result.worktree.portalUrl).toBeNull();
+    expect(result.worktree.ports.httpPort).toBeNull();
+    expect(result.worktree.runtimeStatus).toBe('unknown');
+    expect(docker).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Adds `ldev worktree list` and `ldev worktree status` so registered worktrees can be inspected through their Git metadata, configured ports, Compose project names, and Docker Compose ownership labels.

This keeps runtime ownership explicit instead of relying on generic port reachability. The branch also trims the surrounding documentation/template changes down to the small guidance needed for these commands.

## Changes

- Add worktree inspection logic and CLI registrations for `list` and `status`.
- Let worktree flow preparation fall back to `git rev-parse --show-toplevel` when `ldev` config has no repo root.
- Document the new commands in advanced worktree docs and command reference.
- Update the isolating-worktrees skill to prefer `worktree list/status` for ownership checks.
- Add unit coverage for inspection output, Docker status handling, git-only worktrees, and repo-root fallback.

## Validation

- `npm run typecheck`
- `npm run test:unit -- tests/unit/worktree-inspect.test.ts tests/unit/worktree-flow.test.ts` (ran the unit suite through the package script)
- `npm run verify:ai-templates`
- `npm run format:check`
- `npm run lint` (passes with existing `max-lines` warnings)
- Push hook `verify:push`: lint, format check, typecheck, unit tests, build, smoke tests
