### PR TITLE
feat: support Liferay version selection in project init

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ do for you:
 - **One-pass portal context** — `portal inventory sites|pages|page|structures`
   consolidates several Headless API calls into a single structured response, so
   a developer or an agent can grab "what is in this portal" in one shot.
-- **Local environments from zero** — `project init`, `setup`, `start` scaffold
+- **Local environments from zero** — `project init` + `start` scaffold
   a working Docker-based Liferay runtime without manual Compose plumbing.
 - **Branch-isolated runtimes** — `worktree setup --with-env` gives each branch
   its own Postgres, Liferay and OSGi state. On Linux + Btrfs, snapshots make
@@ -142,12 +142,14 @@ LCP-backed flows, [LCP CLI](https://learn.liferay.com/w/dxp/cloud/reference/comm
 To stand up a fresh local environment:
 
 ```bash
-ldev project init --name my-project --dir ~/projects/my-project
+ldev project init ~/projects/my-project
 cd ~/projects/my-project
-ldev setup
-ldev start
+ldev start --activation-key-file /path/to/activation-key.xml
 ldev oauth install --write-env
 ```
+
+`ldev setup` is optional. Use it before `ldev start` only when you want to
+pre-pull Docker images or warm local runtime directories.
 
 To use it on top of an existing Liferay Workspace, just run `ldev` from the
 workspace root — it detects Blade workspaces and adapts.

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -36,7 +36,7 @@ Top-level entry points:
 
 - `ldev --repo-root <path> ...` — target another local checkout root
 - `ldev context`, `ldev doctor`
-- `ldev setup`, `ldev start`, `ldev stop`, `ldev status`
+- `ldev start`, `ldev stop`, `ldev status`, `ldev setup` for optional preparation
 - `ldev logs`, `ldev logs diagnose`, `ldev shell`
 
 Namespaces:

--- a/docs/commands/project-and-ai.md
+++ b/docs/commands/project-and-ai.md
@@ -11,6 +11,8 @@ Create a new project scaffold linked to local tooling.
 
 ```bash
 ldev project init --list-liferay-versions
+ldev project init my-project
+ldev project init my-project --liferay-version dxp-2026.q1.7-lts --services postgres,elasticsearch
 ldev project init --name my-project --dir ~/projects/my-project
 ldev project init --name my-project --dir . --liferay-version dxp-2026.q1.7-lts
 ldev project init --name my-project --dir . --services postgres
@@ -20,8 +22,9 @@ ldev project init --name my-project --dir . --commit
 
 Options:
 
-- `--name <name>` (required) — project name used for the scaffold
-- `--dir <dir>` (required) — destination directory
+- `[dir]` — destination directory; when `--name` is omitted, the project name defaults to the directory name
+- `--name <name>` — project name used for the scaffold
+- `--dir <dir>` — destination directory; overrides the optional `[dir]` argument
 - `--list-liferay-versions` — list promoted release keys from `https://releases-cdn.liferay.com/releases.json`
 - `--all-liferay-versions` — include non-promoted releases when listing versions
 - `--liferay-version <release-key>` — configure the generated workspace and Docker image for the selected release

--- a/docs/commands/project-and-ai.md
+++ b/docs/commands/project-and-ai.md
@@ -10,7 +10,9 @@ description: Minimal reference for project bootstrap and agent bootstrap workflo
 Create a new project scaffold linked to local tooling.
 
 ```bash
+ldev project init --list-liferay-versions
 ldev project init --name my-project --dir ~/projects/my-project
+ldev project init --name my-project --dir . --liferay-version dxp-2026.q1.7-lts
 ldev project init --name my-project --dir . --services postgres
 ldev project init --name my-project --dir . --services postgres,elasticsearch
 ldev project init --name my-project --dir . --commit
@@ -20,6 +22,9 @@ Options:
 
 - `--name <name>` (required) — project name used for the scaffold
 - `--dir <dir>` (required) — destination directory
+- `--list-liferay-versions` — list promoted release keys from `https://releases-cdn.liferay.com/releases.json`
+- `--all-liferay-versions` — include non-promoted releases when listing versions
+- `--liferay-version <release-key>` — configure the generated workspace and Docker image for the selected release
 - `--services postgres,elasticsearch` — opt in to additional Docker services
 - `--commit` — create a git commit for the generated changes (by default, no commit is created)
 

--- a/docs/commands/project-and-ai.md
+++ b/docs/commands/project-and-ai.md
@@ -14,9 +14,9 @@ ldev project init --list-liferay-versions
 ldev project init my-project
 ldev project init my-project --liferay-version dxp-2026.q1.7-lts --services postgres,elasticsearch
 ldev project init --name my-project --dir ~/projects/my-project
-ldev project init --name my-project --dir . --liferay-version dxp-2026.q1.7-lts
-ldev project init --name my-project --dir . --services postgres
-ldev project init --name my-project --dir . --services postgres,elasticsearch
+ldev project init . --name my-project --liferay-version dxp-2026.q1.7-lts
+ldev project init . --name my-project --services postgres
+ldev project init . --name my-project --services postgres,elasticsearch
 ldev project init --name my-project --dir . --commit
 ```
 
@@ -30,6 +30,17 @@ Options:
 - `--liferay-version <release-key>` — configure the generated workspace and Docker image for the selected release
 - `--services postgres,elasticsearch` — opt in to additional Docker services
 - `--commit` — create a git commit for the generated changes (by default, no commit is created)
+
+After scaffold:
+
+```bash
+cd my-project
+ldev start --activation-key-file /path/to/activation-key.xml
+ldev oauth install --write-env
+```
+
+`ldev setup` is optional. Use it only when you want to pre-pull Docker images
+or warm local runtime directories before starting.
 
 ## `ldev ai install`
 

--- a/docs/commands/runtime.md
+++ b/docs/commands/runtime.md
@@ -34,7 +34,8 @@ These blocks are `null` unless explicitly requested.
 
 ## `ldev setup`
 
-Pull images, seed `docker/.env` and warm the deploy cache before the first `ldev start`.
+Optional preparation before `ldev start`: pull images, refresh `docker/.env`
+and warm local runtime directories.
 
 ```bash
 ldev setup
@@ -42,7 +43,10 @@ ldev setup --skip-pull
 ldev setup --with elasticsearch --with postgres
 ```
 
-Use `--with <service>` (repeatable) to opt into extra Compose services such as `elasticsearch` or `postgres` when the project scaffold omitted them.
+Use `--with <service>` (repeatable) to opt into extra Compose services such as
+`elasticsearch` or `postgres` when the project scaffold omitted them. For new
+projects, prefer selecting services during scaffold:
+`ldev project init my-project --services postgres,elasticsearch`.
 
 ## `ldev start`
 

--- a/docs/core-concepts/environments.md
+++ b/docs/core-concepts/environments.md
@@ -9,16 +9,15 @@ description: How ldev manages local Liferay environments — Docker as the runti
 reproducible, inspectable and replaceable.
 
 This is one of the areas where `ldev` does real work, not just convenience.
-`project init` + `setup` + `start` will scaffold a working Docker-based
-Liferay from zero, and `worktree setup --with-env` will give a branch its
-own runtime state.
+`project init` + `start` will scaffold and run a working Docker-based Liferay
+from zero, and `worktree setup --with-env` will give a branch its own runtime
+state.
 
 ## Bootstrap from zero
 
 ```bash
-ldev project init --name my-project --dir ~/projects/my-project
+ldev project init ~/projects/my-project
 cd ~/projects/my-project
-ldev setup
 ldev start --activation-key-file /path/to/activation-key.xml
 ldev oauth install --write-env
 ```
@@ -27,7 +26,6 @@ Or, if you already have a repo that uses the `ldev` runtime layout:
 
 ```bash
 ldev env init
-ldev setup
 ldev start
 ```
 
@@ -58,11 +56,13 @@ explicit commands instead of tribal knowledge.
 Top-level lifecycle:
 
 ```bash
-ldev setup
 ldev start
 ldev stop
 ldev status
 ```
+
+`ldev setup` is an optional preparation step for pre-pulling Docker images or
+warming runtime directories before `ldev start`.
 
 Advanced recovery lives under `ldev env`:
 

--- a/docs/core-concepts/operations.md
+++ b/docs/core-concepts/operations.md
@@ -24,7 +24,7 @@ you cleanly. These are the reason to install it.
 | --- | --- |
 | Resources as files | `resource export-*` / `import-*` for structures, templates, ADTs and fragments. UI-only in Liferay. |
 | Structure migration | `resource migration-init` + `migration-pipeline`. Liferay has no native migration of articles when a structure changes. |
-| Local environment bootstrap | `project init` / `setup` / `start`. Working Docker-based Liferay from zero. |
+| Local environment bootstrap | `project init` / `start`. Working Docker-based Liferay from zero. |
 | Branch-isolated runtime | `worktree setup --with-env`. Each branch with its own Postgres / Liferay / OSGi state. |
 | OAuth bring-up | `oauth install --write-env`. Bundle deploy + Gogo + token verification + write to local config. |
 | MCP execution layer | `ldev-mcp-server` exposes 18 ldev tools so agents can run real workflows. |

--- a/docs/core-concepts/why-ldev-exists.md
+++ b/docs/core-concepts/why-ldev-exists.md
@@ -40,9 +40,9 @@ developer-experience move that happens to also unblock agents:
 ### Reproducible environments
 
 ```bash
-ldev project init --name my-project --dir ~/projects/my-project
-ldev setup
-ldev start
+ldev project init ~/projects/my-project
+cd ~/projects/my-project
+ldev start --activation-key-file /path/to/activation-key.xml
 ldev oauth install --write-env
 ```
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -38,7 +38,7 @@ Requirements:
 Create the project scaffold:
 
 ```bash
-ldev project init --name my-project --dir ~/projects/my-project
+ldev project init ~/projects/my-project
 cd ~/projects/my-project
 ```
 
@@ -57,10 +57,9 @@ ldev doctor
 `ldev` detects the Blade workspace and provides doctor, portal, resource and
 agent workflows on top of it. Your existing Liferay layout is not modified.
 
-## 3. Prepare and start
+## 3. Start
 
 ```bash
-ldev setup
 ldev doctor
 ldev start --activation-key-file /path/to/activation-key.xml
 ```
@@ -68,6 +67,9 @@ ldev start --activation-key-file /path/to/activation-key.xml
 `doctor` catches missing Docker, port conflicts, bad paths and activation-key
 problems before the first start. If your activation key is already exported in
 your shell, `ldev start` is enough.
+
+`ldev setup` is optional. Run it before `ldev start` only when you want to
+pre-pull Docker images or warm local runtime directories.
 
 ## 4. Check health
 

--- a/docs/getting-started/what-is-ldev.md
+++ b/docs/getting-started/what-is-ldev.md
@@ -28,7 +28,7 @@ These are the parts where `ldev` does something Liferay does not do for you:
 | `resource export-*` / `import-*` | Structures, templates, ADTs and fragments are UI-only in Liferay. `ldev` turns them into reviewable files. |
 | `resource migration-pipeline` | Liferay has no native pipeline for migrating articles when a journal structure changes. `ldev` does. |
 | `portal inventory ...` | One structured call returns sites, pages, structures and templates together — the consolidated context a developer or agent needs first. |
-| `project init` / `setup` / `start` | Stand up a working Docker-based Liferay environment from zero. |
+| `project init` / `start` | Stand up a working Docker-based Liferay environment from zero. |
 | `worktree setup --with-env` | Each branch with its own Postgres, Liferay and OSGi state. On Linux + Btrfs, swaps are near-instant. |
 | `oauth install --write-env` | Deploy the installer bundle, create the OAuth app, verify the token, write credentials. One command. |
 | `ldev-mcp-server` (18 tools) | The same workflows exposed over MCP, so an agent can run them without a custom integration. |

--- a/src/cli/contextual-help.ts
+++ b/src/cli/contextual-help.ts
@@ -73,7 +73,6 @@ export function buildContextualRootSummary(cwd: string): string {
   } else {
     lines.push(
       'Runtime-core here:',
-      '  ldev setup',
       '  ldev start',
       '  ldev stop',
       '  ldev status --json',
@@ -131,7 +130,6 @@ function resolveContextualHelp(cwd: string): ContextualHelp {
         recommended: [
           'ldev context --json',
           'ldev doctor --json',
-          'ldev setup',
           'ldev start',
           'ldev oauth install --write-env',
           'ldev portal check --json',
@@ -141,7 +139,7 @@ function resolveContextualHelp(cwd: string): ContextualHelp {
         notes: [
           'ldev-native is the advanced project type for docker/ + liferay repositories.',
           'Run doctor when runtime or tool readiness matters; context is the default first snapshot.',
-          'This mode includes the richer runtime contract: setup, db, env, osgi, and worktree workflows.',
+          'This mode includes the richer runtime contract: start, db, env, osgi, optional setup, and worktree workflows.',
           'Use it when the repository intentionally relies on Compose overlays, worktrees, or snapshot-oriented flows.',
         ],
       };
@@ -157,9 +155,8 @@ function resolveContextualHelp(cwd: string): ContextualHelp {
           'ldev start',
           '',
           'or:',
-          'ldev project init --name my-project --dir ~/projects/my-project',
+          'ldev project init ~/projects/my-project',
           'cd ~/projects/my-project',
-          'ldev setup',
           'ldev start',
         ],
         notes: [

--- a/src/commands/project/project.command.ts
+++ b/src/commands/project/project.command.ts
@@ -1,14 +1,23 @@
 import {Command} from 'commander';
 
 import {addOutputFormatOption, createFormattedAction} from '../../cli/command-helpers.js';
-import {formatProjectResult, runProjectInit} from '../../features/project/project-init.js';
+import {
+  formatProjectInitLiferayVersions,
+  formatProjectResult,
+  listProjectInitLiferayVersions,
+  requireProjectInitOption,
+  runProjectInit,
+} from '../../features/project/project-init.js';
 import type {DockerService} from '../../features/project/project-scaffold.js';
 
 type ProjectInitCommandOptions = {
-  name: string;
-  dir: string;
+  name?: string;
+  dir?: string;
   services?: string;
   commit?: boolean;
+  liferayVersion?: string;
+  listLiferayVersions?: boolean;
+  allLiferayVersions?: boolean;
 };
 
 export function createProjectCommand(): Command {
@@ -18,9 +27,12 @@ export function createProjectCommand(): Command {
       .command('init')
       .helpGroup('Recommended commands:')
       .description('Create a new project scaffold linked to local tooling')
-      .requiredOption('--name <name>', 'Project name')
-      .requiredOption('--dir <dir>', 'Target directory')
+      .option('--name <name>', 'Project name')
+      .option('--dir <dir>', 'Target directory')
       .option('--services <services>', 'Comma-separated extra services to enable: postgres, elasticsearch')
+      .option('--liferay-version <release-key>', 'Liferay release key to configure, for example dxp-2026.q1.7-lts')
+      .option('--list-liferay-versions', 'List promoted Liferay release keys from releases-cdn.liferay.com')
+      .option('--all-liferay-versions', 'Include non-promoted releases when listing versions')
       .option('--commit', 'Create a git commit for the generated changes'),
   );
   initCommand.addHelpText(
@@ -34,9 +46,13 @@ Optional arguments:
   --services  Comma-separated list of extra Docker services to include.
               Supported values: postgres, elasticsearch
               Example: --services postgres,elasticsearch
+  --liferay-version  Release key from https://releases-cdn.liferay.com/releases.json
+                     Example: --liferay-version dxp-2026.q1.7-lts
 
 Examples:
+  ldev project init --list-liferay-versions
   ldev project init --name my-project --dir ~/projects/my-project
+  ldev project init --name my-project --dir . --liferay-version dxp-2026.q1.7-lts
   ldev project init --name my-project --dir . --services postgres
   ldev project init --name my-project --dir . --services postgres,elasticsearch
 `,
@@ -58,17 +74,25 @@ Use --commit only when you explicitly want bootstrap changes committed immediate
   initCommand.action(
     createFormattedAction(
       async (context, options: ProjectInitCommandOptions) => {
+        if (options.listLiferayVersions || options.allLiferayVersions) {
+          return listProjectInitLiferayVersions({all: Boolean(options.allLiferayVersions)});
+        }
+
         const services = parseServices(options.services);
         const result = await runProjectInit({
-          name: options.name,
-          targetDir: options.dir,
+          name: requireProjectInitOption(options.name, '--name <name>'),
+          targetDir: requireProjectInitOption(options.dir, '--dir <dir>'),
           printer: context.printer,
           commit: Boolean(options.commit),
           services,
+          liferayVersion: options.liferayVersion,
         });
         return result;
       },
-      {text: formatProjectResult},
+      {
+        text: (result) =>
+          Array.isArray(result) ? formatProjectInitLiferayVersions(result) : formatProjectResult(result),
+      },
     ),
   );
 

--- a/src/commands/project/project.command.ts
+++ b/src/commands/project/project.command.ts
@@ -1,14 +1,16 @@
+import path from 'node:path';
+
 import {Command} from 'commander';
 
-import {addOutputFormatOption, createFormattedAction} from '../../cli/command-helpers.js';
+import {addOutputFormatOption, createFormattedArgumentAction} from '../../cli/command-helpers.js';
 import {
   formatProjectInitLiferayVersions,
   formatProjectResult,
   listProjectInitLiferayVersions,
-  requireProjectInitOption,
   runProjectInit,
 } from '../../features/project/project-init.js';
 import type {DockerService} from '../../features/project/project-scaffold.js';
+import {CliError} from '../../core/errors.js';
 
 type ProjectInitCommandOptions = {
   name?: string;
@@ -20,15 +22,21 @@ type ProjectInitCommandOptions = {
   allLiferayVersions?: boolean;
 };
 
+export type ResolvedProjectInitInputs = {
+  name: string;
+  targetDir: string;
+};
+
 export function createProjectCommand(): Command {
   const command = new Command('project');
   const initCommand = addOutputFormatOption(
     command
       .command('init')
+      .argument('[dir]', 'Destination directory. Defaults to --name when omitted')
       .helpGroup('Recommended commands:')
       .description('Create a new project scaffold linked to local tooling')
-      .option('--name <name>', 'Project name')
-      .option('--dir <dir>', 'Target directory')
+      .option('--name <name>', 'Project name. Defaults to the destination directory name')
+      .option('--dir <dir>', 'Target directory. Overrides the optional [dir] argument')
       .option('--services <services>', 'Comma-separated extra services to enable: postgres, elasticsearch')
       .option('--liferay-version <release-key>', 'Liferay release key to configure, for example dxp-2026.q1.7-lts')
       .option('--list-liferay-versions', 'List promoted Liferay release keys from releases-cdn.liferay.com')
@@ -38,11 +46,13 @@ export function createProjectCommand(): Command {
   initCommand.addHelpText(
     'after',
     `
-Required arguments:
-  --name  Project name used for the initial scaffold
-  --dir   Destination directory to create or initialize
+Arguments:
+  [dir]   Destination directory to create or initialize. When --name is omitted,
+          the project name defaults to the directory name.
 
 Optional arguments:
+  --name  Project name used for the initial scaffold
+  --dir   Destination directory. Overrides the optional [dir] argument
   --services  Comma-separated list of extra Docker services to include.
               Supported values: postgres, elasticsearch
               Example: --services postgres,elasticsearch
@@ -51,10 +61,10 @@ Optional arguments:
 
 Examples:
   ldev project init --list-liferay-versions
-  ldev project init --name my-project --dir ~/projects/my-project
-  ldev project init --name my-project --dir . --liferay-version dxp-2026.q1.7-lts
-  ldev project init --name my-project --dir . --services postgres
-  ldev project init --name my-project --dir . --services postgres,elasticsearch
+  ldev project init my-project
+  ldev project init my-project --liferay-version dxp-2026.q1.7-lts --services postgres,elasticsearch
+  ldev project init --dir ~/projects/my-project --liferay-version dxp-2026.q1.7-lts
+  ldev project init --name my-project --dir .
 `,
   );
 
@@ -72,16 +82,17 @@ Use --commit only when you explicitly want bootstrap changes committed immediate
   );
 
   initCommand.action(
-    createFormattedAction(
-      async (context, options: ProjectInitCommandOptions) => {
+    createFormattedArgumentAction(
+      async (context, positionalDir: string | undefined, options: ProjectInitCommandOptions) => {
         if (options.listLiferayVersions || options.allLiferayVersions) {
           return listProjectInitLiferayVersions({all: Boolean(options.allLiferayVersions)});
         }
 
         const services = parseServices(options.services);
+        const inputs = resolveProjectInitInputs(options, positionalDir);
         const result = await runProjectInit({
-          name: requireProjectInitOption(options.name, '--name <name>'),
-          targetDir: requireProjectInitOption(options.dir, '--dir <dir>'),
+          name: inputs.name,
+          targetDir: inputs.targetDir,
           printer: context.printer,
           commit: Boolean(options.commit),
           services,
@@ -97,6 +108,31 @@ Use --commit only when you explicitly want bootstrap changes committed immediate
   );
 
   return command;
+}
+
+export function resolveProjectInitInputs(
+  options: Pick<ProjectInitCommandOptions, 'name' | 'dir'>,
+  positionalDir?: string,
+): ResolvedProjectInitInputs {
+  const targetDir = normalizeInput(options.dir) ?? normalizeInput(positionalDir) ?? normalizeInput(options.name);
+
+  if (!targetDir) {
+    throw new CliError('Missing project destination. Provide [dir], --dir <dir>, or --name <name>.', {
+      code: 'PROJECT_INIT_DESTINATION_REQUIRED',
+    });
+  }
+
+  const name = normalizeInput(options.name) ?? inferProjectNameFromDir(targetDir);
+  return {name, targetDir};
+}
+
+function normalizeInput(value: string | undefined): string | undefined {
+  const normalized = value?.trim();
+  return normalized ? normalized : undefined;
+}
+
+function inferProjectNameFromDir(targetDir: string): string {
+  return path.basename(path.resolve(targetDir)) || 'liferay';
 }
 
 function parseServices(raw: string | undefined): DockerService[] {

--- a/src/features/project/project-init.ts
+++ b/src/features/project/project-init.ts
@@ -55,17 +55,17 @@ export async function runProjectInit(
   dependencies?: ProjectCommandDependencies,
 ): Promise<ProjectCommandResult> {
   const targetDir = path.resolve(options.targetDir);
+  const releasesProvider = dependencies?.fetchLiferayReleases ?? fetchLiferayReleases;
+  const liferayRelease = options.liferayVersion
+    ? selectLiferayRelease(await releasesProvider(), options.liferayVersion)
+    : null;
+
   await fs.ensureDir(targetDir);
 
   const hadGit = await isGitRepository(targetDir);
   if (!hadGit) {
     await initializeGitRepository(targetDir);
   }
-
-  const releasesProvider = dependencies?.fetchLiferayReleases ?? fetchLiferayReleases;
-  const liferayRelease = options.liferayVersion
-    ? selectLiferayRelease(await releasesProvider(), options.liferayVersion)
-    : null;
 
   return applyProjectTooling({
     projectName: options.name,
@@ -92,7 +92,9 @@ export function formatProjectResult(result: ProjectCommandResult): string {
     `Git commit: ${result.changes.committed ? 'created' : result.commitRequested ? 'skipped (no staged changes)' : 'not created'}`,
   );
   lines.push('');
-  lines.push('Review the generated files before committing them.');
+  lines.push(
+    result.changes.committed ? 'Generated files were committed.' : 'Review the generated files before committing them.',
+  );
   lines.push('');
   lines.push('Next steps:');
   result.nextSteps.forEach((step, index) => {
@@ -173,14 +175,20 @@ async function applyProjectTooling(options: {
       scaffoldFilesCopied,
       committed,
     },
-    nextSteps: getNextSteps(options.targetDir),
+    nextSteps: getNextSteps(options.targetDir, committed),
   };
 }
 
-function getNextSteps(targetDir: string): string[] {
+function getNextSteps(targetDir: string, committed: boolean): string[] {
+  const reviewSteps = committed
+    ? ['Review the bootstrap commit with git show --stat.']
+    : [
+        'Review the generated files with git diff or your editor.',
+        'If everything looks right, create your own git commit or rerun with --commit.',
+      ];
+
   return [
-    'Review the generated files with git diff or your editor.',
-    'If everything looks right, create your own git commit or rerun with --commit.',
+    ...reviewSteps,
     'Edit docker/.env and adjust COMPOSE_PROJECT_NAME, ports, and local variables.',
     'Edit .liferay-cli.yml and review the project paths.',
     `cd ${targetDir}`,

--- a/src/features/project/project-init.ts
+++ b/src/features/project/project-init.ts
@@ -194,7 +194,7 @@ function getNextSteps(targetDir: string, committed: boolean): string[] {
     'Install ldev globally with npm i -g @mordonezdev/ldev or use npm link from your local ldev checkout.',
     'ldev start',
     'ldev oauth install --write-env',
-    'Optional: run ldev setup first only when you want to pre-pull Docker images or warm local data directories.',
+    'Optional: run ldev setup first only when you want to pre-pull Docker images or warm local runtime directories.',
     'If you need local data, use ldev db import --file path/to/backup.gz.',
     'Reserve ldev db sync --project <id> --environment <env> --force for an explicit and conscious step, not as default onboarding.',
   ];

--- a/src/features/project/project-init.ts
+++ b/src/features/project/project-init.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import fs from 'fs-extra';
 
 import {upsertEnvFileValues} from '../../core/config/env-file.js';
+import {CliError} from '../../core/errors.js';
 import {
   gitAddPaths,
   gitCommit,
@@ -20,9 +21,12 @@ import {
   type DockerService,
   type ProjectAssets,
 } from './project-scaffold.js';
+import type {LiferayReleaseEntry, LiferayReleaseSelection} from './project-releases.js';
+import {fetchLiferayReleases, filterReleaseList, selectLiferayRelease} from './project-releases.js';
 
 export type ProjectCommandResult = {
   targetDir: string;
+  liferayRelease: LiferayReleaseSelection | null;
   gitInitialized: boolean;
   commitRequested: boolean;
   changes: {
@@ -36,10 +40,18 @@ export type ProjectCommandResult = {
 
 type ProjectCommandDependencies = {
   assets?: ProjectAssets;
+  fetchLiferayReleases?: () => Promise<LiferayReleaseEntry[]>;
 };
 
 export async function runProjectInit(
-  options: {name: string; targetDir: string; printer: Printer; commit?: boolean; services?: DockerService[]},
+  options: {
+    name: string;
+    targetDir: string;
+    printer: Printer;
+    commit?: boolean;
+    services?: DockerService[];
+    liferayVersion?: string;
+  },
   dependencies?: ProjectCommandDependencies,
 ): Promise<ProjectCommandResult> {
   const targetDir = path.resolve(options.targetDir);
@@ -50,6 +62,11 @@ export async function runProjectInit(
     await initializeGitRepository(targetDir);
   }
 
+  const releasesProvider = dependencies?.fetchLiferayReleases ?? fetchLiferayReleases;
+  const liferayRelease = options.liferayVersion
+    ? selectLiferayRelease(await releasesProvider(), options.liferayVersion)
+    : null;
+
   return applyProjectTooling({
     projectName: options.name,
     targetDir,
@@ -59,11 +76,17 @@ export async function runProjectInit(
     gitInitialized: !hadGit,
     commitRequested: Boolean(options.commit),
     services: options.services ?? [],
+    liferayRelease,
   });
 }
 
 export function formatProjectResult(result: ProjectCommandResult): string {
   const lines = [`Project ready in: ${result.targetDir}`];
+  if (result.liferayRelease) {
+    lines.push(
+      `Liferay version: ${result.liferayRelease.releaseKey} (${result.liferayRelease.productVersion}, image ${result.liferayRelease.dockerImage})`,
+    );
+  }
   lines.push(`Git repository: ${result.gitInitialized ? 'initialized' : 'existing'}`);
   lines.push(
     `Git commit: ${result.changes.committed ? 'created' : result.commitRequested ? 'skipped (no staged changes)' : 'not created'}`,
@@ -78,6 +101,27 @@ export function formatProjectResult(result: ProjectCommandResult): string {
   return lines.join('\n');
 }
 
+export async function listProjectInitLiferayVersions(
+  options: {all?: boolean},
+  dependencies?: Pick<ProjectCommandDependencies, 'fetchLiferayReleases'>,
+): Promise<LiferayReleaseEntry[]> {
+  const releasesProvider = dependencies?.fetchLiferayReleases ?? fetchLiferayReleases;
+  return filterReleaseList(await releasesProvider(), Boolean(options.all));
+}
+
+export function formatProjectInitLiferayVersions(releases: LiferayReleaseEntry[]): string {
+  if (releases.length === 0) {
+    return 'No Liferay releases found.';
+  }
+
+  return releases
+    .map((release) => {
+      const promoted = release.promoted ? ' promoted' : '';
+      return `${release.releaseKey}\t${release.productVersion}${promoted}`;
+    })
+    .join('\n');
+}
+
 async function applyProjectTooling(options: {
   projectName: string;
   targetDir: string;
@@ -87,6 +131,7 @@ async function applyProjectTooling(options: {
   gitInitialized: boolean;
   commitRequested: boolean;
   services: DockerService[];
+  liferayRelease: LiferayReleaseSelection | null;
 }): Promise<ProjectCommandResult> {
   const dockerCreated = await ensureDockerScaffold(options.targetDir, options.assets, options.services);
   const liferayCreated = await ensureLiferayScaffold(options.targetDir, options.assets);
@@ -94,7 +139,12 @@ async function applyProjectTooling(options: {
     ? false
     : await ensureLiferayDockerenvScaffold(options.targetDir, options.assets);
   const scaffoldFilesCopied = await copyProjectScaffoldFiles(options.targetDir, options.assets);
-  await configureGeneratedProjectFiles(options.targetDir, options.projectName, options.services);
+  await configureGeneratedProjectFiles(
+    options.targetDir,
+    options.projectName,
+    options.services,
+    options.liferayRelease,
+  );
 
   const touchedPaths = collectTouchedPaths(options.targetDir, {
     dockerCreated,
@@ -114,6 +164,7 @@ async function applyProjectTooling(options: {
 
   return {
     targetDir: options.targetDir,
+    liferayRelease: options.liferayRelease,
     gitInitialized: options.gitInitialized,
     commitRequested: options.commitRequested,
     changes: {
@@ -146,9 +197,17 @@ async function configureGeneratedProjectFiles(
   targetDir: string,
   projectName: string,
   services: DockerService[],
+  liferayRelease: LiferayReleaseSelection | null,
 ): Promise<void> {
   const slug = toProjectSlug(projectName);
-  await updateDockerEnv(path.join(targetDir, 'docker', '.env'), slug, services, process.env.BIND_IP?.trim());
+  await updateDockerEnv(
+    path.join(targetDir, 'docker', '.env'),
+    slug,
+    services,
+    process.env.BIND_IP?.trim(),
+    liferayRelease,
+  );
+  await updateLiferayGradleProperties(path.join(targetDir, 'liferay', 'gradle.properties'), liferayRelease);
 }
 
 async function updateDockerEnv(
@@ -156,6 +215,7 @@ async function updateDockerEnv(
   projectSlug: string,
   services: DockerService[],
   bindIp?: string,
+  liferayRelease?: LiferayReleaseSelection | null,
 ): Promise<void> {
   if (!(await fs.pathExists(dockerEnvFile))) {
     return;
@@ -166,6 +226,10 @@ async function updateDockerEnv(
     COMPOSE_PROJECT_NAME: projectSlug,
     DOCLIB_VOLUME_NAME: `${projectSlug}-doclib`,
   };
+
+  if (liferayRelease) {
+    envValues.LIFERAY_IMAGE = liferayRelease.dockerImage;
+  }
 
   if (services.length > 0) {
     const composeFiles = ['docker-compose.yml', ...services.map((s) => `docker-compose.${s}.yml`)];
@@ -178,6 +242,32 @@ async function updateDockerEnv(
 
   const updatedContent = upsertEnvFileValues(currentContent, envValues);
   await fs.writeFile(dockerEnvFile, `${updatedContent}\n`);
+}
+
+async function updateLiferayGradleProperties(
+  gradlePropertiesFile: string,
+  liferayRelease?: LiferayReleaseSelection | null,
+): Promise<void> {
+  if (!liferayRelease || !(await fs.pathExists(gradlePropertiesFile))) {
+    return;
+  }
+
+  const currentContent = await fs.readFile(gradlePropertiesFile, 'utf8');
+  const updatedContent = upsertEnvFileValues(currentContent, {
+    'liferay.workspace.product': liferayRelease.releaseKey,
+    'liferay.workspace.target.platform.version': liferayRelease.targetPlatformVersion,
+    'liferay.workspace.docker.image.liferay': liferayRelease.dockerImage,
+  });
+  await fs.writeFile(gradlePropertiesFile, `${updatedContent}\n`);
+}
+
+export function requireProjectInitOption(value: string | undefined, optionName: string): string {
+  const normalized = value?.trim();
+  if (!normalized) {
+    throw new CliError(`Missing required option: ${optionName}`, {code: 'PROJECT_INIT_OPTION_REQUIRED'});
+  }
+
+  return normalized;
 }
 
 function toProjectSlug(value: string): string {

--- a/src/features/project/project-init.ts
+++ b/src/features/project/project-init.ts
@@ -3,7 +3,6 @@ import path from 'node:path';
 import fs from 'fs-extra';
 
 import {upsertEnvFileValues} from '../../core/config/env-file.js';
-import {CliError} from '../../core/errors.js';
 import {
   gitAddPaths,
   gitCommit,
@@ -193,11 +192,11 @@ function getNextSteps(targetDir: string, committed: boolean): string[] {
     'Edit .liferay-cli.yml and review the project paths.',
     `cd ${targetDir}`,
     'Install ldev globally with npm i -g @mordonezdev/ldev or use npm link from your local ldev checkout.',
-    'ldev setup',
-    'If you need local data, use ldev db import --file path/to/backup.gz.',
-    'Reserve ldev db sync --project <id> --environment <env> --force for an explicit and conscious step, not as default onboarding.',
     'ldev start',
     'ldev oauth install --write-env',
+    'Optional: run ldev setup first only when you want to pre-pull Docker images or warm local data directories.',
+    'If you need local data, use ldev db import --file path/to/backup.gz.',
+    'Reserve ldev db sync --project <id> --environment <env> --force for an explicit and conscious step, not as default onboarding.',
   ];
 }
 
@@ -267,15 +266,6 @@ async function updateLiferayGradleProperties(
     'liferay.workspace.docker.image.liferay': liferayRelease.dockerImage,
   });
   await fs.writeFile(gradlePropertiesFile, `${updatedContent}\n`);
-}
-
-export function requireProjectInitOption(value: string | undefined, optionName: string): string {
-  const normalized = value?.trim();
-  if (!normalized) {
-    throw new CliError(`Missing required option: ${optionName}`, {code: 'PROJECT_INIT_OPTION_REQUIRED'});
-  }
-
-  return normalized;
 }
 
 function toProjectSlug(value: string): string {

--- a/src/features/project/project-releases.ts
+++ b/src/features/project/project-releases.ts
@@ -1,0 +1,111 @@
+import {CliError} from '../../core/errors.js';
+
+const LIFERAY_RELEASES_URL = 'https://releases-cdn.liferay.com/releases.json';
+
+export type LiferayReleaseEntry = {
+  product: string;
+  productVersion: string;
+  promoted: boolean;
+  releaseKey: string;
+  tags: string[];
+  targetPlatformVersion: string;
+  url: string;
+};
+
+export type LiferayReleaseSelection = LiferayReleaseEntry & {
+  dockerImage: string;
+};
+
+type RawLiferayReleaseEntry = {
+  product?: unknown;
+  productVersion?: unknown;
+  promoted?: unknown;
+  releaseKey?: unknown;
+  tags?: unknown;
+  targetPlatformVersion?: unknown;
+  url?: unknown;
+};
+
+export async function fetchLiferayReleases(fetchImpl: typeof fetch = fetch): Promise<LiferayReleaseEntry[]> {
+  let response: Response;
+  try {
+    response = await fetchImpl(LIFERAY_RELEASES_URL);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    throw new CliError(`Unable to fetch Liferay releases: ${message}`, {code: 'PROJECT_RELEASES_FETCH_FAILED'});
+  }
+
+  if (!response.ok) {
+    throw new CliError(`Unable to fetch Liferay releases: HTTP ${response.status}`, {
+      code: 'PROJECT_RELEASES_FETCH_FAILED',
+    });
+  }
+
+  const payload = await response.json();
+  if (!Array.isArray(payload)) {
+    throw new CliError('Unable to parse Liferay releases: expected an array.', {
+      code: 'PROJECT_RELEASES_INVALID_PAYLOAD',
+    });
+  }
+
+  return payload.map(normalizeReleaseEntry).filter((entry): entry is LiferayReleaseEntry => entry !== null);
+}
+
+export function selectLiferayRelease(releases: LiferayReleaseEntry[], releaseKey: string): LiferayReleaseSelection {
+  const normalizedReleaseKey = releaseKey.trim().toLowerCase();
+  const release = releases.find((entry) => entry.releaseKey.toLowerCase() === normalizedReleaseKey);
+
+  if (!release) {
+    throw new CliError(`Unknown Liferay release version: ${releaseKey}`, {
+      code: 'PROJECT_RELEASE_NOT_FOUND',
+      details: {
+        availableVersions: filterReleaseList(releases)
+          .slice(0, 20)
+          .map((entry) => entry.releaseKey),
+      },
+    });
+  }
+
+  return {
+    ...release,
+    dockerImage: getDockerImage(release),
+  };
+}
+
+export function filterReleaseList(releases: LiferayReleaseEntry[], includeAll = false): LiferayReleaseEntry[] {
+  return releases.filter((entry) => includeAll || entry.promoted);
+}
+
+function normalizeReleaseEntry(entry: RawLiferayReleaseEntry): LiferayReleaseEntry | null {
+  if (
+    typeof entry.product !== 'string' ||
+    typeof entry.productVersion !== 'string' ||
+    typeof entry.releaseKey !== 'string' ||
+    typeof entry.targetPlatformVersion !== 'string' ||
+    typeof entry.url !== 'string'
+  ) {
+    return null;
+  }
+
+  return {
+    product: entry.product,
+    productVersion: entry.productVersion,
+    promoted: entry.promoted === true || entry.promoted === 'true',
+    releaseKey: entry.releaseKey,
+    tags: Array.isArray(entry.tags) ? entry.tags.filter((tag): tag is string => typeof tag === 'string') : [],
+    targetPlatformVersion: entry.targetPlatformVersion,
+    url: entry.url,
+  };
+}
+
+function getDockerImage(release: LiferayReleaseEntry): string {
+  if (release.product === 'dxp') {
+    return `liferay/dxp:${release.releaseKey.replace(/^dxp-/, '')}`;
+  }
+
+  if (release.product === 'portal') {
+    return `liferay/portal:${release.releaseKey.replace(/^portal-/, '')}`;
+  }
+
+  return `liferay/${release.product}:${release.releaseKey.replace(new RegExp(`^${release.product}-`), '')}`;
+}

--- a/templates/ai/project/docs/ai/project-context.md
+++ b/templates/ai/project/docs/ai/project-context.md
@@ -26,12 +26,14 @@ reusable across multiple projects, move it into a vendor skill instead.
 ```bash
 ldev ai bootstrap --intent=develop --cache=60 --json
 ldev --repo-root ../main-checkout ai bootstrap --intent=develop --cache=60 --json
-ldev setup
 ldev start
 ldev status
 ldev logs --since 5m --no-follow
 ldev stop
 ```
+
+Use `ldev setup` before `ldev start` only when you want to pre-pull Docker
+images or warm local runtime directories.
 
 Use the global `--repo-root` form when an agent is inside a worktree but needs
 read-only discovery or bootstrap context from the main checkout.

--- a/templates/ai/project/docs/ai/project-context.md.sample
+++ b/templates/ai/project/docs/ai/project-context.md.sample
@@ -71,7 +71,6 @@ URL, a known structure key, a project-specific path convention.
 ```bash
 ldev doctor
 ldev ai bootstrap --intent=develop --cache=60 --json
-ldev setup
 ldev start
 ldev status --json
 ldev logs --since 10m --service liferay --no-follow
@@ -83,6 +82,7 @@ Notes:
 - Use `ldev` as the official entrypoint instead of ad hoc Docker commands.
 - Prefer JSON output when an agent or script will consume the result.
 - If the env is down, verify it with `ldev status --json` before debugging portal behavior.
+- Use `ldev setup` before `ldev start` only when you want to pre-pull Docker images or warm local runtime directories.
 
 ## Project Layout
 

--- a/templates/ai/workspace-rules/ldev-native-runtime.md
+++ b/templates/ai/workspace-rules/ldev-native-runtime.md
@@ -24,12 +24,14 @@ This project type is intentionally more opinionated:
 
 Operational entry points:
 
-- `ldev setup`
 - `ldev start`
 - `ldev status --json`
 - `ldev logs diagnose --json`
 - `ldev db ...`
 - `ldev env ...`
 - `ldev worktree ...`
+
+`ldev setup` is optional. Use it before `ldev start` only when you want to
+pre-pull Docker images or warm local runtime directories.
 
 Prefer these commands over raw Docker commands when you need repeatable local behavior.

--- a/tests/integration/project.integration.test.ts
+++ b/tests/integration/project.integration.test.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 
 import {describe, expect, test} from 'vitest';
 
-import {runProjectInit} from '../../src/features/project/project-init.js';
+import {formatProjectResult, runProjectInit} from '../../src/features/project/project-init.js';
 import {resolveProjectAssets} from '../../src/features/project/project-scaffold.js';
 import {runProcess} from '../../src/core/platform/process.js';
 import type {LiferayReleaseEntry} from '../../src/features/project/project-releases.js';
@@ -170,6 +170,11 @@ describe('project integration', () => {
 
       expect(result.commitRequested).toBe(true);
       expect(result.changes.committed).toBe(true);
+      expect(result.nextSteps).toContain('Review the bootstrap commit with git show --stat.');
+      expect(result.nextSteps).not.toContain(
+        'If everything looks right, create your own git commit or rerun with --commit.',
+      );
+      expect(formatProjectResult(result)).toContain('Generated files were committed.');
       expect(await gitStatus(targetDir)).toBe('');
       expect(await gitLogSubject(targetDir)).toBe('chore: scaffold initial Liferay project files');
     } finally {
@@ -205,6 +210,34 @@ describe('project integration', () => {
 
       const dockerEnv = await fs.readFile(path.join(targetDir, 'docker', '.env'), 'utf8');
       expect(dockerEnv).toContain('LIFERAY_IMAGE=liferay/dxp:test-lts');
+    } finally {
+      restoreGitIdentityEnv();
+    }
+  });
+
+  test('init validates the selected Liferay release before creating the target repository', async () => {
+    setupGitIdentityEnv();
+    try {
+      const repoRoot = await createProjectRepoFixture();
+      const targetDir = createTempDir('dev-cli-project-init-invalid-version-');
+      await fs.remove(targetDir);
+
+      await expect(
+        runProjectInit(
+          {
+            name: 'sample-project',
+            targetDir,
+            printer: silentPrinter,
+            liferayVersion: 'dxp-missing',
+          },
+          {
+            assets: resolveProjectAssets(repoRoot),
+            fetchLiferayReleases: () => Promise.resolve(releaseFixtures),
+          },
+        ),
+      ).rejects.toMatchObject({code: 'PROJECT_RELEASE_NOT_FOUND'});
+
+      expect(await fs.pathExists(targetDir)).toBe(false);
     } finally {
       restoreGitIdentityEnv();
     }

--- a/tests/integration/project.integration.test.ts
+++ b/tests/integration/project.integration.test.ts
@@ -6,6 +6,7 @@ import {describe, expect, test} from 'vitest';
 import {runProjectInit} from '../../src/features/project/project-init.js';
 import {resolveProjectAssets} from '../../src/features/project/project-scaffold.js';
 import {runProcess} from '../../src/core/platform/process.js';
+import type {LiferayReleaseEntry} from '../../src/features/project/project-releases.js';
 import {createTempDir} from '../../src/testing/temp-repo.js';
 
 const silentPrinter = {
@@ -14,6 +15,18 @@ const silentPrinter = {
   error: () => undefined,
   info: () => undefined,
 };
+
+const releaseFixtures: LiferayReleaseEntry[] = [
+  {
+    product: 'dxp',
+    productVersion: 'DXP 2026.Q1.7 LTS',
+    promoted: true,
+    releaseKey: 'dxp-test-lts',
+    tags: ['recommended', 'supported'],
+    targetPlatformVersion: '2026.q1.7',
+    url: 'https://releases-cdn.liferay.com/dxp/2026.q1.7-lts',
+  },
+];
 
 describe('project integration', () => {
   const GIT_ENV_KEYS = [
@@ -159,6 +172,39 @@ describe('project integration', () => {
       expect(result.changes.committed).toBe(true);
       expect(await gitStatus(targetDir)).toBe('');
       expect(await gitLogSubject(targetDir)).toBe('chore: scaffold initial Liferay project files');
+    } finally {
+      restoreGitIdentityEnv();
+    }
+  });
+
+  test('init can select a Liferay release version for the generated workspace and Docker image', async () => {
+    setupGitIdentityEnv();
+    try {
+      const repoRoot = await createProjectRepoFixture();
+      const targetDir = createTempDir('dev-cli-project-init-version-');
+
+      const result = await runProjectInit(
+        {
+          name: 'sample-project',
+          targetDir,
+          printer: silentPrinter,
+          liferayVersion: 'dxp-test-lts',
+        },
+        {
+          assets: resolveProjectAssets(repoRoot),
+          fetchLiferayReleases: () => Promise.resolve(releaseFixtures),
+        },
+      );
+
+      expect(result.liferayRelease?.releaseKey).toBe('dxp-test-lts');
+
+      const gradleProperties = await fs.readFile(path.join(targetDir, 'liferay', 'gradle.properties'), 'utf8');
+      expect(gradleProperties).toContain('liferay.workspace.product=dxp-test-lts');
+      expect(gradleProperties).toContain('liferay.workspace.target.platform.version=2026.q1.7');
+      expect(gradleProperties).toContain('liferay.workspace.docker.image.liferay=liferay/dxp:test-lts');
+
+      const dockerEnv = await fs.readFile(path.join(targetDir, 'docker', '.env'), 'utf8');
+      expect(dockerEnv).toContain('LIFERAY_IMAGE=liferay/dxp:test-lts');
     } finally {
       restoreGitIdentityEnv();
     }

--- a/tests/smoke/help.test.ts
+++ b/tests/smoke/help.test.ts
@@ -153,13 +153,14 @@ describe('smoke help', () => {
     expect(result.stdout).toContain('--commit');
   }, 10000);
 
-  test('project init --help shows the required bootstrap invocation', async () => {
+  test('project init --help shows the bootstrap invocation', async () => {
     const result = await runCli(['project', 'init', '--help'], {cwd: CLI_CWD});
     expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain('Required arguments:');
+    expect(result.stdout).toContain('Arguments:');
+    expect(result.stdout).toContain('[dir]');
     expect(result.stdout).toContain('--name');
     expect(result.stdout).toContain('--dir');
-    expect(result.stdout).toContain('ldev project init --name my-project --dir ~/projects/my-project');
+    expect(result.stdout).toContain('ldev project init my-project --liferay-version dxp-2026.q1.7-lts');
   }, 10000);
 
   test('resource --help documents the normalized resource contract', async () => {

--- a/tests/smoke/help.test.ts
+++ b/tests/smoke/help.test.ts
@@ -37,7 +37,7 @@ describe('smoke help', () => {
     expect(result.stdout).toContain('ldev resource export-structures --site /global');
     expect(result.stdout).toContain("Run 'ldev --help' to see the full command catalog.");
     expect(result.stdout).toContain('blade init ai-workspace');
-    expect(result.stdout).toContain('ldev project init --name my-project --dir ~/projects/my-project');
+    expect(result.stdout).toContain('ldev project init ~/projects/my-project');
   }, 30000);
 
   test('bare ldev adapts its short summary to blade-workspace', async () => {
@@ -61,7 +61,7 @@ describe('smoke help', () => {
     expect(result.stdout).toContain('Detected project type: ldev-native');
     expect(result.stdout).not.toContain('Core workflows:');
     expect(result.stdout).toContain('Runtime-core here:');
-    expect(result.stdout).toContain('ldev setup');
+    expect(result.stdout).toContain('ldev start');
     expect(result.stdout).toContain('ldev db query ...');
   }, 30000);
 
@@ -84,7 +84,7 @@ describe('smoke help', () => {
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain('Detected project type: ldev-native');
     expect(result.stdout).toContain('Recommended first steps for this ldev-native repo:');
-    expect(result.stdout).toContain('ldev setup');
+    expect(result.stdout).toContain('ldev start');
     expect(result.stdout).toContain('ldev oauth install --write-env');
     expect(result.stdout).toContain('ldev resource export-structures --site /global');
   }, 30000);

--- a/tests/unit/project-command.test.ts
+++ b/tests/unit/project-command.test.ts
@@ -1,0 +1,50 @@
+import path from 'node:path';
+
+import {describe, expect, test} from 'vitest';
+
+import {resolveProjectInitInputs} from '../../src/commands/project/project.command.js';
+
+describe('resolveProjectInitInputs', () => {
+  test('uses the positional directory as target and project name', () => {
+    expect(resolveProjectInitInputs({}, 'dxp2026')).toEqual({
+      name: 'dxp2026',
+      targetDir: 'dxp2026',
+    });
+  });
+
+  test('infers the project name from --dir when --name is omitted', () => {
+    expect(resolveProjectInitInputs({dir: path.join('projects', 'dxp2026')})).toEqual({
+      name: 'dxp2026',
+      targetDir: path.join('projects', 'dxp2026'),
+    });
+  });
+
+  test('uses --name as the target directory when no directory is provided', () => {
+    expect(resolveProjectInitInputs({name: 'dxp2026'})).toEqual({
+      name: 'dxp2026',
+      targetDir: 'dxp2026',
+    });
+  });
+
+  test('lets --name override the inferred project name', () => {
+    expect(resolveProjectInitInputs({name: 'portal-main', dir: 'dxp2026'})).toEqual({
+      name: 'portal-main',
+      targetDir: 'dxp2026',
+    });
+  });
+
+  test('requires at least one project destination input', () => {
+    expectCliErrorCode(() => resolveProjectInitInputs({}), 'PROJECT_INIT_DESTINATION_REQUIRED');
+  });
+});
+
+function expectCliErrorCode(action: () => unknown, code: string): void {
+  try {
+    action();
+  } catch (error) {
+    expect(error).toMatchObject({code});
+    return;
+  }
+
+  throw new Error(`Expected action to throw ${code}`);
+}

--- a/tests/unit/project-releases.test.ts
+++ b/tests/unit/project-releases.test.ts
@@ -1,0 +1,215 @@
+import {describe, expect, test} from 'vitest';
+
+import {
+  fetchLiferayReleases,
+  filterReleaseList,
+  selectLiferayRelease,
+  type LiferayReleaseEntry,
+} from '../../src/features/project/project-releases.js';
+
+const TEST_DXP_RELEASE_KEY = 'dxp-test-lts';
+const TEST_PORTAL_RELEASE_KEY = 'portal-ga';
+
+const dxpRelease: LiferayReleaseEntry = {
+  product: 'dxp',
+  productVersion: 'DXP 2026.Q1.7 LTS',
+  promoted: true,
+  releaseKey: TEST_DXP_RELEASE_KEY,
+  tags: ['recommended', 'supported'],
+  targetPlatformVersion: '2026.q1.7',
+  url: 'https://releases-cdn.liferay.com/dxp/2026.q1.7-lts',
+};
+
+const portalRelease: LiferayReleaseEntry = {
+  product: 'portal',
+  productVersion: 'Portal 7.4 GA100',
+  promoted: false,
+  releaseKey: TEST_PORTAL_RELEASE_KEY,
+  tags: [],
+  targetPlatformVersion: '7.4.3.100',
+  url: 'https://releases-cdn.liferay.com/portal/7.4.3.100-ga100',
+};
+
+describe('filterReleaseList', () => {
+  const releases = [dxpRelease, portalRelease];
+
+  test('returns only promoted releases by default', () => {
+    const result = filterReleaseList(releases);
+    expect(result).toHaveLength(1);
+    expect(result[0].releaseKey).toBe(TEST_DXP_RELEASE_KEY);
+  });
+
+  test('returns all releases when includeAll is true', () => {
+    const result = filterReleaseList(releases, true);
+    expect(result).toHaveLength(2);
+  });
+
+  test('returns empty array when no releases are promoted', () => {
+    expect(filterReleaseList([portalRelease])).toHaveLength(0);
+  });
+});
+
+describe('selectLiferayRelease', () => {
+  const releases = [dxpRelease, portalRelease];
+
+  test('selects a dxp release and derives its docker image', () => {
+    const selection = selectLiferayRelease(releases, TEST_DXP_RELEASE_KEY);
+    expect(selection.releaseKey).toBe(TEST_DXP_RELEASE_KEY);
+    expect(selection.dockerImage).toBe('liferay/dxp:test-lts');
+  });
+
+  test('selects a portal release and derives its docker image', () => {
+    const selection = selectLiferayRelease(releases, TEST_PORTAL_RELEASE_KEY);
+    expect(selection.releaseKey).toBe(TEST_PORTAL_RELEASE_KEY);
+    expect(selection.dockerImage).toBe('liferay/portal:ga');
+  });
+
+  test('matching is case-insensitive', () => {
+    const selection = selectLiferayRelease(releases, 'DXP-TEST-LTS');
+    expect(selection.releaseKey).toBe(TEST_DXP_RELEASE_KEY);
+  });
+
+  test('matching trims whitespace', () => {
+    const selection = selectLiferayRelease(releases, `  ${TEST_DXP_RELEASE_KEY}  `);
+    expect(selection.releaseKey).toBe(TEST_DXP_RELEASE_KEY);
+  });
+
+  test('throws CliError with code PROJECT_RELEASE_NOT_FOUND when key is unknown', () => {
+    expectCliErrorCode(() => selectLiferayRelease(releases, 'dxp-missing'), 'PROJECT_RELEASE_NOT_FOUND');
+  });
+
+  test('error details include available (promoted) versions', () => {
+    let caught: unknown;
+    try {
+      selectLiferayRelease(releases, 'dxp-missing');
+    } catch (error) {
+      caught = error;
+    }
+    expect((caught as {details?: {availableVersions?: unknown}}).details?.availableVersions).toContain(
+      TEST_DXP_RELEASE_KEY,
+    );
+  });
+
+  test('selection spreads all original release fields', () => {
+    const selection = selectLiferayRelease(releases, TEST_DXP_RELEASE_KEY);
+    expect(selection.productVersion).toBe(dxpRelease.productVersion);
+    expect(selection.targetPlatformVersion).toBe(dxpRelease.targetPlatformVersion);
+    expect(selection.promoted).toBe(true);
+    expect(selection.tags).toEqual(dxpRelease.tags);
+  });
+});
+
+describe('fetchLiferayReleases', () => {
+  function makeJsonFetch(payload: unknown, status = 200): typeof fetch {
+    return async () => {
+      await Promise.resolve();
+      return {
+        ok: status >= 200 && status < 300,
+        status,
+        json: async () => {
+          await Promise.resolve();
+          return payload;
+        },
+      } as Response;
+    };
+  }
+
+  function makeNetworkErrorFetch(): typeof fetch {
+    return async () => {
+      await Promise.resolve();
+      throw new Error('getaddrinfo ENOTFOUND releases-cdn.liferay.com');
+    };
+  }
+
+  test('parses a valid releases array and returns normalized entries', async () => {
+    const payload = [
+      {
+        product: 'dxp',
+        productVersion: 'DXP 2026.Q1.7 LTS',
+        promoted: true,
+        releaseKey: TEST_DXP_RELEASE_KEY,
+        tags: ['recommended'],
+        targetPlatformVersion: '2026.q1.7',
+        url: 'https://releases-cdn.liferay.com/dxp/2026.q1.7-lts',
+      },
+    ];
+    const releases = await fetchLiferayReleases(makeJsonFetch(payload));
+    expect(releases).toHaveLength(1);
+    expect(releases[0].releaseKey).toBe(TEST_DXP_RELEASE_KEY);
+    expect(releases[0].promoted).toBe(true);
+  });
+
+  test('accepts promoted as string "true"', async () => {
+    const payload = [
+      {
+        product: 'dxp',
+        productVersion: 'DXP 2026.Q1.7 LTS',
+        promoted: 'true',
+        releaseKey: TEST_DXP_RELEASE_KEY,
+        tags: [],
+        targetPlatformVersion: '2026.q1.7',
+        url: 'https://example.com',
+      },
+    ];
+    const releases = await fetchLiferayReleases(makeJsonFetch(payload));
+    expect(releases[0].promoted).toBe(true);
+  });
+
+  test('silently drops entries with missing required fields', async () => {
+    const payload = [{product: 'dxp', productVersion: 'DXP 2026.Q1.7 LTS', promoted: true, releaseKey: 'dxp-test'}];
+    const releases = await fetchLiferayReleases(makeJsonFetch(payload));
+    expect(releases).toHaveLength(0);
+  });
+
+  test('normalizes missing tags to empty array', async () => {
+    const payload = [
+      {
+        product: 'dxp',
+        productVersion: 'DXP 2026.Q1.7 LTS',
+        promoted: false,
+        releaseKey: TEST_DXP_RELEASE_KEY,
+        targetPlatformVersion: '2026.q1.7',
+        url: 'https://example.com',
+      },
+    ];
+    const releases = await fetchLiferayReleases(makeJsonFetch(payload));
+    expect(releases[0].tags).toEqual([]);
+  });
+
+  test('throws CliError with code PROJECT_RELEASES_FETCH_FAILED on HTTP error', async () => {
+    await expectCliErrorCodeAsync(fetchLiferayReleases(makeJsonFetch(null, 503)), 'PROJECT_RELEASES_FETCH_FAILED');
+  });
+
+  test('throws CliError with code PROJECT_RELEASES_FETCH_FAILED on network failure', async () => {
+    await expectCliErrorCodeAsync(fetchLiferayReleases(makeNetworkErrorFetch()), 'PROJECT_RELEASES_FETCH_FAILED');
+  });
+
+  test('throws CliError with code PROJECT_RELEASES_INVALID_PAYLOAD when response is not an array', async () => {
+    await expectCliErrorCodeAsync(
+      fetchLiferayReleases(makeJsonFetch({releases: []})),
+      'PROJECT_RELEASES_INVALID_PAYLOAD',
+    );
+  });
+});
+
+function expectCliErrorCode(action: () => unknown, code: string): void {
+  try {
+    action();
+  } catch (error) {
+    expect(error).toMatchObject({code});
+    return;
+  }
+
+  throw new Error(`Expected action to throw ${code}`);
+}
+
+async function expectCliErrorCodeAsync(promise: Promise<unknown>, code: string): Promise<void> {
+  try {
+    await promise;
+  } catch (error) {
+    expect(error).toMatchObject({code});
+    return;
+  }
+
+  throw new Error(`Expected promise to reject with ${code}`);
+}


### PR DESCRIPTION
## Summary

- Add Liferay release fetching, filtering, and selection helpers backed by releases-cdn.liferay.com metadata.
- Add `project init` options to list release keys and configure generated workspace/Docker files for a selected release.
- Document the new CLI options and cover the release selection flow with unit and integration tests.

## Validation

- `npm run test:unit -- tests/unit/project-releases.test.ts`
- `npm run test:integration -- tests/integration/project.integration.test.ts`
- `npm run typecheck`