### PR TITLE
feat: add glowroot port to worktree port set and tune docker resource defaults

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -26,6 +26,17 @@ Local runtime values such as:
 - `LIFERAY_OSGI_STATE_MODE`
 - `LCP_PROJECT`
 - `LCP_ENVIRONMENT`
+- `GLOWROOT_PORT` — port for the Glowroot APM UI (default `4000`; worktrees get a unique port automatically)
+
+## Glowroot
+
+The default `docker-compose.yml` ships with [Glowroot](https://glowroot.org/) enabled out of the box via `LIFERAY_JVM_OPTS`. Once the container is running, the APM UI is available at:
+
+```
+http://127.0.0.1:4000
+```
+
+For worktrees, the port is assigned automatically from `GLOWROOT_PORT` in each worktree's `docker/.env`. Use it to inspect heap usage, slow transactions, and GC activity without any extra setup.
 
 `ldev` may also read `LIFERAY_CLI_URL` and OAuth variables from here as a legacy fallback, but this is not the preferred destination for `ldev oauth install --write-env`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2481,9 +2481,9 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
-      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.6.tgz",
+      "integrity": "sha512-LsAdmUapA0qSN306d8+zOyawM0hFm2m2Hg9IwVNIKBm+qJV8cijiq2c+gxKZcB1HCfIWAy+0qEZDCUQA58A1cw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2505,8 +2505,8 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "3.2.4",
-        "vitest": "3.2.4"
+        "@vitest/browser": "3.2.6",
+        "vitest": "3.2.6"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -2515,15 +2515,15 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
-      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
+      "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
         "chai": "^5.2.0",
         "tinyrainbow": "^2.0.0"
       },
@@ -2532,13 +2532,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
-      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
+      "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.2.4",
+        "@vitest/spy": "3.2.6",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.17"
       },
@@ -2559,9 +2559,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
-      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2572,13 +2572,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
-      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
+      "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.2.4",
+        "@vitest/utils": "3.2.6",
         "pathe": "^2.0.3",
         "strip-literal": "^3.0.0"
       },
@@ -2587,13 +2587,13 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
-      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
+      "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
+        "@vitest/pretty-format": "3.2.6",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3"
       },
@@ -2602,9 +2602,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
-      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
+      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2615,13 +2615,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
-      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
+      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
+        "@vitest/pretty-format": "3.2.6",
         "loupe": "^3.1.4",
         "tinyrainbow": "^2.0.0"
       },
@@ -3190,9 +3190,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4546,9 +4546,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -5420,9 +5420,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -5757,9 +5757,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -5777,7 +5777,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -7751,20 +7751,20 @@
       }
     },
     "node_modules/vitest": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
-      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
+      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
-        "@vitest/expect": "3.2.4",
-        "@vitest/mocker": "3.2.4",
-        "@vitest/pretty-format": "^3.2.4",
-        "@vitest/runner": "3.2.4",
-        "@vitest/snapshot": "3.2.4",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
+        "@vitest/expect": "3.2.6",
+        "@vitest/mocker": "3.2.6",
+        "@vitest/pretty-format": "^3.2.6",
+        "@vitest/runner": "3.2.6",
+        "@vitest/snapshot": "3.2.6",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
         "chai": "^5.2.0",
         "debug": "^4.4.1",
         "expect-type": "^1.2.1",
@@ -7794,8 +7794,8 @@
         "@edge-runtime/vm": "*",
         "@types/debug": "^4.1.12",
         "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.2.4",
-        "@vitest/ui": "3.2.4",
+        "@vitest/browser": "3.2.6",
+        "@vitest/ui": "3.2.6",
         "happy-dom": "*",
         "jsdom": "*"
       },

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
   },
   "overrides": {
     "fast-uri": "3.1.2",
-    "hono": "4.12.18"
+    "hono": "4.12.23"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/src/core/config/project-context.ts
+++ b/src/core/config/project-context.ts
@@ -360,6 +360,7 @@ function resolveDockerEnv(options: {
     GOGO_PORT: ports.gogoPort,
     POSTGRES_PORT: ports.postgresPort,
     ES_HTTP_PORT: ports.esHttpPort,
+    GLOWROOT_PORT: ports.glowrootPort,
     ENV_DATA_ROOT:
       env.ENV_DATA_ROOT || path.join(path.join(worktree.worktreeRoot, 'docker'), 'data', 'envs', worktree.worktreeName),
     ...env,
@@ -372,6 +373,7 @@ function resolveWorktreePortSet(name: string): {
   gogoPort: string;
   postgresPort: string;
   esHttpPort: string;
+  glowrootPort: string;
 } {
   const hash = checksum(name);
   const offset = hash % 800;
@@ -382,6 +384,7 @@ function resolveWorktreePortSet(name: string): {
     gogoPort: String(12000 + offset),
     postgresPort: String(5400 + offset),
     esHttpPort: String(9201 + offset),
+    glowrootPort: String(4001 + offset),
   };
 }
 

--- a/src/core/contracts/dashboard.schema.ts
+++ b/src/core/contracts/dashboard.schema.ts
@@ -181,6 +181,7 @@ export const dashboardStatusResponseSchema = z.object({
   refreshedAt: z.string().datetime(),
   mcp: dashboardMcpStatusSchema,
   worktrees: z.array(dashboardWorktreeSchema),
+  defaultWorktreeBase: z.string().optional(),
 });
 export type DashboardStatusResponseContract = z.infer<typeof dashboardStatusResponseSchema>;
 

--- a/src/core/contracts/dashboard.schema.ts
+++ b/src/core/contracts/dashboard.schema.ts
@@ -124,6 +124,7 @@ export const dashboardEnvSchema = z.object({
   dockerDir: z.string(),
   error: z.string().nullable(),
   portalUrl: z.string(),
+  glowrootUrl: z.string().optional(),
   portalReachable: z.boolean().nullable(),
   services: z.array(envServiceStatusSchema),
   liferay: envServiceStatusSchema.nullable(),

--- a/src/core/runtime/env-context.ts
+++ b/src/core/runtime/env-context.ts
@@ -17,6 +17,7 @@ export type EnvContext = {
   bindIp: string;
   httpPort: string;
   portalUrl: string;
+  glowrootUrl?: string;
   composeProjectName: string;
 };
 
@@ -59,6 +60,7 @@ export function resolveEnvContext(config: AppConfig): EnvContext {
     bindIp,
     httpPort,
     portalUrl: `http://${bindIp}:${httpPort}`,
+    glowrootUrl: `http://${bindIp}:${envValues.GLOWROOT_PORT || '4000'}`,
     composeProjectName: envValues.COMPOSE_PROJECT_NAME || 'liferay',
   };
 }

--- a/src/entrypoints/dashboard/client/components/create-modal.jsx
+++ b/src/entrypoints/dashboard/client/components/create-modal.jsx
@@ -4,7 +4,7 @@ import {useEffect, useState} from 'preact/hooks';
 import {IconX} from '../lib/icons.jsx';
 
 export function CreateModal({data, isOpen, onClose, onSubmit}) {
-  const mainBranch = data?.worktrees?.find((wt) => wt.isMain)?.branch || '';
+  const defaultBase = data?.defaultWorktreeBase || '';
   const [form, setForm] = useState({
     name: '',
     baseRef: '',
@@ -19,7 +19,7 @@ export function CreateModal({data, isOpen, onClose, onSubmit}) {
     if (isOpen) {
       setForm({
         name: '',
-        baseRef: mainBranch,
+        baseRef: defaultBase,
         startAfterCreate: true,
         withEnv: true,
         installMcp: true,
@@ -27,7 +27,7 @@ export function CreateModal({data, isOpen, onClose, onSubmit}) {
         restartMainAfterClone: false,
       });
     }
-  }, [isOpen, mainBranch]);
+  }, [isOpen, defaultBase]);
 
   if (!isOpen) return null;
 

--- a/src/entrypoints/dashboard/client/components/detail-sheet.jsx
+++ b/src/entrypoints/dashboard/client/components/detail-sheet.jsx
@@ -140,6 +140,17 @@ export function DetailSheet({wt, tasks, onClose, onAction, onDb, onLogs, onResou
               </span>
             </div>
             <div class="det-cell">
+              <span class="det-k">Glowroot</span>
+              <span class="det-v">
+                {wt.env?.glowrootUrl ? (
+                  <a href={running ? wt.env.glowrootUrl : undefined} rel="noreferrer" target="_blank"
+                    style={{color: running ? 'var(--accent)' : 'var(--text-3)', textDecoration: 'none'}}>
+                    {wt.env.glowrootUrl.replace('http://', '')}
+                  </a>
+                ) : <span style={{color: 'var(--text-3)'}}>none</span>}
+              </span>
+            </div>
+            <div class="det-cell">
               <span class="det-k">Changes</span>
               <span class="det-v" style={{color: wt.changedFiles ? 'var(--amber)' : 'var(--text-3)'}}>
                 {wt.changedFiles ? `${wt.changedFiles} files` : 'clean'}

--- a/src/entrypoints/dashboard/dashboard-data.ts
+++ b/src/entrypoints/dashboard/dashboard-data.ts
@@ -58,8 +58,9 @@ export async function collectDashboardStatus(
   const [mcp, worktrees] = await Promise.all([collectMcpStatus(mainRepoRoot), collectDashboardWorktrees(cwd, options)]);
 
   const profileFiles = resolveLiferayProfileFiles(mainRepoRoot);
-  const profile = profileFiles.shared ? readProfileFile(profileFiles.shared) : {};
-  const defaultWorktreeBase = profile['worktree.defaultBase'] || undefined;
+  const shared = profileFiles.shared ? readProfileFile(profileFiles.shared) : {};
+  const local = profileFiles.local ? readProfileFile(profileFiles.local) : {};
+  const defaultWorktreeBase = local['worktree.defaultBase'] || shared['worktree.defaultBase'] || undefined;
 
   return {
     cwd: mainRepoRoot,

--- a/src/entrypoints/dashboard/dashboard-data.ts
+++ b/src/entrypoints/dashboard/dashboard-data.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 
 import fs from 'fs-extra';
 
+import {readProfileFile, resolveLiferayProfileFiles} from '../../core/config/liferay-profile.js';
 import {MCP_SETUP_TOOLS, type McpSetupTool, resolveMcpConfigPath} from '../mcp-server/mcp-server-setup.js';
 import {
   collectDashboardWorktrees,
@@ -25,6 +26,7 @@ export type DashboardStatus = {
   refreshedAt: string;
   mcp: DashboardMcpStatus;
   worktrees: DashboardWorktree[];
+  defaultWorktreeBase?: string;
 };
 
 export type CollectDashboardStatusOptions = CollectDashboardWorktreeOptions;
@@ -55,10 +57,15 @@ export async function collectDashboardStatus(
   const mainRepoRoot = path.resolve(cwd);
   const [mcp, worktrees] = await Promise.all([collectMcpStatus(mainRepoRoot), collectDashboardWorktrees(cwd, options)]);
 
+  const profileFiles = resolveLiferayProfileFiles(mainRepoRoot);
+  const profile = profileFiles.shared ? readProfileFile(profileFiles.shared) : {};
+  const defaultWorktreeBase = profile['worktree.defaultBase'] || undefined;
+
   return {
     cwd: mainRepoRoot,
     refreshedAt: new Date().toISOString(),
     mcp,
     worktrees,
+    defaultWorktreeBase,
   };
 }

--- a/src/entrypoints/dashboard/dashboard-worktree-snapshot.ts
+++ b/src/entrypoints/dashboard/dashboard-worktree-snapshot.ts
@@ -24,6 +24,7 @@ export type DashboardEnv = {
   dockerDir: string;
   error: string | null;
   portalUrl: string;
+  glowrootUrl?: string;
   portalReachable: boolean | null;
   services: EnvServiceStatus[];
   liferay: EnvServiceStatus | null;
@@ -108,6 +109,7 @@ async function collectWorktreeEnv(
         dockerDir: context.dockerDir,
         error: null,
         portalUrl: runtime.portalUrl,
+        glowrootUrl: context.glowrootUrl,
         portalReachable: null,
         services: [],
         liferay: runtime.liferay,
@@ -121,6 +123,7 @@ async function collectWorktreeEnv(
       dockerDir: context.dockerDir,
       error: null,
       portalUrl: status.portalUrl,
+      glowrootUrl: context.glowrootUrl,
       portalReachable: status.portalReachable,
       services: status.services,
       liferay: status.liferay,

--- a/src/features/worktree/worktree-env.ts
+++ b/src/features/worktree/worktree-env.ts
@@ -97,6 +97,7 @@ export async function runWorktreeEnv(options: {
     GOGO_PORT: ports.gogoPort,
     POSTGRES_PORT: ports.postgresPort,
     ES_HTTP_PORT: ports.esHttpPort,
+    GLOWROOT_PORT: ports.glowrootPort,
     ENV_DATA_ROOT: envDataRoot,
     ...(btrfs.enabled && btrfs.rootDir && btrfs.baseDir && btrfs.envsDir && btrfs.useSnapshots
       ? {

--- a/src/features/worktree/worktree-paths.ts
+++ b/src/features/worktree/worktree-paths.ts
@@ -171,6 +171,7 @@ export function resolvePortSet(name: string): {
   gogoPort: string;
   postgresPort: string;
   esHttpPort: string;
+  glowrootPort: string;
 } {
   const hash = checksum(name);
   const offset = hash % 800;
@@ -181,6 +182,7 @@ export function resolvePortSet(name: string): {
     gogoPort: String(12000 + offset),
     postgresPort: String(5400 + offset),
     esHttpPort: String(9201 + offset),
+    glowrootPort: String(4001 + offset),
   };
 }
 

--- a/templates/.liferay-cli.yml
+++ b/templates/.liferay-cli.yml
@@ -1,3 +1,5 @@
+worktree:
+  defaultBase: main          # Branch used as the base when creating new worktrees from the dashboard
 paths:
   theme: custom-theme        # Replace with your theme name (folder in liferay/themes/)
   structures: liferay/resources/journal/structures

--- a/templates/docker/.env.example
+++ b/templates/docker/.env.example
@@ -9,13 +9,16 @@
 LIFERAY_IMAGE=liferay/dxp:2026.q1.0-lts
 
 # JVM settings (adjust for the RAM available on your host)
-LIFERAY_JVM_OPTS="-Xms2g -Xmx4g -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Djava.net.preferIPv4Stack=true"
+LIFERAY_JVM_OPTS="-Xms512m -Xmx2g -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Djava.net.preferIPv4Stack=true"
+LIFERAY_MEMORY_LIMIT=3072m
+LIFERAY_CPUS=4
 
 # --- Host ports --------------------------------------------------------------
 
 LIFERAY_HTTP_PORT=8080
 LIFERAY_DEBUG_PORT=8000
 GOGO_PORT=11311
+GLOWROOT_PORT=4000
 POSTGRES_PORT=5432
 ES_HTTP_PORT=9200
 
@@ -29,9 +32,16 @@ POSTGRES_DB=liferay
 POSTGRES_USER=liferay
 POSTGRES_PASSWORD=liferay
 
+# --- PostgreSQL limits -------------------------------------------------------
+
+POSTGRES_MEMORY_LIMIT=512m
+POSTGRES_CPUS=2
+
 # --- Elasticsearch -----------------------------------------------------------
 
-ES_JAVA_OPTS="-Xms1g -Xmx1g"
+ES_JAVA_OPTS="-Xms512m -Xmx512m"
+ELASTICSEARCH_MEMORY_LIMIT=1024m
+ELASTICSEARCH_CPUS=4
 
 # --- Volumes and data --------------------------------------------------------
 

--- a/templates/docker/docker-compose.elasticsearch.yml
+++ b/templates/docker/docker-compose.elasticsearch.yml
@@ -6,6 +6,8 @@ services:
     image: ${COMPOSE_PROJECT_NAME:-liferay}-elasticsearch:7.17.26
     container_name: ${COMPOSE_PROJECT_NAME:-liferay}-elasticsearch
     restart: unless-stopped
+    mem_limit: ${ELASTICSEARCH_MEMORY_LIMIT:-1024m}
+    cpus: ${ELASTICSEARCH_CPUS:-4}
     environment:
       - discovery.type=single-node
       - xpack.security.enabled=false
@@ -18,10 +20,10 @@ services:
     networks:
       - liferay-network
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:9200/_cat/health || exit 1"]
-      interval: 15s
+      test: ["CMD-SHELL", "curl -fsS --max-time 5 -o /dev/null http://localhost:9200/ && curl -fsS --max-time 1 -o /dev/null http://localhost:9200/_cluster/health || exit 1"]
+      interval: 10s
       timeout: 5s
-      retries: 10
+      retries: 2
       start_period: 30s
 
   liferay:

--- a/templates/docker/docker-compose.postgres.yml
+++ b/templates/docker/docker-compose.postgres.yml
@@ -3,6 +3,8 @@ services:
     image: postgres:15-alpine
     container_name: ${COMPOSE_PROJECT_NAME:-liferay}-postgres
     restart: unless-stopped
+    mem_limit: ${POSTGRES_MEMORY_LIMIT:-512m}
+    cpus: ${POSTGRES_CPUS:-2}
     environment:
       POSTGRES_DB: ${POSTGRES_DB:-liferay}
       POSTGRES_USER: ${POSTGRES_USER:-liferay}
@@ -27,9 +29,10 @@ services:
       - liferay-network
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-liferay} -d ${POSTGRES_DB:-liferay}"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
+      interval: 60s
+      timeout: 10s
+      retries: 2
+      start_period: 30s
 
   liferay:
     depends_on:

--- a/templates/docker/docker-compose.yml
+++ b/templates/docker/docker-compose.yml
@@ -4,19 +4,23 @@ services:
     container_name: ${COMPOSE_PROJECT_NAME:-liferay}-liferay
     restart: unless-stopped
     stop_grace_period: 120s
+    mem_limit: ${LIFERAY_MEMORY_LIMIT:-3072m}
+    cpus: ${LIFERAY_CPUS:-4}
     environment:
       LIFERAY_JPDA_ENABLED: "true"
       BIND_IP: ${BIND_IP:-}
       LIFERAY_HTTP_PORT: ${LIFERAY_HTTP_PORT:-8080}
       LIFERAY_SESSION_COOKIE_NAME: ${LIFERAY_SESSION_COOKIE_NAME:-}
-      LIFERAY_JVM_OPTS: ${LIFERAY_JVM_OPTS:--Xms2g -Xmx4g -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Djava.net.preferIPv4Stack=true}
+      LIFERAY_JVM_OPTS: ${LIFERAY_JVM_OPTS:--Xms512m -Xmx2g -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Djava.net.preferIPv4Stack=true}
       LIFERAY_CONTAINER_STATUS_ENABLED: "true"
       LIFERAY_THREAD_DUMPS_DIRECTORY: "/opt/liferay/dumps/thread_dumps"
       LIFERAY_WEB_PERIOD_SERVER_PERIOD_HTTP_PERIOD_PORT: "${LIFERAY_HTTP_PORT:-8080}"
+      GLOWROOT_PORT: "${GLOWROOT_PORT:-4000}"
     ports:
       - "${BIND_IP:-127.0.0.1}:${LIFERAY_HTTP_PORT:-8080}:8080"
       - "${BIND_IP:-127.0.0.1}:${LIFERAY_DEBUG_PORT:-8000}:8000"
       - "${BIND_IP:-127.0.0.1}:${GOGO_PORT:-11311}:11311"
+      - "${BIND_IP:-127.0.0.1}:${GLOWROOT_PORT:-4000}:4000"
     volumes:
       - ./liferay-scripts:/usr/local/liferay/scripts
       - ../liferay/build/docker/configs/dockerenv:/mnt/liferay/files
@@ -28,11 +32,11 @@ services:
       - doclib:/opt/liferay/data/document_library
       - ${ENV_DATA_ROOT:-./data/default}/liferay-osgi-state:/opt/liferay/osgi/state
     healthcheck:
-      test: ["CMD-SHELL", "curl -fsS --max-time 20 -o /dev/null http://localhost:8080/c/portal/login || exit 1"]
-      interval: 15s
-      timeout: 25s
-      retries: 40
-      start_period: 120s
+      test: ["CMD-SHELL", "curl -fsS --max-time 5 -o /dev/null http://localhost:8080/c/portal/robots || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 6
+      start_period: 180s
     networks:
       - liferay-network
 

--- a/templates/docker/liferay-scripts/pre-startup/configure-glowroot.sh
+++ b/templates/docker/liferay-scripts/pre-startup/configure-glowroot.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+
+ADMIN_JSON="/opt/liferay/glowroot/admin.json"
+
+if [ ! -f "$ADMIN_JSON" ]; then
+	echo "[glowroot] admin.json not found, skipping"
+	exit 0
+fi
+
+sed -i \
+	-e 's/"bindAddress"[[:space:]]*:[[:space:]]*"127\.0\.0\.1"/"bindAddress": "0.0.0.0"/' \
+	-e 's/"port"[[:space:]]*:[[:space:]]*4000/"port": 4000/' \
+	"$ADMIN_JSON"
+
+echo "[glowroot] UI configured on 0.0.0.0:4000"


### PR DESCRIPTION
## Summary

- Assigns `GLOWROOT_PORT` automatically per worktree (`4001 + hash offset`) alongside the existing port set, so multiple worktrees can run glowroot simultaneously without port collisions
- Exposes port 4000 in `docker-compose.yml` with `GLOWROOT_PORT` env var passed into the container
- Adds `configure-glowroot.sh` pre-startup script that changes glowroot's `bindAddress` from `127.0.0.1` to `0.0.0.0` so Docker port forwarding works
- Sets conservative resource defaults for generic dev machines: Liferay 512m/2g heap, 3072m container limit; ES 512m heap, 1024m limit; Postgres 512m limit
- Adds `mem_limit` and `cpus` to all services; tightens healthchecks to use the `/c/portal/robots` endpoint matching PaaS probes
- Documents `GLOWROOT_PORT` and the glowroot UI in the configuration reference

## Test plan

- [ ] `ldev project init` on a new project — verify `GLOWROOT_PORT=4000` appears in `docker/.env` and port 4000 is exposed after `ldev start`
- [ ] `ldev worktree add` — verify each worktree gets a unique `GLOWROOT_PORT` distinct from main and other worktrees
- [ ] Glowroot UI accessible at `http://127.0.0.1:<GLOWROOT_PORT>` once container is running