### PR TITLE
feat: add Restore button to dashboard with confirmation modal

### DIFF
--- a/docs/agentic/index.md
+++ b/docs/agentic/index.md
@@ -54,7 +54,7 @@ Then create `.claude/skills/` so `npx skills add` can place Claude Code symlinks
 mkdir -p .claude/skills
 ```
 
-See [`docs/ai/`](/ai/) for full setup instructions. In Blade workspaces, `ldev` coexists with the official AI folders rather than replacing them.
+See [`docs/ai/`](/ai/AGENTS) for full setup instructions. In Blade workspaces, `ldev` coexists with the official AI folders rather than replacing them.
 
 ## Context snapshots
 

--- a/docs/commands/project-and-ai.md
+++ b/docs/commands/project-and-ai.md
@@ -75,4 +75,4 @@ prefer the global form `ldev --repo-root <path> ai bootstrap ...`.
 ldev ai bootstrap --intent=develop --cache=60 --json
 ```
 
-To set up agent meta-files (`AGENTS.md`, `CLAUDE.md`, etc.) and skills in a project, see [`docs/ai/`](../ai/README.md).
+To set up agent meta-files (`AGENTS.md`, `CLAUDE.md`, etc.) and skills in a project, see [`docs/ai/`](/ai/AGENTS).

--- a/docs/reference/faq.md
+++ b/docs/reference/faq.md
@@ -67,4 +67,4 @@ Because they let you export, review, import, and migrate structures, templates, 
 
 ## How do I set up agent meta-files for a project?
 
-Copy `AGENTS.md` from `docs/ai/` into the project root, create `.claude/skills/`, and run `npx skills add https://github.com/mordonez/ldev`. See [docs/ai/README.md](../ai/README.md) for the full setup steps.
+Copy `AGENTS.md` from `docs/ai/` into the project root, create `.claude/skills/`, and run `npx skills add https://github.com/mordonez/ldev`. See [`docs/ai/`](/ai/AGENTS) for the full setup steps.

--- a/docs/superpowers/specs/2026-06-29-dashboard-restore-button-design.md
+++ b/docs/superpowers/specs/2026-06-29-dashboard-restore-button-design.md
@@ -1,0 +1,119 @@
+# Dashboard: Restore Button with Confirmation Modal
+
+**Date:** 2026-06-29
+**Status:** Approved
+
+## Problem
+
+The dashboard "Recreate" button only force-recreates the Docker container while keeping existing data intact. There is no way to restore an environment from scratch (replacing all data from the main environment) without going to the CLI.
+
+`ldev env restore` does this — it stops the environment, replaces all data directories from main (or BTRFS base), then exits. There is no dashboard equivalent.
+
+## Goal
+
+Add a "Restore" button to the dashboard's advanced actions menu that:
+1. Shows a confirmation modal with a clear warning before proceeding
+2. Calls `runEnvRestore` to replace all environment data from main
+3. Calls `runEnvStart` afterwards to bring the environment back up
+4. Appears for all worktrees that have an env (both main and worktrees — backend handles the BTRFS_BASE error for main if needed)
+
+## Non-goals
+
+- No changes to the "Recreate" button behavior
+- No generic confirmation mechanism for other actions (YAGNI)
+- No new CLI command (already exists as `ldev env restore`)
+
+## Architecture
+
+Follows the exact same pattern as the "Delete worktree" action:
+- Button with `target: 'restore'` → `onRestore(name)` handler → modal state → POST to backend → queued task
+
+## Backend Changes
+
+### `dashboard-actions.json`
+New entry:
+```json
+{
+  "id": "restore",
+  "key": "worktree-restore",
+  "label": "Restoring environment for {worktree}",
+  "method": "POST",
+  "queueAction": "restore",
+  "route": "/api/worktrees/{worktree}/env/restore",
+  "taskKind": "env-restore"
+}
+```
+
+### `dashboard-action-catalog.ts`
+Add `'worktree-restore'` to the `DashboardOperationKey` union type.
+
+### `dashboard-operation-routes.ts`
+Add `'worktree-restore'` to `QUEUED_OPERATION_RUNNERS`:
+- Import `runEnvRestore`, `formatEnvRestore` from `env-restore.js`
+- Import `runEnvStart` from `env-start.js`
+- Runner: call `runEnvRestore(config, {printer, signal})`, print result lines, then call `runEnvStart(config, {printer, signal})`
+
+## Frontend Changes
+
+### `actions.ts`
+Add to `ACTION_BUTTONS`:
+```ts
+restore: {className: 'btn-ghost', label: 'Restore', target: 'restore'},
+```
+
+### `worktree-presentation.js`
+Add `restore` button to `advancedActions` after `recreate`, conditioned on `wt.env`:
+```js
+worktreeButton('restore', {
+  disabled: busyWorktree,
+  label: busyWorktree ? busyLabel : 'Restore',
+}),
+```
+
+### `worktree-card.jsx`
+- Add `onRestore` prop to `WorktreeCard` and `MoreMenu`
+- In `MoreMenu.dispatch`: handle `action.target === 'restore'` → `onRestore(wt.name)`
+- Add `restore` to `ACTION_ICONS` using `IconRotateCcw` (same icon set as recreate)
+
+### `dashboard-actions.jsx`
+- Add `restoreModal: {name: string, busy: boolean} | null` state (initially `null`)
+- Add `restoreWorktree(name)`: sets modal state to `{name, busy: false}`
+- Add `confirmRestoreWorktree()`: sets `busy: true`, POSTs to `actionUrl(name, 'restore')`, closes modal on success, shows toast
+- Add `RestoreWorktreeModal` component with:
+  - Title: "Restore environment"
+  - Subtitle: worktree name
+  - Warning text: "This will replace all environment data (database, Liferay data, Elasticsearch, Document Library) with data from the main environment. The environment will restart automatically. This action cannot be undone."
+  - Cancel button + "Restore environment" confirm button (styled as danger)
+- Include `RestoreWorktreeModal` in `DashboardActionModals`
+- Export `restoreModal`, `restoreWorktree`, `closeRestoreModal`, `confirmRestoreWorktree` from `useDashboardActions`
+- Include `Boolean(restoreModal)` in `hasOpenModal`
+
+### `app.jsx`
+- Pass `onRestore={actions.restoreWorktree}` to `WorktreeCard`
+- Pass `onRestore` to `DetailSheet` (and wire the close+open pattern like `onDelete`)
+
+### `detail-sheet.jsx`
+- Add `onRestore` prop
+- Add Restore button in the Operations section (after Recreate, before Delete), conditioned on `wt.env`:
+  ```jsx
+  {wt.env && (
+    <button class="btn" type="button"
+      style={{color: 'var(--red)'}}
+      onClick={() => { onClose(); onRestore(wt.name); }}>
+      <IconRotateCcw size={14} />Restore
+    </button>
+  )}
+  ```
+
+## Modal Warning Text
+
+```
+This will replace all environment data (database, Liferay data, Elasticsearch,
+Document Library) with data from the main environment. The environment will
+restart automatically. This action cannot be undone.
+```
+
+## Error Handling
+
+- If `runEnvRestore` throws (e.g., main env with no BTRFS_BASE), the task fails and the error appears in the Activity panel — same as any other failed queued task
+- Frontend shows a toast on POST failure (same pattern as delete)

--- a/src/entrypoints/dashboard/client/app.jsx
+++ b/src/entrypoints/dashboard/client/app.jsx
@@ -170,6 +170,7 @@ function App() {
                     onDelete={actions.deleteWorktree}
                     onLogs={actions.openLogs}
                     onResource={actions.openResourceModal}
+                    onRestore={actions.restoreWorktree}
                     onSelect={setSelectedWt}
                     tasks={tasks}
                     wt={wt}
@@ -196,6 +197,7 @@ function App() {
           onDelete={(name, branch) => { setSelectedWt(null); actions.deleteWorktree(name, branch); }}
           onLogs={actions.openLogs}
           onResource={actions.openResourceModal}
+          onRestore={(name) => { setSelectedWt(null); actions.restoreWorktree(name); }}
           tasks={tasks}
           wt={sheetWt}
         />

--- a/src/entrypoints/dashboard/client/components/detail-sheet.jsx
+++ b/src/entrypoints/dashboard/client/components/detail-sheet.jsx
@@ -24,7 +24,7 @@ import {cx} from '../lib/cx.js';
 import {CopyBtn} from './copy-btn.jsx';
 import {StatusPill} from './status-pill.jsx';
 
-export function DetailSheet({wt, tasks, onClose, onAction, onDb, onLogs, onResource, onDelete, onCopy, copiedPath}) {
+export function DetailSheet({wt, tasks, onClose, onAction, onDb, onLogs, onResource, onDelete, onRestore, onCopy, copiedPath}) {
   const running = isRunning(wt);
   const reasons = attentionReasons(wt);
   const ab = wt.aheadBehind || {};
@@ -244,6 +244,13 @@ export function DetailSheet({wt, tasks, onClose, onAction, onDb, onLogs, onResou
               {wt.env && (
                 <button class="btn" type="button" onClick={() => onAction(wt.name, 'recreate', null)}>
                   <IconRotateCcw size={14} />Recreate
+                </button>
+              )}
+              {wt.env && (
+                <button class="btn" type="button"
+                  style={{color: 'var(--red)'}}
+                  onClick={() => { onClose(); onRestore(wt.name); }}>
+                  <IconRotateCcw size={14} />Restore
                 </button>
               )}
               {!wt.isMain && (

--- a/src/entrypoints/dashboard/client/components/worktree-card.jsx
+++ b/src/entrypoints/dashboard/client/components/worktree-card.jsx
@@ -32,6 +32,7 @@ const ACTION_ICONS = {
   doctor: <IconSearch size={12} />,
   recreate: <IconRotateCcw size={12} />,
   restart: <IconPlay size={12} />,
+  restore: <IconRotateCcw size={12} />,
   start: <IconPlay size={12} />,
   stop: <IconSquare size={12} />,
 };
@@ -45,7 +46,7 @@ function actionIcon(action) {
   return null;
 }
 
-export function WorktreeCard({onAction, onCopy, onDelete, onDb, onLogs, onResource, onSelect, tasks, wt}) {
+export function WorktreeCard({onAction, onCopy, onDelete, onDb, onLogs, onResource, onRestore, onSelect, tasks, wt}) {
   const presentation = buildWorktreePresentation(wt, tasks);
   const running = isRunning(wt);
   const isStarting = isWorktreeStarting(tasks, wt.name);
@@ -143,7 +144,7 @@ export function WorktreeCard({onAction, onCopy, onDelete, onDb, onLogs, onResour
           </button>
         )}
         <MoreMenu actions={presentation.advancedActions} wt={wt}
-          onAction={onAction} onDb={onDb} onDelete={onDelete} onLogs={onLogs} onResource={onResource} />
+          onAction={onAction} onDb={onDb} onDelete={onDelete} onLogs={onLogs} onResource={onResource} onRestore={onRestore} />
       </div>
     </article>
   );
@@ -186,7 +187,7 @@ function CopyPathBtn({path, onCopy}) {
   );
 }
 
-function MoreMenu({actions, wt, onAction, onDb, onDelete, onLogs, onResource}) {
+function MoreMenu({actions, wt, onAction, onDb, onDelete, onLogs, onResource, onRestore}) {
   const detailsRef = useRef(null);
 
   useEffect(() => {
@@ -216,6 +217,7 @@ function MoreMenu({actions, wt, onAction, onDb, onDelete, onLogs, onResource}) {
     else if (action.target === 'resource') onResource(wt.name);
     else if (action.target === 'logs') onLogs(wt.name);
     else if (action.target === 'delete') onDelete(wt.name, wt.branch);
+    else if (action.target === 'restore') onRestore(wt.name);
   };
 
   return (

--- a/src/entrypoints/dashboard/client/lib/actions.ts
+++ b/src/entrypoints/dashboard/client/lib/actions.ts
@@ -26,6 +26,7 @@ const ACTION_BUTTONS: Partial<Record<string, Pick<WorktreeButton, 'className' | 
   delete: {className: 'btn-delete', label: 'Delete', target: 'delete'},
   'oauth-install': {className: 'btn-ghost', label: 'OAuth install', target: 'action'},
   recreate: {className: 'btn-ghost', label: 'Recreate', target: 'action'},
+  restore: {className: 'btn-ghost', label: 'Restore', target: 'restore'},
   start: {className: 'btn-start', label: 'Start', target: 'action'},
   stop: {className: 'btn-stop', label: 'Stop', target: 'action'},
 };

--- a/src/entrypoints/dashboard/client/lib/dashboard-actions.jsx
+++ b/src/entrypoints/dashboard/client/lib/dashboard-actions.jsx
@@ -17,6 +17,7 @@ export function useDashboardActions({fetchStatus, postJson, showToast}) {
   const [dbWorktree, setDbWorktree] = useState(null);
   const [deleteModal, setDeleteModal] = useState(null);
   const [infoModal, setInfoModal] = useState(null);
+  const [restoreModal, setRestoreModal] = useState(null);
   const [logModal, setLogModal] = useState(null);
   const [logText, setLogText] = useState('');
   const [resourceWorktree, setResourceWorktree] = useState(null);
@@ -125,6 +126,24 @@ export function useDashboardActions({fetchStatus, postJson, showToast}) {
     return true;
   };
 
+  const restoreWorktree = (name) => {
+    setRestoreModal({name, busy: false});
+  };
+
+  const confirmRestoreWorktree = async () => {
+    if (!restoreModal?.name || restoreModal.busy) return;
+    setRestoreModal((current) => (current ? {...current, busy: true} : current));
+    try {
+      await postJson(actionUrl(restoreModal.name, 'restore'));
+      setRestoreModal(null);
+      showToast(`Queued: restore ${restoreModal.name}`);
+      setTimeout(fetchStatus, 400);
+    } catch (err) {
+      setRestoreModal((current) => (current ? {...current, busy: false} : current));
+      showToast(`Error: ${String(err.message || err)}`);
+    }
+  };
+
   const confirmDeleteWorktree = async () => {
     if (!deleteModal?.name || deleteModal.busy) {
       return;
@@ -159,15 +178,19 @@ export function useDashboardActions({fetchStatus, postJson, showToast}) {
     dbWorktree,
     deleteModal,
     deleteWorktree,
-    hasOpenModal: Boolean(dbWorktree || deleteModal || infoModal || logModal || resourceWorktree),
+    hasOpenModal: Boolean(dbWorktree || deleteModal || infoModal || logModal || resourceWorktree || restoreModal),
     infoModal,
     logModal,
     logText,
+    closeRestoreModal: () => setRestoreModal(null),
+    confirmRestoreWorktree,
     openDbModal: setDbWorktree,
     openDoctor,
     openLogs,
     openResourceModal: setResourceWorktree,
     resourceWorktree,
+    restoreModal,
+    restoreWorktree,
     runAction,
     setDeleteModal,
   };
@@ -206,6 +229,12 @@ export function DashboardActionModals({actions, postJson, showToast}) {
           actions.setDeleteModal((current) => (current ? {...current, deleteBranch: checked} : current))
         }
         value={actions.deleteModal}
+      />
+      <RestoreWorktreeModal
+        isOpen={Boolean(actions.restoreModal)}
+        onClose={actions.closeRestoreModal}
+        onConfirm={actions.confirmRestoreWorktree}
+        value={actions.restoreModal}
       />
       <Modal
         footer={`${actions.logText.split('\n').filter(Boolean).length} lines`}
@@ -264,6 +293,34 @@ function DeleteWorktreeModal({isOpen, onClose, onConfirm, onToggleDeleteBranch, 
           </button>
           <button class="btn-primary btn-danger" disabled={value.busy} type="submit">
             {value.busy ? 'Queueing...' : 'Delete worktree'}
+          </button>
+        </div>
+      </form>
+    </ModalFrame>
+  );
+}
+
+function RestoreWorktreeModal({isOpen, onClose, onConfirm, value}) {
+  if (!isOpen || !value) return null;
+
+  return (
+    <ModalFrame maxWidth="560px" onClose={value.busy ? () => {} : onClose} subtitle={value.name} title="Restore environment">
+      <form
+        class="create-form"
+        onSubmit={(event) => {
+          event.preventDefault();
+          void onConfirm();
+        }}
+      >
+        <div class="field-hint">
+          This will replace all environment data (database, Liferay data, Elasticsearch, Document Library) with data from the main environment. The environment will restart automatically. This action cannot be undone.
+        </div>
+        <div class="create-actions">
+          <button class="btn-secondary" disabled={value.busy} type="button" onClick={onClose}>
+            Cancel
+          </button>
+          <button class="btn-primary btn-danger" disabled={value.busy} type="submit">
+            {value.busy ? 'Queueing...' : 'Restore environment'}
           </button>
         </div>
       </form>

--- a/src/entrypoints/dashboard/client/lib/worktree-presentation.js
+++ b/src/entrypoints/dashboard/client/lib/worktree-presentation.js
@@ -90,6 +90,10 @@ function worktreeActions(wt, running, stopped, primary, busy, activeWorktreeTask
         disabled: busyWorktree,
         label: busyWorktree ? busyLabel : 'Recreate',
       }),
+      worktreeButton('restore', {
+        disabled: busyWorktree,
+        label: busyWorktree ? busyLabel : 'Restore',
+      }),
     );
   }
 

--- a/src/entrypoints/dashboard/dashboard-action-catalog.ts
+++ b/src/entrypoints/dashboard/dashboard-action-catalog.ts
@@ -8,6 +8,7 @@ export type DashboardOperationKey =
   | 'worktree-env-init'
   | 'worktree-oauth-install'
   | 'worktree-repair'
+  | 'worktree-restore'
   | 'worktree-start'
   | 'worktree-stop';
 

--- a/src/entrypoints/dashboard/dashboard-actions.json
+++ b/src/entrypoints/dashboard/dashboard-actions.json
@@ -66,6 +66,15 @@
     "taskKind": "env-recreate"
   },
   {
+    "id": "restore",
+    "key": "worktree-restore",
+    "label": "Restoring environment for {worktree}",
+    "method": "POST",
+    "queueAction": "restore",
+    "route": "/api/worktrees/{worktree}/env/restore",
+    "taskKind": "env-restore"
+  },
+  {
     "id": "deploy-status",
     "deployAction": "status",
     "key": "worktree-deploy",

--- a/src/entrypoints/dashboard/dashboard-operation-routes.ts
+++ b/src/entrypoints/dashboard/dashboard-operation-routes.ts
@@ -6,7 +6,8 @@ import {formatDeployStatus, runDeployStatus} from '../../features/deploy/deploy-
 import {formatDoctor, runDoctor} from '../../features/doctor/doctor.service.js';
 import {runEnvRecreate, formatEnvRecreate} from '../../features/env/env-recreate.js';
 import {runEnvRestart, formatEnvRestart} from '../../features/env/env-restart.js';
-import {runEnvStart} from '../../features/env/env-start.js';
+import {formatEnvRestore, runEnvRestore} from '../../features/env/env-restore.js';
+import {formatEnvStart, runEnvStart} from '../../features/env/env-start.js';
 import {runEnvStop} from '../../features/env/env-stop.js';
 import {formatOAuthInstall, runOAuthInstall} from '../../features/oauth/oauth-install.js';
 import {runWorktreeClean} from '../../features/worktree/worktree-clean.js';
@@ -60,6 +61,8 @@ const QUEUED_OPERATION_RUNNERS: Partial<Record<DashboardOperationKey, QueuedOper
     runWorktreeOAuthInstall(deps.worktrees, requireWorktreeName(operation), printer),
   'worktree-repair': (operation, deps, printer, signal) =>
     runRepairOperation(deps.worktrees, requireWorktreeName(operation), operation.repairAction!, printer, signal),
+  'worktree-restore': (operation, deps, printer, signal) =>
+    runRestoreOperation(deps.worktrees, requireWorktreeName(operation), printer, signal),
   'worktree-start': (operation, deps, printer, signal) =>
     runWorktreeStart(deps.worktrees, requireWorktreeName(operation), printer, signal),
   'worktree-stop': (operation, deps, printer, signal) =>
@@ -238,6 +241,19 @@ async function previewDoctorOperation(resolver: DashboardWorktreeResolver, workt
     env: process.env,
     scopes: ['basic', 'runtime', 'portal'],
   });
+}
+
+async function runRestoreOperation(
+  resolver: DashboardWorktreeResolver,
+  worktreeName: string,
+  printer: Printer,
+  signal: AbortSignal,
+): Promise<void> {
+  const config = await resolver.resolveConfig(worktreeName);
+  const restoreResult = await runEnvRestore(config, {printer});
+  writeTaskLines(printer, formatEnvRestore(restoreResult));
+  const startResult = await runEnvStart(config, {printer, signal});
+  writeTaskLines(printer, formatEnvStart(startResult));
 }
 
 async function runRepairOperation(

--- a/tests/unit/dashboard-worktree-presentation.test.ts
+++ b/tests/unit/dashboard-worktree-presentation.test.ts
@@ -50,6 +50,7 @@ describe('buildWorktreePresentation', () => {
       'Deploy status',
       'Cache update',
       'Recreate',
+      'Restore',
       'Delete',
     ]);
   });


### PR DESCRIPTION
## Summary

- Adds a **Restore** button to the dashboard advanced actions menu and detail sheet, separate from the existing **Recreate** button
- Clicking Restore shows a confirmation modal with a clear warning before proceeding, since the operation replaces all environment data
- The backend handler chains `runEnvRestore` (stops env, replaces all data dirs from main) followed by `runEnvStart` (brings the environment back up)

## What Restore does vs Recreate

| | Recreate | Restore |
|---|---|---|
| Data | Kept intact | Replaced from main/BTRFS |
| Container | Force-recreated | Stopped, then started fresh |
| Use case | Refresh container config | Reset to clean baseline |

## Warning modal text

> "This will replace all environment data (database, Liferay data, Elasticsearch, Document Library) with data from the main environment. The environment will restart automatically. This action cannot be undone."

## Test plan

- [ ] Restore button appears in the advanced actions (⋯) menu for worktrees with an env
- [ ] Restore button appears in the detail sheet Operations section
- [ ] Clicking Restore opens the confirmation modal with the warning text
- [ ] Cancel closes the modal without doing anything
- [ ] Confirming queues the task and shows a toast
- [x] The task appears in the Activity panel and completes successfully
- [ ] TypeScript compiles clean (`npm run typecheck`)
- [x] All unit tests pass (`npm run test:unit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)