### PR TITLE
feat(portal): add diagnose guest-visibility command

### DIFF
--- a/docs/commands/discovery.md
+++ b/docs/commands/discovery.md
@@ -167,6 +167,28 @@ the Pages whose evidence matches the requested resource.
 Prefer `--site` whenever you already know the owning Site. Without it,
 `where-used` scans every accessible Site and can take much longer.
 
+## `ldev portal diagnose guest-visibility`
+
+Content created via Headless APIs does not always inherit the default Guest
+View permission the way UI-created content does, which breaks anonymous
+rendering silently. This command compares authenticated vs anonymous access
+and reports the exact permission gap instead of requiring a manual
+Playwright-vs-curl comparison.
+
+```bash
+ldev portal diagnose guest-visibility --url /web/guest/some-page
+ldev portal diagnose guest-visibility --site /global --page-size 50
+ldev portal diagnose guest-visibility --url /web/guest/some-page --json
+```
+
+- `--url <friendlyUrl>` — compares the authenticated vs anonymous render of one page
+- `--site <site>` — scans the site's structured contents and documents, comparing authenticated vs anonymous listings item by item
+- `--page-size <n>` — Headless page size for the `--site` scan (default `100`)
+
+Exits non-zero when a gap is found. Each finding names the missing permission
+(`VIEW` for role `Guest`) on the affected resource and, where possible, the
+permissions endpoint to call to fix it.
+
 Options:
 
 - `--type <fragment|widget|structure|template|adt>` — resource type to trace

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -20,7 +20,7 @@ If you want to understand what `ldev` is for, start with:
 
 - [Runtime](/commands/runtime) — start, stop, doctor, logs, env lifecycle
 - [Discovery](/commands/discovery) — context, portal check, inventory,
-  preflight, OAuth
+  preflight, OAuth, guest-visibility diagnostics
 - [Data and Deploy](/commands/data-and-deploy) — db sync/import, document
   library, deploy module/theme/all, content prune
 - [Resources](/commands/resources) — structures, templates, ADTs, fragments,

--- a/src/commands/liferay/diagnose.command.ts
+++ b/src/commands/liferay/diagnose.command.ts
@@ -1,0 +1,45 @@
+import {Command} from 'commander';
+
+import {addOutputFormatOption, createFormattedAction} from '../../cli/command-helpers.js';
+import {
+  formatGuestVisibilityReport,
+  runGuestVisibilityDiagnosis,
+} from '../../features/liferay/diagnose/liferay-guest-visibility.js';
+
+type GuestVisibilityCommandOptions = {
+  url?: string;
+  site?: string;
+  pageSize?: string;
+};
+
+export function createDiagnoseCommands(parent: Command): void {
+  const diagnose = new Command('diagnose').description('Runtime diagnostics for common Liferay content bugs');
+  diagnose.helpGroup('Portal diagnostics:');
+
+  addOutputFormatOption(
+    diagnose
+      .command('guest-visibility')
+      .description(
+        'Compare authenticated vs anonymous access to detect content missing the default Guest View permission',
+      )
+      .option('--url <friendlyUrl>', 'Public page URL, like /web/guest/home')
+      .option('--site <site>', 'Site friendly URL or numeric ID (scans structured contents and documents)')
+      .option('--page-size <pageSize>', 'Headless page size for the content scan', '100'),
+    'json',
+  ).action(
+    createFormattedAction(
+      async (context, options: GuestVisibilityCommandOptions) =>
+        runGuestVisibilityDiagnosis(context.config, {
+          url: options.url,
+          site: options.site,
+          pageSize: Number.parseInt(options.pageSize ?? '100', 10) || 100,
+        }),
+      {
+        text: formatGuestVisibilityReport,
+        exitCode: (result) => (result.ok ? 0 : 1),
+      },
+    ),
+  );
+
+  parent.addCommand(diagnose);
+}

--- a/src/commands/liferay/liferay.command.ts
+++ b/src/commands/liferay/liferay.command.ts
@@ -4,6 +4,7 @@ import {createReindexCommand} from '../reindex/reindex.command.js';
 import {createAuthCommands} from './auth.command.js';
 import {createContentCommand} from './content.command.js';
 import {createLiferayConfigCommand} from './config.command.js';
+import {createDiagnoseCommands} from './diagnose.command.js';
 import {createInventoryCommands} from './inventory.command.js';
 import {createLiferayAuditCommands} from './liferay-audit.command.js';
 import {createPageLayoutCommands} from './page-layout.command.js';
@@ -51,6 +52,7 @@ Main groups:
   inventory    Sites, pages, structures and templates
   audit        Minimal runtime audit of a site and API reachability
   page-layout  Export and diff of content pages
+  diagnose     Runtime diagnostics for common content bugs (e.g. guest-visibility)
   search       Elasticsearch inspection and test queries
   theme-check  Validate Clay icon coverage in a deployed theme
   reindex      Reindex observation and temporary tuning
@@ -64,6 +66,7 @@ Main groups:
   command.addCommand(createContentCommand().helpGroup('Content management:'));
   createLiferayAuditCommands(command);
   createPageLayoutCommands(command);
+  createDiagnoseCommands(command);
   command.addCommand(createLiferaySearchCommand().helpGroup('Portal diagnostics:'));
   command.addCommand(createLiferayThemeCheckCommand().helpGroup('Portal diagnostics:'));
   command.addCommand(createReindexCommand().helpGroup('Portal diagnostics:'));

--- a/src/features/liferay/diagnose/liferay-guest-visibility.ts
+++ b/src/features/liferay/diagnose/liferay-guest-visibility.ts
@@ -6,7 +6,7 @@ import {trimLeadingSlash} from '../../../core/utils/text.js';
 import {LiferayErrors} from '../errors/index.js';
 import {fetchPagedItems} from '../inventory/liferay-inventory-shared.js';
 import {createLiferayGateway, type LiferayGateway} from '../liferay-gateway.js';
-import {resolveSite} from '../portal/site-resolution.js';
+import {resolveSite, type ResolvedSite} from '../portal/site-resolution.js';
 
 const REPORT_KIND = 'liferay-guest-visibility-diagnosis';
 const REPORT_SCHEMA_VERSION = 1;
@@ -33,6 +33,12 @@ type PermissionEntry = {
   actionIds?: string[];
 };
 
+// The Headless Delivery `.../permissions` endpoint returns a page-shaped
+// object ({items, page, lastPage, ...}), not a bare array.
+type PermissionsPage = {
+  items?: PermissionEntry[];
+};
+
 export type GuestVisibilityGap = {
   resourceType: GuestVisibilityResourceType;
   id: number;
@@ -47,11 +53,23 @@ export type GuestVisibilityGap = {
 };
 
 export type GuestVisibilityPageCheck = {
-  url: string;
   friendlyUrl: string;
+  renderedUrl: string;
+  /**
+   * Whether the OAuth2-authenticated caller can see the page through the
+   * headless page-metadata API. OAuth2 Bearer tokens do not authenticate the
+   * normal theme-rendering pipeline (confirmed: an authenticated Bearer
+   * request and an anonymous request return byte-identical rendered pages),
+   * so this is the only "authenticated" signal available without a
+   * cookie-based portal session.
+   */
   visibleAuthenticated: boolean;
-  anonymousStatus: number;
-  visibleAnonymously: boolean;
+  /** Anonymous access to the headless page-metadata API (`/o/headless-delivery/...`). */
+  headlessAnonymousStatus: number;
+  headlessVisibleAnonymously: boolean;
+  /** Anonymous access to the real rendered page URL — the ground truth for guest visibility. */
+  renderedAnonymousStatus: number;
+  renderedVisibleAnonymously: boolean;
 };
 
 export type GuestVisibilityReport = {
@@ -137,7 +155,7 @@ export async function runGuestVisibilityDiagnosis(
     if (target.pageFriendlyUrl === '/') {
       notes.push('Site root URLs are not checked at page level; content scan still runs for the whole site.');
     } else {
-      page = await checkPageGuestVisibility(config, apiClient, gateway, site.id, target.pageFriendlyUrl);
+      page = await checkPageGuestVisibility(config, apiClient, gateway, site, target.pageFriendlyUrl, notes);
     }
   }
 
@@ -152,7 +170,7 @@ export async function runGuestVisibilityDiagnosis(
     gaps.push(...result.gaps);
   }
 
-  const pageOk = page === undefined || page.visibleAnonymously || !page.visibleAuthenticated;
+  const pageOk = page === undefined || page.renderedVisibleAnonymously || !page.visibleAuthenticated;
 
   return {
     kind: REPORT_KIND,
@@ -223,23 +241,40 @@ async function checkPageGuestVisibility(
   config: AppConfig,
   apiClient: HttpApiClient,
   gateway: LiferayGateway,
-  siteId: number,
+  site: ResolvedSite,
   friendlyUrl: string,
+  notes: string[],
 ): Promise<GuestVisibilityPageCheck> {
   const slug = trimLeadingSlash(friendlyUrl);
-  const pagePath = `/o/headless-delivery/v1.0/sites/${siteId}/site-pages/${slug}`;
+  const pagePath = `/o/headless-delivery/v1.0/sites/${site.id}/site-pages/${slug}`;
+  const renderedUrl = `/web${site.friendlyUrlPath}${friendlyUrl}`;
 
-  const authenticatedResponse = await gateway.getRaw<unknown>(pagePath);
-  const anonymousResponse = await apiClient.get<unknown>(config.liferay.url, pagePath, {
-    timeoutSeconds: config.liferay.timeoutSeconds,
-  });
+  const [authenticatedApiResponse, anonymousApiResponse, anonymousRenderedResponse] = await Promise.all([
+    gateway.getRaw<unknown>(pagePath),
+    apiClient.get<unknown>(config.liferay.url, pagePath, {timeoutSeconds: config.liferay.timeoutSeconds}),
+    apiClient.get<unknown>(config.liferay.url, renderedUrl, {timeoutSeconds: config.liferay.timeoutSeconds}),
+  ]);
+
+  if (authenticatedApiResponse.ok && anonymousApiResponse.ok !== anonymousRenderedResponse.ok) {
+    notes.push(
+      anonymousRenderedResponse.ok
+        ? `The headless page API (${pagePath}) is blocked for anonymous users (status=${anonymousApiResponse.status}) ` +
+            `but the rendered page itself (${renderedUrl}) is visible anonymously (status=${anonymousRenderedResponse.status}); ` +
+            'this usually reflects an instance-level restriction on the headless API, not a Guest View gap on the page.'
+        : `The rendered page (${renderedUrl}) is hidden for anonymous users (status=${anonymousRenderedResponse.status}) ` +
+            `even though the headless page API reports it as accessible (status=${anonymousApiResponse.status}); ` +
+            'check page-level and layout permissions.',
+    );
+  }
 
   return {
-    url: friendlyUrl,
     friendlyUrl,
-    visibleAuthenticated: authenticatedResponse.ok,
-    anonymousStatus: anonymousResponse.status,
-    visibleAnonymously: anonymousResponse.ok,
+    renderedUrl,
+    visibleAuthenticated: authenticatedApiResponse.ok,
+    headlessAnonymousStatus: anonymousApiResponse.status,
+    headlessVisibleAnonymously: anonymousApiResponse.ok,
+    renderedAnonymousStatus: anonymousRenderedResponse.status,
+    renderedVisibleAnonymously: anonymousRenderedResponse.ok,
   };
 }
 
@@ -292,9 +327,9 @@ async function buildGapForItem(
   const title = item.title ?? item.fileName ?? `#${id}`;
   const permissionsPath = `${kind.itemBasePath}/${id}/permissions`;
 
-  const permissionsResponse = await gateway.getRaw<PermissionEntry[]>(permissionsPath);
+  const permissionsResponse = await gateway.getRaw<PermissionsPage>(permissionsPath);
   const permissions =
-    permissionsResponse.ok && Array.isArray(permissionsResponse.data) ? permissionsResponse.data : null;
+    permissionsResponse.ok && Array.isArray(permissionsResponse.data?.items) ? permissionsResponse.data.items : null;
 
   if (permissions === null) {
     // Without readable permissions we can only report a gap when the anonymous
@@ -358,9 +393,12 @@ async function buildGapForItem(
 function buildFixSuggestion(baseUrl: string, permissionsPath: string, guestActionIds: string[]): string {
   const fixedActionIds = JSON.stringify([...guestActionIds, VIEW_ACTION_ID]);
   return (
-    `Grant role ${GUEST_ROLE_NAME} the ${VIEW_ACTION_ID} action: PUT ${baseUrl}${permissionsPath} ` +
-    `with the current role entries plus {"roleName":"${GUEST_ROLE_NAME}","actionIds":${fixedActionIds}} ` +
-    `(UI equivalent: Permissions action on the resource, check View for Guest).`
+    `Grant role ${GUEST_ROLE_NAME} the ${VIEW_ACTION_ID} action: GET ${baseUrl}${permissionsPath} to read the ` +
+    `current "items" array, then PUT ${baseUrl}${permissionsPath} with that same array as a bare JSON array ` +
+    `(not wrapped in "items" — the replace endpoint expects a top-level array, unlike the GET response shape), ` +
+    `replacing the ${GUEST_ROLE_NAME} entry's actionIds with ${fixedActionIds} (or adding ` +
+    `{"roleName":"${GUEST_ROLE_NAME}","actionIds":${fixedActionIds}} if Guest has no entry at all). ` +
+    `UI equivalent: Permissions action on the resource, check View for Guest.`
   );
 }
 
@@ -408,10 +446,16 @@ export function formatGuestVisibilityReport(report: GuestVisibilityReport): stri
 
   if (report.page) {
     const authenticatedLabel = report.page.visibleAuthenticated ? 'visible' : 'hidden';
-    const anonymousLabel = report.page.visibleAnonymously ? 'visible' : 'hidden';
+    const renderedLabel = report.page.renderedVisibleAnonymously ? 'visible' : 'hidden';
     lines.push(
-      `page ${report.page.friendlyUrl}: authenticated=${authenticatedLabel} anonymous=${anonymousLabel} (anonymousStatus=${report.page.anonymousStatus})`,
+      `page ${report.page.renderedUrl}: authenticated(headlessApi)=${authenticatedLabel} anonymous(rendered)=${renderedLabel} (status=${report.page.renderedAnonymousStatus})`,
     );
+    if (report.page.headlessVisibleAnonymously !== report.page.renderedVisibleAnonymously) {
+      const headlessLabel = report.page.headlessVisibleAnonymously ? 'visible' : 'hidden';
+      lines.push(
+        `  headlessApi anonymous=${headlessLabel} (status=${report.page.headlessAnonymousStatus}) differs from the rendered page — see notes`,
+      );
+    }
   }
 
   lines.push(

--- a/src/features/liferay/diagnose/liferay-guest-visibility.ts
+++ b/src/features/liferay/diagnose/liferay-guest-visibility.ts
@@ -1,0 +1,444 @@
+import type {AppConfig} from '../../../core/config/load-config.js';
+import {mapConcurrent} from '../../../core/concurrency.js';
+import {createOAuthTokenClient, type OAuthTokenClient} from '../../../core/http/auth.js';
+import {createLiferayApiClient, type HttpApiClient} from '../../../core/http/client.js';
+import {trimLeadingSlash} from '../../../core/utils/text.js';
+import {LiferayErrors} from '../errors/index.js';
+import {fetchPagedItems} from '../inventory/liferay-inventory-shared.js';
+import {createLiferayGateway, type LiferayGateway} from '../liferay-gateway.js';
+import {resolveSite} from '../portal/site-resolution.js';
+
+const REPORT_KIND = 'liferay-guest-visibility-diagnosis';
+const REPORT_SCHEMA_VERSION = 1;
+const GUEST_ROLE_NAME = 'Guest';
+const VIEW_ACTION_ID = 'VIEW';
+const PERMISSION_FETCH_CONCURRENCY = 4;
+
+export type GuestVisibilityResourceType = 'structuredContent' | 'document';
+
+type HeadlessListItem = {
+  id?: number;
+  title?: string;
+  friendlyUrlPath?: string;
+  fileName?: string;
+};
+
+type HeadlessListPage = {
+  items?: HeadlessListItem[];
+  lastPage?: number;
+};
+
+type PermissionEntry = {
+  roleName?: string;
+  actionIds?: string[];
+};
+
+export type GuestVisibilityGap = {
+  resourceType: GuestVisibilityResourceType;
+  id: number;
+  title: string;
+  visibleAuthenticated: true;
+  visibleAnonymously: false;
+  guestHasViewPermission: boolean | null;
+  missingPermission: typeof VIEW_ACTION_ID | null;
+  diagnosis: string;
+  fix: string | null;
+  permissionsPath: string;
+};
+
+export type GuestVisibilityPageCheck = {
+  url: string;
+  friendlyUrl: string;
+  visibleAuthenticated: boolean;
+  anonymousStatus: number;
+  visibleAnonymously: boolean;
+};
+
+export type GuestVisibilityReport = {
+  kind: typeof REPORT_KIND;
+  schemaVersion: typeof REPORT_SCHEMA_VERSION;
+  generatedAt: string;
+  baseUrl: string;
+  site: {
+    id: number;
+    friendlyUrlPath: string;
+    name: string;
+  };
+  page?: GuestVisibilityPageCheck;
+  anonymousApiAccessible: {
+    structuredContents: boolean;
+    documents: boolean;
+  };
+  checked: {
+    structuredContents: number;
+    documents: number;
+  };
+  gaps: GuestVisibilityGap[];
+  notes: string[];
+  ok: boolean;
+};
+
+export type GuestVisibilityOptions = {
+  url?: string;
+  site?: string;
+  pageSize?: number;
+};
+
+type GuestVisibilityDependencies = {
+  apiClient?: HttpApiClient;
+  tokenClient?: OAuthTokenClient;
+  now?: () => Date;
+};
+
+type ResourceKindDescriptor = {
+  resourceType: GuestVisibilityResourceType;
+  reportKey: 'structuredContents' | 'documents';
+  listPath: (siteId: number) => string;
+  itemBasePath: string;
+};
+
+const RESOURCE_KINDS: ResourceKindDescriptor[] = [
+  {
+    resourceType: 'structuredContent',
+    reportKey: 'structuredContents',
+    listPath: (siteId) => `/o/headless-delivery/v1.0/sites/${siteId}/structured-contents?flatten=true`,
+    itemBasePath: '/o/headless-delivery/v1.0/structured-contents',
+  },
+  {
+    resourceType: 'document',
+    reportKey: 'documents',
+    listPath: (siteId) => `/o/headless-delivery/v1.0/sites/${siteId}/documents?flatten=true`,
+    itemBasePath: '/o/headless-delivery/v1.0/documents',
+  },
+];
+
+type DiagnosisTarget = {
+  site: string;
+  pageFriendlyUrl?: string;
+};
+
+export async function runGuestVisibilityDiagnosis(
+  config: AppConfig,
+  options: GuestVisibilityOptions,
+  dependencies?: GuestVisibilityDependencies,
+): Promise<GuestVisibilityReport> {
+  const apiClient = dependencies?.apiClient ?? createLiferayApiClient();
+  const tokenClient = dependencies?.tokenClient ?? createOAuthTokenClient();
+  const gateway = createLiferayGateway(config, apiClient, tokenClient);
+  const pageSize = options.pageSize ?? 100;
+
+  const target = resolveDiagnosisTarget(options);
+  const site = await resolveSite(config, target.site, {apiClient, tokenClient});
+
+  const notes: string[] = [];
+  let page: GuestVisibilityPageCheck | undefined;
+
+  if (target.pageFriendlyUrl) {
+    if (target.pageFriendlyUrl === '/') {
+      notes.push('Site root URLs are not checked at page level; content scan still runs for the whole site.');
+    } else {
+      page = await checkPageGuestVisibility(config, apiClient, gateway, site.id, target.pageFriendlyUrl);
+    }
+  }
+
+  const anonymousApiAccessible = {structuredContents: true, documents: true};
+  const checked = {structuredContents: 0, documents: 0};
+  const gaps: GuestVisibilityGap[] = [];
+
+  for (const kind of RESOURCE_KINDS) {
+    const result = await diagnoseResourceKind(config, apiClient, gateway, site.id, kind, pageSize, notes);
+    anonymousApiAccessible[kind.reportKey] = result.anonymousApiAccessible;
+    checked[kind.reportKey] = result.checkedCount;
+    gaps.push(...result.gaps);
+  }
+
+  const pageOk = page === undefined || page.visibleAnonymously || !page.visibleAuthenticated;
+
+  return {
+    kind: REPORT_KIND,
+    schemaVersion: REPORT_SCHEMA_VERSION,
+    generatedAt: (dependencies?.now ?? (() => new Date()))().toISOString(),
+    baseUrl: config.liferay.url,
+    site: {
+      id: site.id,
+      friendlyUrlPath: site.friendlyUrlPath,
+      name: site.name,
+    },
+    ...(page === undefined ? {} : {page}),
+    anonymousApiAccessible,
+    checked,
+    gaps,
+    notes,
+    ok: gaps.length === 0 && pageOk,
+  };
+}
+
+function resolveDiagnosisTarget(options: GuestVisibilityOptions): DiagnosisTarget {
+  if (options.url) {
+    return parsePublicPageUrl(options.url);
+  }
+
+  if (options.site) {
+    return {site: options.site};
+  }
+
+  throw LiferayErrors.diagnoseError('Provide --url (like /web/guest/home) or --site.');
+}
+
+function parsePublicPageUrl(rawUrl: string): DiagnosisTarget {
+  let sanitized = rawUrl.trim();
+
+  try {
+    sanitized = new URL(sanitized).pathname;
+  } catch {
+    // Keep relative paths as they are.
+  }
+
+  sanitized = sanitized.split('#')[0].split('?')[0];
+
+  const localeMatch = sanitized.match(/^\/[a-z]{2}(?:_[A-Z]{2})?(\/web\/.*)$/);
+  if (localeMatch) {
+    sanitized = localeMatch[1];
+  }
+
+  if (!sanitized.startsWith('/web/')) {
+    throw LiferayErrors.diagnoseError(
+      `Only public page URLs like /web/{site}/{page} are supported; received '${rawUrl}'. Use --site for private or root-level checks.`,
+    );
+  }
+
+  const rest = sanitized.slice('/web/'.length);
+  const slashIndex = rest.indexOf('/');
+  const siteSlug = slashIndex > 0 ? rest.slice(0, slashIndex) : rest;
+  const friendlyUrl = slashIndex > 0 ? rest.slice(slashIndex) : '/';
+
+  if (siteSlug === '') {
+    throw LiferayErrors.diagnoseError(`Could not extract a site from URL '${rawUrl}'.`);
+  }
+
+  return {site: `/${siteSlug}`, pageFriendlyUrl: friendlyUrl};
+}
+
+async function checkPageGuestVisibility(
+  config: AppConfig,
+  apiClient: HttpApiClient,
+  gateway: LiferayGateway,
+  siteId: number,
+  friendlyUrl: string,
+): Promise<GuestVisibilityPageCheck> {
+  const slug = trimLeadingSlash(friendlyUrl);
+  const pagePath = `/o/headless-delivery/v1.0/sites/${siteId}/site-pages/${slug}`;
+
+  const authenticatedResponse = await gateway.getRaw<unknown>(pagePath);
+  const anonymousResponse = await apiClient.get<unknown>(config.liferay.url, pagePath, {
+    timeoutSeconds: config.liferay.timeoutSeconds,
+  });
+
+  return {
+    url: friendlyUrl,
+    friendlyUrl,
+    visibleAuthenticated: authenticatedResponse.ok,
+    anonymousStatus: anonymousResponse.status,
+    visibleAnonymously: anonymousResponse.ok,
+  };
+}
+
+async function diagnoseResourceKind(
+  config: AppConfig,
+  apiClient: HttpApiClient,
+  gateway: LiferayGateway,
+  siteId: number,
+  kind: ResourceKindDescriptor,
+  pageSize: number,
+  notes: string[],
+): Promise<{anonymousApiAccessible: boolean; checkedCount: number; gaps: GuestVisibilityGap[]}> {
+  const listPath = kind.listPath(siteId);
+  const authenticatedItems = await fetchPagedItems<HeadlessListItem>(config, listPath, pageSize, {
+    apiClient,
+    gateway,
+  });
+
+  const anonymous = await fetchAnonymousItemIds(config, apiClient, listPath, pageSize);
+
+  if (!anonymous.accessible) {
+    notes.push(
+      `Anonymous access to ${listPath} is not available (status=${anonymous.status}); falling back to a permissions-only check for ${kind.reportKey}.`,
+    );
+  }
+
+  const candidates = anonymous.accessible
+    ? authenticatedItems.filter((item) => typeof item.id === 'number' && !anonymous.ids.has(item.id))
+    : authenticatedItems.filter((item) => typeof item.id === 'number');
+
+  const gaps = await mapConcurrent(candidates, PERMISSION_FETCH_CONCURRENCY, async (item) =>
+    buildGapForItem(config, gateway, kind, item, anonymous.accessible),
+  );
+
+  return {
+    anonymousApiAccessible: anonymous.accessible,
+    checkedCount: authenticatedItems.length,
+    gaps: gaps.filter((gap): gap is GuestVisibilityGap => gap !== null),
+  };
+}
+
+async function buildGapForItem(
+  config: AppConfig,
+  gateway: LiferayGateway,
+  kind: ResourceKindDescriptor,
+  item: HeadlessListItem,
+  anonymousApiAccessible: boolean,
+): Promise<GuestVisibilityGap | null> {
+  const id = item.id as number;
+  const title = item.title ?? item.fileName ?? `#${id}`;
+  const permissionsPath = `${kind.itemBasePath}/${id}/permissions`;
+
+  const permissionsResponse = await gateway.getRaw<PermissionEntry[]>(permissionsPath);
+  const permissions =
+    permissionsResponse.ok && Array.isArray(permissionsResponse.data) ? permissionsResponse.data : null;
+
+  if (permissions === null) {
+    // Without readable permissions we can only report a gap when the anonymous
+    // fetch already proved the resource is hidden for Guest.
+    if (!anonymousApiAccessible) {
+      return null;
+    }
+
+    return {
+      resourceType: kind.resourceType,
+      id,
+      title,
+      visibleAuthenticated: true,
+      visibleAnonymously: false,
+      guestHasViewPermission: null,
+      missingPermission: null,
+      diagnosis: `${kind.resourceType} ${id} ("${title}") is visible authenticated but hidden for anonymous users; its permissions could not be read (status=${permissionsResponse.status}). Check the OAuth2 client scopes.`,
+      fix: null,
+      permissionsPath,
+    };
+  }
+
+  const guestEntry = permissions.find((entry) => entry.roleName === GUEST_ROLE_NAME);
+  const guestActionIds = guestEntry?.actionIds ?? [];
+  const guestHasView = guestActionIds.includes(VIEW_ACTION_ID);
+
+  if (guestHasView) {
+    // Permissions-only mode: nothing proves the resource is hidden, so no gap.
+    if (!anonymousApiAccessible) {
+      return null;
+    }
+
+    return {
+      resourceType: kind.resourceType,
+      id,
+      title,
+      visibleAuthenticated: true,
+      visibleAnonymously: false,
+      guestHasViewPermission: true,
+      missingPermission: null,
+      diagnosis: `${kind.resourceType} ${id} ("${title}") is hidden for anonymous users even though role ${GUEST_ROLE_NAME} has ${VIEW_ACTION_ID} on the resource itself. Check guest access on the parent folder, the site, or portal guest-API settings.`,
+      fix: null,
+      permissionsPath,
+    };
+  }
+
+  return {
+    resourceType: kind.resourceType,
+    id,
+    title,
+    visibleAuthenticated: true,
+    visibleAnonymously: false,
+    guestHasViewPermission: false,
+    missingPermission: VIEW_ACTION_ID,
+    diagnosis: `Missing ${VIEW_ACTION_ID} permission for role ${GUEST_ROLE_NAME} on ${kind.resourceType} ${id} ("${title}"). This is the known gap for headless-created content: it does not inherit the default Guest View grant that UI-created content gets.`,
+    fix: buildFixSuggestion(config.liferay.url, permissionsPath, guestActionIds),
+    permissionsPath,
+  };
+}
+
+function buildFixSuggestion(baseUrl: string, permissionsPath: string, guestActionIds: string[]): string {
+  const fixedActionIds = JSON.stringify([...guestActionIds, VIEW_ACTION_ID]);
+  return (
+    `Grant role ${GUEST_ROLE_NAME} the ${VIEW_ACTION_ID} action: PUT ${baseUrl}${permissionsPath} ` +
+    `with the current role entries plus {"roleName":"${GUEST_ROLE_NAME}","actionIds":${fixedActionIds}} ` +
+    `(UI equivalent: Permissions action on the resource, check View for Guest).`
+  );
+}
+
+async function fetchAnonymousItemIds(
+  config: AppConfig,
+  apiClient: HttpApiClient,
+  basePath: string,
+  pageSize: number,
+): Promise<{accessible: boolean; status: number; ids: Set<number>}> {
+  const ids = new Set<number>();
+  let page = 1;
+  let lastPage = 1;
+
+  while (page <= lastPage) {
+    const separator = basePath.includes('?') ? '&' : '?';
+    const response = await apiClient.get<HeadlessListPage>(
+      config.liferay.url,
+      `${basePath}${separator}page=${page}&pageSize=${pageSize}`,
+      {timeoutSeconds: config.liferay.timeoutSeconds},
+    );
+
+    if (!response.ok) {
+      return {accessible: false, status: response.status, ids: new Set()};
+    }
+
+    for (const item of response.data?.items ?? []) {
+      if (typeof item.id === 'number') {
+        ids.add(item.id);
+      }
+    }
+
+    lastPage = response.data?.lastPage ?? 1;
+    page += 1;
+  }
+
+  return {accessible: true, status: 200, ids};
+}
+
+export function formatGuestVisibilityReport(report: GuestVisibilityReport): string {
+  const lines: string[] = [
+    report.ok ? 'GUEST_VISIBILITY_OK' : 'GUEST_VISIBILITY_GAPS',
+    `baseUrl=${report.baseUrl}`,
+    `site=${report.site.friendlyUrlPath} (${report.site.id}) ${report.site.name}`.trimEnd(),
+  ];
+
+  if (report.page) {
+    const authenticatedLabel = report.page.visibleAuthenticated ? 'visible' : 'hidden';
+    const anonymousLabel = report.page.visibleAnonymously ? 'visible' : 'hidden';
+    lines.push(
+      `page ${report.page.friendlyUrl}: authenticated=${authenticatedLabel} anonymous=${anonymousLabel} (anonymousStatus=${report.page.anonymousStatus})`,
+    );
+  }
+
+  lines.push(
+    `checked structuredContents=${report.checked.structuredContents} documents=${report.checked.documents}`,
+    `anonymousApi structuredContents=${formatAccessLabel(report.anonymousApiAccessible.structuredContents)} documents=${formatAccessLabel(report.anonymousApiAccessible.documents)}`,
+  );
+
+  if (report.gaps.length > 0) {
+    lines.push('', `Gaps (${report.gaps.length}):`);
+    for (const gap of report.gaps) {
+      lines.push(`- ${gap.diagnosis}`);
+      if (gap.fix) {
+        lines.push(`  fix: ${gap.fix}`);
+      }
+    }
+  }
+
+  if (report.notes.length > 0) {
+    lines.push('', 'Notes:');
+    for (const note of report.notes) {
+      lines.push(`- ${note}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+function formatAccessLabel(accessible: boolean): string {
+  return accessible ? 'ok' : 'unavailable';
+}

--- a/src/features/liferay/errors/liferay-error-codes.ts
+++ b/src/features/liferay/errors/liferay-error-codes.ts
@@ -38,6 +38,9 @@ export enum LiferayErrorCode {
   // Theme/Page errors
   THEME_ERROR = 'LIFERAY_THEME_ERROR',
   PAGE_LAYOUT_ERROR = 'LIFERAY_PAGE_LAYOUT_ERROR',
+
+  // Diagnose errors
+  DIAGNOSE_ERROR = 'LIFERAY_DIAGNOSE_ERROR',
 }
 
 /**
@@ -75,6 +78,8 @@ export const errorCodeMetadata: Record<
 
   [LiferayErrorCode.THEME_ERROR]: {severity: 'error', retryable: false, logFullMessage: false},
   [LiferayErrorCode.PAGE_LAYOUT_ERROR]: {severity: 'error', retryable: false, logFullMessage: false},
+
+  [LiferayErrorCode.DIAGNOSE_ERROR]: {severity: 'error', retryable: false, logFullMessage: false},
 };
 
 /**

--- a/src/features/liferay/errors/liferay-error-factory.ts
+++ b/src/features/liferay/errors/liferay-error-factory.ts
@@ -152,6 +152,12 @@ export const LiferayErrors = {
     createLiferayError(message, LiferayErrorCode.PAGE_LAYOUT_ERROR, options),
 
   /**
+   * Diagnose command operation failed (invalid input, unsupported target, etc.).
+   */
+  diagnoseError: (message: string, options?: LiferayErrorOptions): CliError =>
+    createLiferayError(message, LiferayErrorCode.DIAGNOSE_ERROR, options),
+
+  /**
    * Convert a code string to metadata and check if retryable.
    */
   isRetryable: (code: string): boolean => {

--- a/tests/unit/liferay-guest-visibility.test.ts
+++ b/tests/unit/liferay-guest-visibility.test.ts
@@ -61,7 +61,10 @@ describe('guest-visibility diagnosis', () => {
         }
 
         if (url.endsWith('/structured-contents/1/permissions')) {
-          return new Response('[{"roleName":"Owner","actionIds":["VIEW","UPDATE"]}]', {status: 200});
+          // Liferay's permissions endpoint is page-shaped, not a bare array.
+          return new Response('{"items":[{"roleName":"Owner","actionIds":["VIEW","UPDATE"]}],"lastPage":1}', {
+            status: 200,
+          });
         }
 
         throw new Error(`Unexpected URL ${url}`);
@@ -95,7 +98,7 @@ describe('guest-visibility diagnosis', () => {
     expect(text).toContain('Missing VIEW permission for role Guest');
   });
 
-  test('detects a page hidden anonymously via --url', async () => {
+  test('detects a page hidden anonymously via --url (both the headless API and the rendered page agree)', async () => {
     const apiClient = createLiferayApiClient({
       fetchImpl: createTestFetchImpl((url, init) => {
         if (url.includes('/by-friendly-url-path/guest')) {
@@ -107,6 +110,10 @@ describe('guest-visibility diagnosis', () => {
             return new Response('{"id":5001,"title":"Home"}', {status: 200});
           }
           return new Response('{}', {status: 403});
+        }
+
+        if (url.endsWith('/web/guest/home')) {
+          return new Response('', {status: 403});
         }
 
         if (url.includes('/structured-contents?flatten=true') || url.includes('/documents?flatten=true')) {
@@ -125,12 +132,59 @@ describe('guest-visibility diagnosis', () => {
 
     expect(report.page).toMatchObject({
       friendlyUrl: '/home',
+      renderedUrl: '/web/guest/home',
       visibleAuthenticated: true,
-      visibleAnonymously: false,
-      anonymousStatus: 403,
+      headlessVisibleAnonymously: false,
+      renderedVisibleAnonymously: false,
+      renderedAnonymousStatus: 403,
     });
     expect(report.ok).toBe(false);
     expect(report.gaps).toHaveLength(0);
+    // Both signals agree (both hidden), so no divergence note for the page check.
+    expect(report.notes.some((note) => note.includes('headless page API'))).toBe(false);
+  });
+
+  test('does not flag a page whose headless API is blocked anonymously but that still renders fine (real-world instance-level API lockdown)', async () => {
+    const apiClient = createLiferayApiClient({
+      fetchImpl: createTestFetchImpl((url, init) => {
+        if (url.includes('/by-friendly-url-path/guest')) {
+          return new Response('{"id":20121,"friendlyUrlPath":"/guest","name":"Guest"}', {status: 200});
+        }
+
+        if (url.endsWith('/site-pages/home')) {
+          if (hasAuthHeader(init)) {
+            return new Response('{"id":5001,"title":"Home"}', {status: 200});
+          }
+          // Headless API itself rejects anonymous requests regardless of the page's real permissions.
+          return new Response('', {status: 403});
+        }
+
+        if (url.endsWith('/web/guest/home')) {
+          // The actual rendered page works fine for anonymous visitors.
+          return new Response('<html>ok</html>', {status: 200});
+        }
+
+        if (url.includes('/structured-contents?flatten=true') || url.includes('/documents?flatten=true')) {
+          return emptyPage();
+        }
+
+        throw new Error(`Unexpected URL ${url}`);
+      }),
+    });
+
+    const report = await runGuestVisibilityDiagnosis(
+      CONFIG,
+      {url: '/web/guest/home'},
+      {apiClient, tokenClient: TOKEN_CLIENT},
+    );
+
+    expect(report.page).toMatchObject({
+      visibleAuthenticated: true,
+      headlessVisibleAnonymously: false,
+      renderedVisibleAnonymously: true,
+    });
+    expect(report.ok).toBe(true);
+    expect(report.notes.some((note) => note.includes('instance-level restriction on the headless API'))).toBe(true);
   });
 
   test('falls back to a permissions-only check when the anonymous list endpoint itself is blocked', async () => {
@@ -155,11 +209,11 @@ describe('guest-visibility diagnosis', () => {
         }
 
         if (url.endsWith('/structured-contents/1/permissions')) {
-          return new Response('[{"roleName":"Owner","actionIds":["VIEW"]}]', {status: 200});
+          return new Response('{"items":[{"roleName":"Owner","actionIds":["VIEW"]}],"lastPage":1}', {status: 200});
         }
 
         if (url.endsWith('/structured-contents/2/permissions')) {
-          return new Response('[{"roleName":"Guest","actionIds":["VIEW"]}]', {status: 200});
+          return new Response('{"items":[{"roleName":"Guest","actionIds":["VIEW"]}],"lastPage":1}', {status: 200});
         }
 
         throw new Error(`Unexpected URL ${url}`);
@@ -172,6 +226,39 @@ describe('guest-visibility diagnosis', () => {
     expect(report.notes.some((note) => note.includes('structuredContents'))).toBe(true);
     expect(report.gaps).toHaveLength(1);
     expect(report.gaps[0]).toMatchObject({id: 1, missingPermission: 'VIEW'});
+  });
+
+  test('reports an unreadable-permissions gap when the permissions endpoint itself fails', async () => {
+    const apiClient = createLiferayApiClient({
+      fetchImpl: createTestFetchImpl((url, init) => {
+        if (url.includes('/by-friendly-url-path/guest')) {
+          return new Response('{"id":20121,"friendlyUrlPath":"/guest","name":"Guest"}', {status: 200});
+        }
+
+        if (url.includes('/structured-contents?flatten=true')) {
+          if (hasAuthHeader(init)) {
+            return new Response('{"items":[{"id":1,"title":"Locked Article"}],"lastPage":1}', {status: 200});
+          }
+          return new Response('{"items":[],"lastPage":1}', {status: 200});
+        }
+
+        if (url.includes('/documents?flatten=true')) {
+          return emptyPage();
+        }
+
+        if (url.endsWith('/structured-contents/1/permissions')) {
+          return new Response('{}', {status: 403});
+        }
+
+        throw new Error(`Unexpected URL ${url}`);
+      }),
+    });
+
+    const report = await runGuestVisibilityDiagnosis(CONFIG, {site: '/guest'}, {apiClient, tokenClient: TOKEN_CLIENT});
+
+    expect(report.gaps).toHaveLength(1);
+    expect(report.gaps[0]).toMatchObject({id: 1, guestHasViewPermission: null, missingPermission: null, fix: null});
+    expect(report.gaps[0].diagnosis).toContain('permissions could not be read');
   });
 
   test('requires --url or --site', async () => {

--- a/tests/unit/liferay-guest-visibility.test.ts
+++ b/tests/unit/liferay-guest-visibility.test.ts
@@ -1,0 +1,188 @@
+import {describe, expect, test} from 'vitest';
+
+import {createLiferayApiClient} from '../../src/core/http/client.js';
+import {isCliError} from '../../src/core/errors.js';
+import {
+  runGuestVisibilityDiagnosis,
+  formatGuestVisibilityReport,
+} from '../../src/features/liferay/diagnose/liferay-guest-visibility.js';
+import {createStaticTokenClient, createTestFetchImpl} from '../../src/testing/cli-test-helpers.js';
+
+const CONFIG = {
+  cwd: '/tmp/repo',
+  repoRoot: '/tmp/repo',
+  dockerDir: '/tmp/repo/docker',
+  liferayDir: '/tmp/repo/liferay',
+  files: {
+    dockerEnv: '/tmp/repo/docker/.env',
+    liferayProfile: '/tmp/repo/.liferay-cli.yml',
+  },
+  liferay: {
+    url: 'http://localhost:8080',
+    oauth2ClientId: 'client-id',
+    oauth2ClientSecret: 'client-secret',
+    scopeAliases: 'scope-a',
+    timeoutSeconds: 30,
+  },
+};
+
+const TOKEN_CLIENT = createStaticTokenClient();
+
+function hasAuthHeader(init?: RequestInit): boolean {
+  const headers = (init?.headers ?? {}) as Record<string, string>;
+  return Boolean(headers.Authorization);
+}
+
+function emptyPage() {
+  return new Response('{"items":[],"lastPage":1}', {status: 200});
+}
+
+describe('guest-visibility diagnosis', () => {
+  test('reports a permission gap for a structured content missing Guest View', async () => {
+    const apiClient = createLiferayApiClient({
+      fetchImpl: createTestFetchImpl((url, init) => {
+        if (url.includes('/by-friendly-url-path/guest')) {
+          return new Response('{"id":20121,"friendlyUrlPath":"/guest","name":"Guest"}', {status: 200});
+        }
+
+        if (url.includes('/structured-contents?flatten=true')) {
+          if (hasAuthHeader(init)) {
+            return new Response(
+              '{"items":[{"id":1,"title":"Headless Article"},{"id":2,"title":"UI Article"}],"lastPage":1}',
+              {status: 200},
+            );
+          }
+          // Anonymous view is missing item 1: it lacks Guest View.
+          return new Response('{"items":[{"id":2,"title":"UI Article"}],"lastPage":1}', {status: 200});
+        }
+
+        if (url.includes('/documents?flatten=true')) {
+          return emptyPage();
+        }
+
+        if (url.endsWith('/structured-contents/1/permissions')) {
+          return new Response('[{"roleName":"Owner","actionIds":["VIEW","UPDATE"]}]', {status: 200});
+        }
+
+        throw new Error(`Unexpected URL ${url}`);
+      }),
+    });
+
+    const report = await runGuestVisibilityDiagnosis(
+      CONFIG,
+      {site: '/guest'},
+      {apiClient, tokenClient: TOKEN_CLIENT, now: () => new Date('2026-03-26T12:00:00.000Z')},
+    );
+
+    expect(report.ok).toBe(false);
+    expect(report.checked).toEqual({structuredContents: 2, documents: 0});
+    expect(report.anonymousApiAccessible).toEqual({structuredContents: true, documents: true});
+    expect(report.gaps).toHaveLength(1);
+
+    const [gap] = report.gaps;
+    expect(gap).toMatchObject({
+      resourceType: 'structuredContent',
+      id: 1,
+      title: 'Headless Article',
+      guestHasViewPermission: false,
+      missingPermission: 'VIEW',
+    });
+    expect(gap.diagnosis).toContain('Missing VIEW permission for role Guest');
+    expect(gap.fix).toContain('/o/headless-delivery/v1.0/structured-contents/1/permissions');
+
+    const text = formatGuestVisibilityReport(report);
+    expect(text).toContain('GUEST_VISIBILITY_GAPS');
+    expect(text).toContain('Missing VIEW permission for role Guest');
+  });
+
+  test('detects a page hidden anonymously via --url', async () => {
+    const apiClient = createLiferayApiClient({
+      fetchImpl: createTestFetchImpl((url, init) => {
+        if (url.includes('/by-friendly-url-path/guest')) {
+          return new Response('{"id":20121,"friendlyUrlPath":"/guest","name":"Guest"}', {status: 200});
+        }
+
+        if (url.endsWith('/site-pages/home')) {
+          if (hasAuthHeader(init)) {
+            return new Response('{"id":5001,"title":"Home"}', {status: 200});
+          }
+          return new Response('{}', {status: 403});
+        }
+
+        if (url.includes('/structured-contents?flatten=true') || url.includes('/documents?flatten=true')) {
+          return emptyPage();
+        }
+
+        throw new Error(`Unexpected URL ${url}`);
+      }),
+    });
+
+    const report = await runGuestVisibilityDiagnosis(
+      CONFIG,
+      {url: '/web/guest/home'},
+      {apiClient, tokenClient: TOKEN_CLIENT},
+    );
+
+    expect(report.page).toMatchObject({
+      friendlyUrl: '/home',
+      visibleAuthenticated: true,
+      visibleAnonymously: false,
+      anonymousStatus: 403,
+    });
+    expect(report.ok).toBe(false);
+    expect(report.gaps).toHaveLength(0);
+  });
+
+  test('falls back to a permissions-only check when the anonymous list endpoint itself is blocked', async () => {
+    const apiClient = createLiferayApiClient({
+      fetchImpl: createTestFetchImpl((url, init) => {
+        if (url.includes('/by-friendly-url-path/guest')) {
+          return new Response('{"id":20121,"friendlyUrlPath":"/guest","name":"Guest"}', {status: 200});
+        }
+
+        if (url.includes('/structured-contents?flatten=true')) {
+          if (hasAuthHeader(init)) {
+            return new Response(
+              '{"items":[{"id":1,"title":"No Guest View"},{"id":2,"title":"Has Guest View"}],"lastPage":1}',
+              {status: 200},
+            );
+          }
+          return new Response('{}', {status: 403});
+        }
+
+        if (url.includes('/documents?flatten=true')) {
+          return emptyPage();
+        }
+
+        if (url.endsWith('/structured-contents/1/permissions')) {
+          return new Response('[{"roleName":"Owner","actionIds":["VIEW"]}]', {status: 200});
+        }
+
+        if (url.endsWith('/structured-contents/2/permissions')) {
+          return new Response('[{"roleName":"Guest","actionIds":["VIEW"]}]', {status: 200});
+        }
+
+        throw new Error(`Unexpected URL ${url}`);
+      }),
+    });
+
+    const report = await runGuestVisibilityDiagnosis(CONFIG, {site: '/guest'}, {apiClient, tokenClient: TOKEN_CLIENT});
+
+    expect(report.anonymousApiAccessible.structuredContents).toBe(false);
+    expect(report.notes.some((note) => note.includes('structuredContents'))).toBe(true);
+    expect(report.gaps).toHaveLength(1);
+    expect(report.gaps[0]).toMatchObject({id: 1, missingPermission: 'VIEW'});
+  });
+
+  test('requires --url or --site', async () => {
+    const apiClient = createLiferayApiClient({
+      fetchImpl: createTestFetchImpl((url) => {
+        throw new Error(`Unexpected URL ${url}`);
+      }),
+    });
+
+    await expect(runGuestVisibilityDiagnosis(CONFIG, {}, {apiClient, tokenClient: TOKEN_CLIENT})).rejects.toSatisfy(
+      (error: unknown) => isCliError(error) && error.code === 'LIFERAY_DIAGNOSE_ERROR',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `ldev portal diagnose guest-visibility` (`--url <friendlyUrl>` or `--site <site>`) to detect content created via Headless APIs that is missing the default Guest View permission UI-created content gets automatically.
- Fetches the target authenticated and anonymously (a page via `--url`, and/or a site's structured contents and documents via `--site`), compares visibility, and for each gap reports the exact missing permission plus a suggested fix (which permissions endpoint to PUT and what to add for role Guest).
- Supports `--json`/`--ndjson`/`--strict` like the rest of the `portal` namespace, and exits non-zero when a gap is found.

## Design notes
- New feature module: `src/features/liferay/diagnose/liferay-guest-visibility.ts`, registered as a `diagnose` command group in `src/commands/liferay/diagnose.command.ts` (mirrors the `page-layout` command group pattern) under `portal`, since no `diagnose` group existed yet.
- Added a `LIFERAY_DIAGNOSE_ERROR` error code / `LiferayErrors.diagnoseError` factory helper, following the existing `LiferayErrorCode` conventions.
- When the anonymous listing endpoint itself is blocked (e.g. permission scoped at the collection level), the command falls back to a permissions-only check per item instead of giving up, and still flags items where role Guest clearly lacks the `VIEW` action.
- Reuses `resolveSite`, `fetchPagedItems`, and `LiferayGateway` from existing inventory/portal helpers rather than duplicating HTTP/pagination logic.

Fixes #168

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:unit` (1285 tests, including new `tests/unit/liferay-guest-visibility.test.ts`)
- [x] Manual `ldev portal diagnose guest-visibility --help` / `ldev portal diagnose --help` to confirm command registration