### PR TITLE
feat(resource): add static lint commands for page-definition.json and fragments

### DIFF
--- a/docs/commands/resources.md
+++ b/docs/commands/resources.md
@@ -118,3 +118,27 @@ Flags worth remembering:
 - `--liferay-timeout-seconds 300` is useful for slow structure/migration calls; repeated runs can use `LIFERAY_CLI_HTTP_TIMEOUT_SECONDS` or `liferay.oauth2.timeoutSeconds`
 
 See the [Resource Migration Pipeline workflow](/workflows/resource-migration-pipeline) for an end-to-end example.
+
+## Lint
+
+Static, network-free checks against local files — catch silent Liferay authoring traps before a deploy cycle:
+
+```bash
+ldev resource lint-page-definition --dir liferay/resources
+ldev resource lint-page-definition --file liferay/resources/layouts/news/page-definition.json
+ldev resource lint-fragments --dir liferay/fragments
+ldev resource lint-fragments --file liferay/fragments/sites/global/src/news/fragments/news-card/index.html
+```
+
+- `lint-page-definition` scans `page-definition.json` files (and `ddm-structures/*.xml` descriptors) for:
+  - a missing `"type": "Root"` on the top-level `pageElement` (page deploys but renders completely empty, no log line)
+  - a `fieldKey` that looks like a miscased reserved Info Item field, e.g. `"Title"` instead of the reserved lowercase `"title"`
+  - a DDM structure field `name` colliding with a reserved `JournalArticle` Info Item field (silently shadowed in `CollectionItem`/`DisplayPageItem` mappings)
+  - `numberOfItems` set lower than `numberOfItemsPerPage` in a Collection Display config (silent cap on visible items)
+- `lint-fragments` parses fragment HTML for:
+  - `data-lfr-editable-*` elements nested inside another editable (invisible to field mapping at render time, even though `fragmentFields` mappings are accepted at deploy time)
+  - editables missing an `id` or `type` attribute, unknown editable types, and duplicate editable ids within one fragment
+
+Both commands accept `--file <file>` for a single target or `--dir <dir>` (default `.`) to scan recursively, report one finding per line with file/rule/severity, and exit non-zero when any `error`-severity finding exists. Use `--json` for machine-readable output.
+
+See [`docs/reference/liferay-site-initializer-gotchas.md`](https://github.com/mordonez/ldev/blob/main/docs/reference/liferay-site-initializer-gotchas.md) for the full field-notes writeup these rules are based on.

--- a/src/commands/resource/resource-lint-commands.ts
+++ b/src/commands/resource/resource-lint-commands.ts
@@ -1,0 +1,48 @@
+import type {Command} from 'commander';
+
+import {registerResourceWorkflow} from './resource.command.js';
+import {runLiferayResourceLintFragments} from '../../features/liferay/resource/liferay-resource-lint-fragments.js';
+import {runLiferayResourceLintPageDefinition} from '../../features/liferay/resource/liferay-resource-lint-page-definition.js';
+import {
+  formatLiferayResourceLintResult,
+  getLiferayResourceLintExitCode,
+} from '../../features/liferay/resource/liferay-resource-lint-shared.js';
+
+export function registerResourceLintCommands(resource: Command): void {
+  registerResourceWorkflow(resource, {
+    name: 'lint-page-definition',
+    description:
+      'Statically lint page-definition.json files (and ddm-structures XML) for silent Liferay authoring traps',
+    configure: (command) =>
+      command
+        .option('--file <file>', 'Single page-definition.json (or ddm-structure XML) file to lint')
+        .option('--dir <dir>', 'Directory to scan recursively for page-definition.json and ddm-structures/*.xml', '.'),
+    run: async (_context, options) =>
+      runLiferayResourceLintPageDefinition({
+        file: options.file,
+        dir: options.dir,
+      }),
+    render: {
+      text: formatLiferayResourceLintResult,
+      exitCode: getLiferayResourceLintExitCode,
+    },
+  });
+
+  registerResourceWorkflow(resource, {
+    name: 'lint-fragments',
+    description: 'Statically lint fragment HTML for nested editables and other silently-invalid markup',
+    configure: (command) =>
+      command
+        .option('--file <file>', 'Single fragment HTML file to lint')
+        .option('--dir <dir>', 'Directory to scan recursively for fragments (fragment.json + HTML)', '.'),
+    run: async (_context, options) =>
+      runLiferayResourceLintFragments({
+        file: options.file,
+        dir: options.dir,
+      }),
+    render: {
+      text: formatLiferayResourceLintResult,
+      exitCode: getLiferayResourceLintExitCode,
+    },
+  });
+}

--- a/src/commands/resource/resource.command.ts
+++ b/src/commands/resource/resource.command.ts
@@ -8,6 +8,7 @@ import {LiferayErrors} from '../../features/liferay/errors/index.js';
 import {runLiferayPreflight} from '../../features/liferay/liferay-preflight.js';
 import {registerResourceExportCommands} from './resource-export-commands.js';
 import {registerResourceImportCommands} from './resource-import-commands.js';
+import {registerResourceLintCommands} from './resource-lint-commands.js';
 import {registerResourceMigrationCommand} from './resource-migration-command.js';
 import {registerResourceReadCommands} from './resource-read-commands.js';
 
@@ -164,6 +165,7 @@ export function buildResourceCommand(options: ResourceCommandOptions): Command {
   registerResourceExportCommands(resource);
   registerResourceImportCommands(resource);
   registerResourceMigrationCommand(resource);
+  registerResourceLintCommands(resource);
 
   return resource;
 }
@@ -186,6 +188,9 @@ Import:
 
 Migration:
   migration-init, migration-pipeline
+
+Lint (static, no network access):
+  lint-page-definition, lint-fragments
 
 Recommended:
   migration-pipeline for normal end-to-end migrations

--- a/src/core/contracts/index.ts
+++ b/src/core/contracts/index.ts
@@ -98,6 +98,9 @@ export {
   liferayResourceImportAdtItemResultSchema,
   liferayResourceImportStructureItemResultSchema,
   liferayResourceImportTemplateItemResultSchema,
+  resourceLintSeveritySchema,
+  resourceLintFindingSchema,
+  resourceLintResultSchema,
 } from './resource.schema.js';
 
 export type {
@@ -109,6 +112,9 @@ export type {
   LiferayResourceImportAdtItemResult,
   LiferayResourceImportStructureItemResult,
   LiferayResourceImportTemplateItemResult,
+  ResourceLintSeverity,
+  ResourceLintFinding,
+  ResourceLintResult,
 } from './resource.schema.js';
 
 // Environment schemas (ldev_status, ldev_logs_diagnose, ldev_context)

--- a/src/core/contracts/resource.schema.ts
+++ b/src/core/contracts/resource.schema.ts
@@ -67,6 +67,44 @@ export const liferayResourceSyncFragmentsResultSchema = z.discriminatedUnion('mo
 export type LiferayResourceImportFragmentsResult = z.infer<typeof liferayResourceSyncFragmentsResultSchema>;
 
 /**
+ * ResourceLintSeverity: severity level of a static lint finding.
+ */
+export const resourceLintSeveritySchema = z.enum(['error', 'warning']);
+
+export type ResourceLintSeverity = z.infer<typeof resourceLintSeveritySchema>;
+
+/**
+ * ResourceLintFinding: one static lint finding against a local resource file.
+ * `location` is an optional pointer inside the file (JSON path or line number).
+ */
+export const resourceLintFindingSchema = z.object({
+  file: z.string(),
+  rule: z.string(),
+  severity: resourceLintSeveritySchema,
+  message: z.string(),
+  location: z.string().optional(),
+});
+
+export type ResourceLintFinding = z.infer<typeof resourceLintFindingSchema>;
+
+/**
+ * ResourceLintResult: aggregate result of a static lint run.
+ * `ok` is false when at least one error-severity finding exists.
+ */
+export const resourceLintResultSchema = z.object({
+  target: z.string(),
+  filesScanned: z.number().int().nonnegative(),
+  findings: z.array(resourceLintFindingSchema),
+  summary: z.object({
+    errors: z.number().int().nonnegative(),
+    warnings: z.number().int().nonnegative(),
+  }),
+  ok: z.boolean(),
+});
+
+export type ResourceLintResult = z.infer<typeof resourceLintResultSchema>;
+
+/**
  * LiferayResourceImportFailure: result of a failed import.
  */
 export const liferayResourceImportFailureSchema = z.object({

--- a/src/features/liferay/resource/liferay-resource-lint-fragments.ts
+++ b/src/features/liferay/resource/liferay-resource-lint-fragments.ts
@@ -1,0 +1,363 @@
+import fs from 'fs-extra';
+import path from 'node:path';
+
+import type {ResourceLintFinding, ResourceLintResult} from '../../../core/contracts/index.js';
+import {parseJsonRecord} from '../../../core/utils/json.js';
+import {LiferayErrors} from '../errors/index.js';
+import {buildResourceLintResult, createResourceLintFinding} from './liferay-resource-lint-shared.js';
+
+/**
+ * Static linter for fragment HTML files.
+ *
+ * Detects structurally invalid editable markup that Liferay accepts silently:
+ * - `data-lfr-editable-*` (or `<lfr-editable>`) elements nested inside another
+ *   editable — inner editables are invisible to field mapping with no error
+ * - editable elements missing the id or type attribute
+ * - unknown editable types
+ * - duplicate editable ids within one fragment
+ */
+
+export type LiferayResourceLintFragmentsOptions = {
+  file?: string;
+  dir?: string;
+};
+
+const KNOWN_EDITABLE_TYPES = new Set(['text', 'rich-text', 'image', 'link', 'html', 'date']);
+const TEXT_LIKE_EDITABLE_TYPES = new Set(['text', 'rich-text']);
+const SCAN_IGNORED_DIRECTORIES = new Set(['node_modules', '.git', '.gradle', 'build', 'dist', 'bundles']);
+const VOID_ELEMENTS = new Set([
+  'area',
+  'base',
+  'br',
+  'col',
+  'embed',
+  'hr',
+  'img',
+  'input',
+  'link',
+  'meta',
+  'param',
+  'source',
+  'track',
+  'wbr',
+]);
+const RAW_TEXT_ELEMENTS = new Set(['script', 'style']);
+
+export async function runLiferayResourceLintFragments(
+  options: LiferayResourceLintFragmentsOptions,
+): Promise<ResourceLintResult> {
+  const {target, htmlFiles} = await resolveFragmentHtmlTargets(options);
+  const findings: ResourceLintFinding[] = [];
+
+  for (const file of htmlFiles) {
+    const html = await fs.readFile(file, 'utf8');
+    findings.push(...lintFragmentHtml(file, html));
+  }
+
+  return buildResourceLintResult(target, htmlFiles.length, findings);
+}
+
+// ── Target resolution ─────────────────────────────────────────────────────────
+
+async function resolveFragmentHtmlTargets(
+  options: LiferayResourceLintFragmentsOptions,
+): Promise<{target: string; htmlFiles: string[]}> {
+  if (options.file !== undefined && options.file.trim() !== '') {
+    const file = path.resolve(options.file);
+    if (!(await fs.pathExists(file))) {
+      throw LiferayErrors.resourceError(`File not found: ${file}`);
+    }
+
+    return {target: file, htmlFiles: [file]};
+  }
+
+  const dir = path.resolve(options.dir ?? '.');
+  if (!(await fs.pathExists(dir))) {
+    throw LiferayErrors.resourceError(`Directory not found: ${dir}`);
+  }
+
+  const htmlFiles: string[] = [];
+  await collectFragmentHtmlFiles(dir, htmlFiles);
+  htmlFiles.sort((left, right) => left.localeCompare(right));
+
+  if (htmlFiles.length === 0) {
+    throw LiferayErrors.resourceError(`No fragment HTML files (fragment.json + html) found under ${dir}`);
+  }
+
+  return {target: dir, htmlFiles};
+}
+
+async function collectFragmentHtmlFiles(dir: string, htmlFiles: string[]): Promise<void> {
+  const entries = await fs.readdir(dir, {withFileTypes: true});
+
+  for (const entry of entries) {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (!SCAN_IGNORED_DIRECTORIES.has(entry.name)) {
+        await collectFragmentHtmlFiles(entryPath, htmlFiles);
+      }
+      continue;
+    }
+
+    if (!entry.isFile() || entry.name !== 'fragment.json') {
+      continue;
+    }
+
+    const fragmentJson = parseJsonRecord(await fs.readFile(entryPath, 'utf8'));
+    const htmlPath = typeof fragmentJson?.htmlPath === 'string' ? fragmentJson.htmlPath : 'index.html';
+    const htmlFile = path.join(dir, htmlPath);
+    if (await fs.pathExists(htmlFile)) {
+      htmlFiles.push(htmlFile);
+    }
+  }
+}
+
+// ── Fragment HTML lint ────────────────────────────────────────────────────────
+
+type EditableInfo = {
+  id: string | undefined;
+  type: string | undefined;
+};
+
+type OpenElement = {
+  tagName: string;
+  editable: EditableInfo | undefined;
+};
+
+export function lintFragmentHtml(file: string, html: string): ResourceLintFinding[] {
+  const findings: ResourceLintFinding[] = [];
+  const stack: OpenElement[] = [];
+  const seenEditableIds = new Map<string, number>();
+  let rawTextUntil: string | undefined;
+
+  const tagPattern = /<!--[\s\S]*?-->|<\/?[a-zA-Z][^\s/>]*(?:"[^"]*"|'[^']*'|[^"'>])*>/g;
+
+  for (const match of html.matchAll(tagPattern)) {
+    const tag = match[0];
+    if (tag.startsWith('<!--')) {
+      continue;
+    }
+
+    const line = lineNumberAt(html, match.index);
+
+    if (tag.startsWith('</')) {
+      const tagName = parseTagName(tag.slice(2));
+      if (tagName === undefined) {
+        continue;
+      }
+
+      if (rawTextUntil !== undefined) {
+        if (tagName !== rawTextUntil) {
+          continue;
+        }
+        rawTextUntil = undefined;
+      }
+
+      popUntil(stack, tagName);
+      continue;
+    }
+
+    if (rawTextUntil !== undefined) {
+      continue;
+    }
+
+    const tagName = parseTagName(tag.slice(1));
+    if (tagName === undefined) {
+      continue;
+    }
+
+    const attributes = parseAttributes(tag);
+    const editable = readEditableInfo(tagName, attributes);
+
+    if (editable !== undefined) {
+      findings.push(...checkEditableElement(file, editable, stack, seenEditableIds, line));
+    }
+
+    const selfClosing = /\/\s*>$/.test(tag);
+    if (!selfClosing && !VOID_ELEMENTS.has(tagName)) {
+      stack.push({tagName, editable});
+      if (RAW_TEXT_ELEMENTS.has(tagName)) {
+        rawTextUntil = tagName;
+      }
+    }
+  }
+
+  return findings;
+}
+
+function checkEditableElement(
+  file: string,
+  editable: EditableInfo,
+  stack: OpenElement[],
+  seenEditableIds: Map<string, number>,
+  line: number,
+): ResourceLintFinding[] {
+  const findings: ResourceLintFinding[] = [];
+  const location = `line ${line}`;
+  const label = editable.id === undefined ? '(missing id)' : `"${editable.id}"`;
+
+  if (editable.id === undefined || editable.type === undefined) {
+    const missing = editable.id === undefined ? 'id' : 'type';
+    findings.push(
+      createResourceLintFinding(
+        file,
+        'incomplete-editable',
+        'error',
+        `Editable ${label} is missing its ${missing} attribute; Liferay ignores incomplete editables silently`,
+        location,
+      ),
+    );
+  }
+
+  if (editable.type !== undefined && !KNOWN_EDITABLE_TYPES.has(editable.type)) {
+    findings.push(
+      createResourceLintFinding(
+        file,
+        'unknown-editable-type',
+        'error',
+        `Editable ${label} declares unknown type "${editable.type}"; expected one of: ${[...KNOWN_EDITABLE_TYPES].join(', ')}`,
+        location,
+      ),
+    );
+  }
+
+  if (editable.id !== undefined) {
+    const firstLine = seenEditableIds.get(editable.id);
+    if (firstLine === undefined) {
+      seenEditableIds.set(editable.id, line);
+    } else {
+      findings.push(
+        createResourceLintFinding(
+          file,
+          'duplicate-editable-id',
+          'error',
+          `Editable id "${editable.id}" is declared more than once (first seen at line ${firstLine}); ids must be unique within a fragment`,
+          location,
+        ),
+      );
+    }
+  }
+
+  const ancestor = findNearestEditableAncestor(stack);
+  if (ancestor !== undefined) {
+    findings.push(buildNestedEditableFinding(file, editable, ancestor, location));
+  }
+
+  return findings;
+}
+
+function buildNestedEditableFinding(
+  file: string,
+  editable: EditableInfo,
+  ancestor: EditableInfo,
+  location: string,
+): ResourceLintFinding {
+  const innerLabel = editable.id === undefined ? 'editable' : `Editable "${editable.id}"`;
+  const outerLabel = ancestor.id === undefined ? 'another editable' : `editable "${ancestor.id}"`;
+  const base =
+    `${innerLabel} is nested inside ${outerLabel}; nested editables are invisible to Liferay field mapping ` +
+    'and their fragmentFields mappings are accepted at deploy time but do nothing at render time.';
+
+  if (ancestor.type === 'link' && editable.type !== undefined && TEXT_LIKE_EDITABLE_TYPES.has(editable.type)) {
+    return createResourceLintFinding(
+      file,
+      'nested-editable',
+      'warning',
+      `${base} Fix by mapping "text" and "fragmentLink" together on the outer link editable id and dropping the inner id from fragmentFields`,
+      location,
+    );
+  }
+
+  if (ancestor.type === 'link' && editable.type === 'image') {
+    return createResourceLintFinding(
+      file,
+      'nested-editable',
+      'error',
+      `${base} An image nested in a link cannot be fixed via mapping (link editables do not accept fragmentImage); remove the wrapping link element so the image becomes a top-level editable`,
+      location,
+    );
+  }
+
+  return createResourceLintFinding(
+    file,
+    'nested-editable',
+    'error',
+    `${base} Restructure the HTML so editables do not nest`,
+    location,
+  );
+}
+
+function findNearestEditableAncestor(stack: OpenElement[]): EditableInfo | undefined {
+  for (let index = stack.length - 1; index >= 0; index -= 1) {
+    const editable = stack[index].editable;
+    if (editable !== undefined) {
+      return editable;
+    }
+  }
+
+  return undefined;
+}
+
+// ── HTML tokenizer helpers ────────────────────────────────────────────────────
+
+function parseTagName(afterAngle: string): string | undefined {
+  const match = /^([a-zA-Z][-a-zA-Z0-9_:]*)/.exec(afterAngle);
+  return match?.[1]?.toLowerCase();
+}
+
+function parseAttributes(tag: string): Map<string, string> {
+  const attributes = new Map<string, string>();
+  const attributePattern = /([a-zA-Z_:@][-a-zA-Z0-9_:.@]*)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'>]+)))?/g;
+  const body = tag.replace(/^<\/?[a-zA-Z][^\s/>]*/, '').replace(/\/?>$/, '');
+
+  for (const match of body.matchAll(attributePattern)) {
+    const groups = match as unknown as Array<string | undefined>;
+    attributes.set(match[1].toLowerCase(), groups[2] ?? groups[3] ?? groups[4] ?? '');
+  }
+
+  return attributes;
+}
+
+function readEditableInfo(tagName: string, attributes: Map<string, string>): EditableInfo | undefined {
+  if (tagName === 'lfr-editable') {
+    return {
+      id: normalizeAttribute(attributes.get('id')),
+      type: normalizeAttribute(attributes.get('type')),
+    };
+  }
+
+  const hasEditableAttribute = [...attributes.keys()].some((name) => name.startsWith('data-lfr-editable-'));
+  if (!hasEditableAttribute) {
+    return undefined;
+  }
+
+  return {
+    id: normalizeAttribute(attributes.get('data-lfr-editable-id')),
+    type: normalizeAttribute(attributes.get('data-lfr-editable-type')),
+  };
+}
+
+function normalizeAttribute(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed === undefined || trimmed === '' ? undefined : trimmed;
+}
+
+function popUntil(stack: OpenElement[], tagName: string): void {
+  for (let index = stack.length - 1; index >= 0; index -= 1) {
+    if (stack[index].tagName === tagName) {
+      stack.length = index;
+      return;
+    }
+  }
+}
+
+function lineNumberAt(content: string, index: number): number {
+  let line = 1;
+  for (let position = 0; position < index && position < content.length; position += 1) {
+    if (content.charCodeAt(position) === 10) {
+      line += 1;
+    }
+  }
+
+  return line;
+}

--- a/src/features/liferay/resource/liferay-resource-lint-fragments.ts
+++ b/src/features/liferay/resource/liferay-resource-lint-fragments.ts
@@ -130,7 +130,10 @@ export function lintFragmentHtml(file: string, html: string): ResourceLintFindin
   const seenEditableIds = new Map<string, number>();
   let rawTextUntil: string | undefined;
 
-  const tagPattern = /<!--[\s\S]*?-->|<\/?[a-zA-Z][^\s/>]*(?:"[^"]*"|'[^']*'|[^"'>])*>/g;
+  // Tag name alternatives cover plain HTML tag names and FreeMarker dynamic tag
+  // names (e.g. `<${configuration.headingLevel}>`), which real Liferay fragments
+  // use for configurable heading levels and similar cases.
+  const tagPattern = /<!--[\s\S]*?-->|<\/?(?:[a-zA-Z][^\s/>]*|\$\{[^}]*\})(?:"[^"]*"|'[^']*'|[^"'>])*>/g;
 
   for (const match of html.matchAll(tagPattern)) {
     const tag = match[0];
@@ -301,14 +304,14 @@ function findNearestEditableAncestor(stack: OpenElement[]): EditableInfo | undef
 // ── HTML tokenizer helpers ────────────────────────────────────────────────────
 
 function parseTagName(afterAngle: string): string | undefined {
-  const match = /^([a-zA-Z][-a-zA-Z0-9_:]*)/.exec(afterAngle);
+  const match = /^([a-zA-Z][-a-zA-Z0-9_:]*|\$\{[^}]*\})/.exec(afterAngle);
   return match?.[1]?.toLowerCase();
 }
 
 function parseAttributes(tag: string): Map<string, string> {
   const attributes = new Map<string, string>();
   const attributePattern = /([a-zA-Z_:@][-a-zA-Z0-9_:.@]*)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'>]+)))?/g;
-  const body = tag.replace(/^<\/?[a-zA-Z][^\s/>]*/, '').replace(/\/?>$/, '');
+  const body = tag.replace(/^<\/?(?:[a-zA-Z][^\s/>]*|\$\{[^}]*\})/, '').replace(/\/?>$/, '');
 
   for (const match of body.matchAll(attributePattern)) {
     const groups = match as unknown as Array<string | undefined>;

--- a/src/features/liferay/resource/liferay-resource-lint-page-definition.ts
+++ b/src/features/liferay/resource/liferay-resource-lint-page-definition.ts
@@ -1,0 +1,287 @@
+import fs from 'fs-extra';
+import path from 'node:path';
+
+import type {ResourceLintFinding, ResourceLintResult} from '../../../core/contracts/index.js';
+import {isRecord, parseJsonSafely} from '../../../core/utils/json.js';
+import {LiferayErrors} from '../errors/index.js';
+import {buildResourceLintResult, createResourceLintFinding} from './liferay-resource-lint-shared.js';
+
+/**
+ * Static linter for `page-definition.json` files (layouts, page templates and
+ * display page templates) plus companion `ddm-structures/*.xml` descriptors.
+ *
+ * Catches Liferay authoring traps that fail silently at runtime:
+ * - missing `"type": "Root"` on the top-level pageElement (empty page, no log line)
+ * - miscased reserved Info Item field keys such as `"Title"` (mapping never resolves)
+ * - DDM structure field names shadowed by reserved JournalArticle Info Item fields
+ * - `numberOfItems` smaller than `numberOfItemsPerPage` in Collection Display config
+ */
+
+export type LiferayResourceLintPageDefinitionOptions = {
+  file?: string;
+  dir?: string;
+};
+
+/**
+ * Reserved JournalArticle Info Item field keys, from
+ * com.liferay.journal.web.internal.info.item.JournalArticleInfoItemFields.
+ * Custom DDM fields sharing one of these names are silently shadowed.
+ */
+export const RESERVED_INFO_ITEM_FIELD_NAMES = [
+  'authorName',
+  'authorProfileImage',
+  'createDate',
+  'description',
+  'displayDate',
+  'expirationDate',
+  'lastEditorName',
+  'lastEditorProfileImage',
+  'modifiedDate',
+  'previewImage',
+  'publishDate',
+  'smallImage',
+  'title',
+] as const;
+
+const RESERVED_FIELD_NAMES = new Set<string>(RESERVED_INFO_ITEM_FIELD_NAMES);
+const RESERVED_FIELD_NAMES_LOWERCASE = new Map<string, string>(
+  RESERVED_INFO_ITEM_FIELD_NAMES.map((name) => [name.toLowerCase(), name]),
+);
+
+const PAGE_DEFINITION_FILE_NAME = 'page-definition.json';
+const SCAN_IGNORED_DIRECTORIES = new Set(['node_modules', '.git', '.gradle', 'build', 'dist', 'bundles']);
+
+export async function runLiferayResourceLintPageDefinition(
+  options: LiferayResourceLintPageDefinitionOptions,
+): Promise<ResourceLintResult> {
+  const {target, jsonFiles, xmlFiles} = await resolvePageDefinitionTargets(options);
+  const findings: ResourceLintFinding[] = [];
+
+  for (const file of jsonFiles) {
+    findings.push(...(await lintPageDefinitionFile(file)));
+  }
+
+  for (const file of xmlFiles) {
+    findings.push(...(await lintDdmStructureXmlFile(file)));
+  }
+
+  return buildResourceLintResult(target, jsonFiles.length + xmlFiles.length, findings);
+}
+
+// ── Target resolution ─────────────────────────────────────────────────────────
+
+async function resolvePageDefinitionTargets(
+  options: LiferayResourceLintPageDefinitionOptions,
+): Promise<{target: string; jsonFiles: string[]; xmlFiles: string[]}> {
+  if (options.file !== undefined && options.file.trim() !== '') {
+    const file = path.resolve(options.file);
+    if (!(await fs.pathExists(file))) {
+      throw LiferayErrors.resourceError(`File not found: ${file}`);
+    }
+
+    return file.toLowerCase().endsWith('.xml')
+      ? {target: file, jsonFiles: [], xmlFiles: [file]}
+      : {target: file, jsonFiles: [file], xmlFiles: []};
+  }
+
+  const dir = path.resolve(options.dir ?? '.');
+  if (!(await fs.pathExists(dir))) {
+    throw LiferayErrors.resourceError(`Directory not found: ${dir}`);
+  }
+
+  const jsonFiles: string[] = [];
+  const xmlFiles: string[] = [];
+  await collectPageDefinitionFiles(dir, jsonFiles, xmlFiles);
+  jsonFiles.sort((left, right) => left.localeCompare(right));
+  xmlFiles.sort((left, right) => left.localeCompare(right));
+
+  if (jsonFiles.length === 0 && xmlFiles.length === 0) {
+    throw LiferayErrors.resourceError(
+      `No ${PAGE_DEFINITION_FILE_NAME} or ddm-structures/*.xml files found under ${dir}`,
+    );
+  }
+
+  return {target: dir, jsonFiles, xmlFiles};
+}
+
+async function collectPageDefinitionFiles(dir: string, jsonFiles: string[], xmlFiles: string[]): Promise<void> {
+  const entries = await fs.readdir(dir, {withFileTypes: true});
+
+  for (const entry of entries) {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (!SCAN_IGNORED_DIRECTORIES.has(entry.name)) {
+        await collectPageDefinitionFiles(entryPath, jsonFiles, xmlFiles);
+      }
+      continue;
+    }
+
+    if (!entry.isFile()) {
+      continue;
+    }
+
+    if (entry.name === PAGE_DEFINITION_FILE_NAME) {
+      jsonFiles.push(entryPath);
+    } else if (entry.name.toLowerCase().endsWith('.xml') && path.basename(dir) === 'ddm-structures') {
+      xmlFiles.push(entryPath);
+    }
+  }
+}
+
+// ── page-definition.json rules ────────────────────────────────────────────────
+
+async function lintPageDefinitionFile(file: string): Promise<ResourceLintFinding[]> {
+  const raw = await fs.readFile(file, 'utf8');
+  const parsed = parseJsonSafely<unknown>(raw);
+
+  if (!isRecord(parsed)) {
+    return [createResourceLintFinding(file, 'invalid-json', 'error', 'File is not valid JSON or is not a JSON object')];
+  }
+
+  const findings: ResourceLintFinding[] = [];
+  findings.push(...checkRootPageElementType(file, parsed));
+  walkJson(parsed, '$', (value, jsonPath) => {
+    findings.push(...checkMiscasedReservedFieldKey(file, value, jsonPath));
+    findings.push(...checkCollectionItemCap(file, value, jsonPath));
+  });
+
+  return findings;
+}
+
+function checkRootPageElementType(file: string, parsed: Record<string, unknown>): ResourceLintFinding[] {
+  const pageElement = parsed.pageElement;
+  if (!isRecord(pageElement)) {
+    return [
+      createResourceLintFinding(
+        file,
+        'missing-page-element',
+        'error',
+        'Missing top-level "pageElement" object; Liferay ignores this file silently',
+        '$.pageElement',
+      ),
+    ];
+  }
+
+  if (pageElement.type !== 'Root') {
+    return [
+      createResourceLintFinding(
+        file,
+        'missing-root-type',
+        'error',
+        'Top-level pageElement must declare "type": "Root"; without it the page deploys but renders completely empty with no log line',
+        '$.pageElement.type',
+      ),
+    ];
+  }
+
+  return [];
+}
+
+function checkMiscasedReservedFieldKey(file: string, value: unknown, jsonPath: string): ResourceLintFinding[] {
+  if (!isRecord(value) || typeof value.fieldKey !== 'string') {
+    return [];
+  }
+
+  const fieldKey = value.fieldKey;
+  if (RESERVED_FIELD_NAMES.has(fieldKey)) {
+    return [];
+  }
+
+  const reserved = RESERVED_FIELD_NAMES_LOWERCASE.get(fieldKey.toLowerCase());
+  if (reserved === undefined) {
+    return [];
+  }
+
+  return [
+    createResourceLintFinding(
+      file,
+      'miscased-reserved-field-key',
+      'warning',
+      `fieldKey "${fieldKey}" does not match the reserved Info Item field "${reserved}"; unless a custom DDM field is really named "${fieldKey}", the mapping silently fails to resolve — use "${reserved}"`,
+      `${jsonPath}.fieldKey`,
+    ),
+  ];
+}
+
+function checkCollectionItemCap(file: string, value: unknown, jsonPath: string): ResourceLintFinding[] {
+  if (!isRecord(value)) {
+    return [];
+  }
+
+  const numberOfItems = value.numberOfItems;
+  const numberOfItemsPerPage = value.numberOfItemsPerPage;
+  if (typeof numberOfItems !== 'number' || typeof numberOfItemsPerPage !== 'number') {
+    return [];
+  }
+
+  if (numberOfItems >= numberOfItemsPerPage) {
+    return [];
+  }
+
+  return [
+    createResourceLintFinding(
+      file,
+      'collection-number-of-items-cap',
+      'warning',
+      `numberOfItems (${numberOfItems}) is lower than numberOfItemsPerPage (${numberOfItemsPerPage}); numberOfItems is a hard cap on the total result count, so the Collection Display silently shows at most ${numberOfItems} item(s)`,
+      `${jsonPath}.numberOfItems`,
+    ),
+  ];
+}
+
+function walkJson(value: unknown, jsonPath: string, visit: (value: unknown, jsonPath: string) => void): void {
+  visit(value, jsonPath);
+
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => {
+      walkJson(item, `${jsonPath}[${index}]`, visit);
+    });
+    return;
+  }
+
+  if (isRecord(value)) {
+    for (const [key, child] of Object.entries(value)) {
+      walkJson(child, `${jsonPath}.${key}`, visit);
+    }
+  }
+}
+
+// ── ddm-structures/*.xml rule ─────────────────────────────────────────────────
+
+const DYNAMIC_ELEMENT_PATTERN = /<dynamic-element\b[^>]*>/g;
+const NAME_ATTRIBUTE_PATTERN = /\bname\s*=\s*"([^"]*)"/;
+
+async function lintDdmStructureXmlFile(file: string): Promise<ResourceLintFinding[]> {
+  const raw = await fs.readFile(file, 'utf8');
+  const findings: ResourceLintFinding[] = [];
+
+  for (const match of raw.matchAll(DYNAMIC_ELEMENT_PATTERN)) {
+    const name = NAME_ATTRIBUTE_PATTERN.exec(match[0])?.[1];
+    if (name === undefined || !RESERVED_FIELD_NAMES.has(name)) {
+      continue;
+    }
+
+    findings.push(
+      createResourceLintFinding(
+        file,
+        'reserved-info-item-field-name',
+        'warning',
+        `DDM structure field "${name}" collides with a reserved JournalArticle Info Item field; the custom field is silently shadowed in CollectionItem/DisplayPageItem mappings — rename it`,
+        `line ${lineNumberAt(raw, match.index)}`,
+      ),
+    );
+  }
+
+  return findings;
+}
+
+function lineNumberAt(content: string, index: number): number {
+  let line = 1;
+  for (let position = 0; position < index && position < content.length; position += 1) {
+    if (content.charCodeAt(position) === 10) {
+      line += 1;
+    }
+  }
+
+  return line;
+}

--- a/src/features/liferay/resource/liferay-resource-lint-shared.ts
+++ b/src/features/liferay/resource/liferay-resource-lint-shared.ts
@@ -1,0 +1,54 @@
+import type {ResourceLintFinding, ResourceLintResult, ResourceLintSeverity} from '../../../core/contracts/index.js';
+
+/**
+ * Shared helpers for the static resource linters (page definitions and fragments).
+ * Pure and network-free: they only read local files handed to them by the runners.
+ */
+
+export function buildResourceLintResult(
+  target: string,
+  filesScanned: number,
+  findings: ResourceLintFinding[],
+): ResourceLintResult {
+  const errors = findings.filter((finding) => finding.severity === 'error').length;
+  const warnings = findings.filter((finding) => finding.severity === 'warning').length;
+
+  return {
+    target,
+    filesScanned,
+    findings,
+    summary: {errors, warnings},
+    ok: errors === 0,
+  };
+}
+
+export function createResourceLintFinding(
+  file: string,
+  rule: string,
+  severity: ResourceLintSeverity,
+  message: string,
+  location?: string,
+): ResourceLintFinding {
+  return location === undefined ? {file, rule, severity, message} : {file, rule, severity, message, location};
+}
+
+export function formatLiferayResourceLintResult(result: ResourceLintResult): string {
+  const lines: string[] = [];
+
+  for (const finding of result.findings) {
+    const where = finding.location === undefined ? finding.file : `${finding.file} (${finding.location})`;
+    lines.push(`${finding.severity}: ${where}: ${finding.message} [${finding.rule}]`);
+  }
+
+  const status = result.ok ? 'OK' : 'FAILED';
+  lines.push(
+    `${status}: ${result.filesScanned} file(s) scanned, ` +
+      `${result.summary.errors} error(s), ${result.summary.warnings} warning(s)`,
+  );
+
+  return lines.join('\n');
+}
+
+export function getLiferayResourceLintExitCode(result: ResourceLintResult): number {
+  return result.ok ? 0 : 1;
+}

--- a/tests/unit/liferay-resource-lint-fragments.test.ts
+++ b/tests/unit/liferay-resource-lint-fragments.test.ts
@@ -1,0 +1,165 @@
+import fs from 'fs-extra';
+import path from 'node:path';
+import {describe, expect, test} from 'vitest';
+
+import {
+  lintFragmentHtml,
+  runLiferayResourceLintFragments,
+} from '../../src/features/liferay/resource/liferay-resource-lint-fragments.js';
+import {getLiferayResourceLintExitCode} from '../../src/features/liferay/resource/liferay-resource-lint-shared.js';
+import {createTempDir} from '../../src/testing/temp-repo.js';
+
+async function writeFile(dir: string, relativePath: string, content: string): Promise<string> {
+  const filePath = path.join(dir, relativePath);
+  await fs.ensureDir(path.dirname(filePath));
+  await fs.writeFile(filePath, content);
+  return filePath;
+}
+
+describe('lintFragmentHtml (pure rules)', () => {
+  test('passes fully non-nested editables', () => {
+    const html = `
+      <div>
+        <a data-lfr-editable-id="news-card-link" data-lfr-editable-type="link" href="#"></a>
+        <img data-lfr-editable-id="news-card-image" data-lfr-editable-type="image" src="" />
+        <span data-lfr-editable-id="news-card-title" data-lfr-editable-type="text">Title</span>
+      </div>
+    `;
+
+    expect(lintFragmentHtml('index.html', html)).toHaveLength(0);
+  });
+
+  test('flags an image editable nested inside a link editable as an error', () => {
+    const html = `
+      <a data-lfr-editable-id="news-card-link" data-lfr-editable-type="link" href="#">
+        <img data-lfr-editable-id="news-card-image" data-lfr-editable-type="image" src="" />
+      </a>
+    `;
+
+    const findings = lintFragmentHtml('index.html', html);
+
+    expect(findings).toContainEqual(expect.objectContaining({rule: 'nested-editable', severity: 'error'}));
+    const finding = findings.find((item) => item.rule === 'nested-editable');
+    expect(finding?.message).toMatch(/image nested in a link/);
+  });
+
+  test('flags a text editable nested inside a link editable as a warning with a mapping fix', () => {
+    const html = `
+      <a data-lfr-editable-id="news-card-title-link" data-lfr-editable-type="link" href="#">
+        <span data-lfr-editable-id="news-card-title" data-lfr-editable-type="text">Title</span>
+      </a>
+    `;
+
+    const findings = lintFragmentHtml('index.html', html);
+    const finding = findings.find((item) => item.rule === 'nested-editable');
+
+    expect(finding?.severity).toBe('warning');
+    expect(finding?.message).toMatch(/fragmentLink/);
+  });
+
+  test('flags any other nested editable combination as an error', () => {
+    const html = `
+      <div data-lfr-editable-id="outer" data-lfr-editable-type="rich-text">
+        <img data-lfr-editable-id="inner-image" data-lfr-editable-type="image" src="" />
+      </div>
+    `;
+
+    const findings = lintFragmentHtml('index.html', html);
+
+    expect(findings).toContainEqual(expect.objectContaining({rule: 'nested-editable', severity: 'error'}));
+  });
+
+  test('flags an editable missing its id attribute', () => {
+    const html = `<img data-lfr-editable-type="image" src="" />`;
+
+    const findings = lintFragmentHtml('index.html', html);
+
+    expect(findings).toContainEqual(expect.objectContaining({rule: 'incomplete-editable', severity: 'error'}));
+  });
+
+  test('flags an editable missing its type attribute', () => {
+    const html = `<img data-lfr-editable-id="news-card-image" src="" />`;
+
+    const findings = lintFragmentHtml('index.html', html);
+
+    expect(findings).toContainEqual(expect.objectContaining({rule: 'incomplete-editable', severity: 'error'}));
+  });
+
+  test('flags an unknown editable type', () => {
+    const html = `<div data-lfr-editable-id="news-card-video" data-lfr-editable-type="video"></div>`;
+
+    const findings = lintFragmentHtml('index.html', html);
+
+    expect(findings).toContainEqual(expect.objectContaining({rule: 'unknown-editable-type', severity: 'error'}));
+  });
+
+  test('flags a duplicate editable id within the same fragment', () => {
+    const html = `
+      <span data-lfr-editable-id="news-card-title" data-lfr-editable-type="text">A</span>
+      <span data-lfr-editable-id="news-card-title" data-lfr-editable-type="text">B</span>
+    `;
+
+    const findings = lintFragmentHtml('index.html', html);
+
+    expect(findings).toContainEqual(expect.objectContaining({rule: 'duplicate-editable-id', severity: 'error'}));
+  });
+
+  test('ignores editable-looking attributes inside comments and script/style blocks', () => {
+    const html = `
+      <!-- <img data-lfr-editable-id="commented" data-lfr-editable-type="image" /> -->
+      <script>const html = '<img data-lfr-editable-id="in-script" data-lfr-editable-type="image" />';</script>
+      <style>/* <img data-lfr-editable-id="in-style" data-lfr-editable-type="image" /> */</style>
+      <img data-lfr-editable-id="real" data-lfr-editable-type="image" src="" />
+    `;
+
+    const findings = lintFragmentHtml('index.html', html);
+
+    expect(findings).toHaveLength(0);
+  });
+});
+
+describe('resource lint-fragments (file/dir resolution)', () => {
+  test('lints a fragment discovered via fragment.json in a directory scan', async () => {
+    const dir = createTempDir('dev-cli-lint-fragments-dir-');
+    const fragmentDir = path.join(dir, 'src', 'marketing', 'fragments', 'news-card');
+    await writeFile(
+      dir,
+      path.relative(dir, path.join(fragmentDir, 'fragment.json')),
+      JSON.stringify({htmlPath: 'index.html'}),
+    );
+    await writeFile(
+      dir,
+      path.relative(dir, path.join(fragmentDir, 'index.html')),
+      '<a data-lfr-editable-id="link" data-lfr-editable-type="link" href="#">' +
+        '<img data-lfr-editable-id="image" data-lfr-editable-type="image" src="" />' +
+        '</a>',
+    );
+
+    const result = await runLiferayResourceLintFragments({dir});
+
+    expect(result.filesScanned).toBe(1);
+    expect(result.ok).toBe(false);
+    expect(getLiferayResourceLintExitCode(result)).toBe(1);
+    expect(result.findings).toContainEqual(expect.objectContaining({rule: 'nested-editable'}));
+  });
+
+  test('lints a single --file target directly regardless of fragment.json', async () => {
+    const dir = createTempDir('dev-cli-lint-fragments-file-');
+    const file = await writeFile(
+      dir,
+      'index.html',
+      '<span data-lfr-editable-id="title" data-lfr-editable-type="text">Title</span>',
+    );
+
+    const result = await runLiferayResourceLintFragments({file});
+
+    expect(result.target).toBe(path.resolve(file));
+    expect(result.ok).toBe(true);
+  });
+
+  test('throws when the directory has no fragment.json files', async () => {
+    const dir = createTempDir('dev-cli-lint-fragments-empty-');
+
+    await expect(runLiferayResourceLintFragments({dir})).rejects.toThrow(/No fragment HTML files/);
+  });
+});

--- a/tests/unit/liferay-resource-lint-fragments.test.ts
+++ b/tests/unit/liferay-resource-lint-fragments.test.ts
@@ -104,6 +104,31 @@ describe('lintFragmentHtml (pure rules)', () => {
     expect(findings).toContainEqual(expect.objectContaining({rule: 'duplicate-editable-id', severity: 'error'}));
   });
 
+  test('detects nesting through a FreeMarker dynamic tag name (e.g. configurable heading level)', () => {
+    // Real Liferay fragments commonly use `<${configuration.headingLevel}>` for a
+    // configurable h1-h6 wrapper; the tokenizer must not silently skip these tags.
+    const html = `
+      <\${configuration.headingLevel} data-lfr-editable-id="outer-heading" data-lfr-editable-type="link">
+        <img data-lfr-editable-id="inner-image" data-lfr-editable-type="image" />
+      </\${configuration.headingLevel}>
+    `;
+
+    const findings = lintFragmentHtml('index.html', html);
+
+    expect(findings).toContainEqual(expect.objectContaining({rule: 'nested-editable', severity: 'error'}));
+  });
+
+  test('does not flag a non-nested editable declared directly on a FreeMarker dynamic tag', () => {
+    const html = `
+      <\${configuration.headingLevel} data-lfr-editable-id="title" data-lfr-editable-type="text">
+        Title
+      </\${configuration.headingLevel}>
+      <img data-lfr-editable-id="image" data-lfr-editable-type="image" />
+    `;
+
+    expect(lintFragmentHtml('index.html', html)).toHaveLength(0);
+  });
+
   test('ignores editable-looking attributes inside comments and script/style blocks', () => {
     const html = `
       <!-- <img data-lfr-editable-id="commented" data-lfr-editable-type="image" /> -->

--- a/tests/unit/liferay-resource-lint-page-definition.test.ts
+++ b/tests/unit/liferay-resource-lint-page-definition.test.ts
@@ -1,0 +1,228 @@
+import fs from 'fs-extra';
+import path from 'node:path';
+import {describe, expect, test} from 'vitest';
+
+import {runLiferayResourceLintPageDefinition} from '../../src/features/liferay/resource/liferay-resource-lint-page-definition.js';
+import {getLiferayResourceLintExitCode} from '../../src/features/liferay/resource/liferay-resource-lint-shared.js';
+import {createTempDir} from '../../src/testing/temp-repo.js';
+
+async function writeFile(dir: string, relativePath: string, content: string): Promise<string> {
+  const filePath = path.join(dir, relativePath);
+  await fs.ensureDir(path.dirname(filePath));
+  await fs.writeFile(filePath, content);
+  return filePath;
+}
+
+const VALID_PAGE_DEFINITION = JSON.stringify({
+  pageElement: {
+    type: 'Root',
+    pageElements: [
+      {
+        type: 'Fragment',
+        fragmentEntryLinkId: '1',
+      },
+    ],
+  },
+});
+
+describe('resource lint-page-definition', () => {
+  test('passes a well-formed page-definition.json with type Root', async () => {
+    const dir = createTempDir('dev-cli-lint-page-definition-good-');
+    await writeFile(dir, 'layouts/news/page-definition.json', VALID_PAGE_DEFINITION);
+
+    const result = await runLiferayResourceLintPageDefinition({dir});
+
+    expect(result.ok).toBe(true);
+    expect(result.summary.errors).toBe(0);
+    expect(getLiferayResourceLintExitCode(result)).toBe(0);
+  });
+
+  test('flags a missing "type": "Root" on the top-level pageElement', async () => {
+    const dir = createTempDir('dev-cli-lint-page-definition-missing-root-');
+    await writeFile(dir, 'layouts/news/page-definition.json', JSON.stringify({pageElement: {pageElements: []}}));
+
+    const result = await runLiferayResourceLintPageDefinition({dir});
+
+    expect(result.ok).toBe(false);
+    expect(getLiferayResourceLintExitCode(result)).toBe(1);
+    expect(result.findings).toContainEqual(expect.objectContaining({rule: 'missing-root-type', severity: 'error'}));
+  });
+
+  test('flags a wholly missing pageElement object', async () => {
+    const dir = createTempDir('dev-cli-lint-page-definition-missing-element-');
+    await writeFile(dir, 'layouts/news/page-definition.json', JSON.stringify({name: 'News'}));
+
+    const result = await runLiferayResourceLintPageDefinition({dir});
+
+    expect(result.ok).toBe(false);
+    expect(result.findings).toContainEqual(expect.objectContaining({rule: 'missing-page-element', severity: 'error'}));
+  });
+
+  test('flags invalid JSON content', async () => {
+    const dir = createTempDir('dev-cli-lint-page-definition-invalid-json-');
+    await writeFile(dir, 'layouts/news/page-definition.json', '{not valid json');
+
+    const result = await runLiferayResourceLintPageDefinition({dir});
+
+    expect(result.ok).toBe(false);
+    expect(result.findings).toContainEqual(expect.objectContaining({rule: 'invalid-json', severity: 'error'}));
+  });
+
+  test('warns on capitalized "Title" fieldKey mistaken for the reserved lowercase "title"', async () => {
+    const dir = createTempDir('dev-cli-lint-page-definition-title-case-');
+    const pageDefinition = {
+      pageElement: {
+        type: 'Root',
+        pageElements: [
+          {
+            type: 'Fragment',
+            fragmentFields: [
+              {
+                id: 'news-card-title',
+                value: {
+                  text: {
+                    mapping: {
+                      fieldKey: 'Title',
+                      itemReference: {contextSource: 'CollectionItem'},
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        ],
+      },
+    };
+    await writeFile(dir, 'layouts/news/page-definition.json', JSON.stringify(pageDefinition));
+
+    const result = await runLiferayResourceLintPageDefinition({dir});
+
+    expect(result.summary.warnings).toBeGreaterThan(0);
+    expect(result.findings).toContainEqual(
+      expect.objectContaining({rule: 'miscased-reserved-field-key', severity: 'warning'}),
+    );
+  });
+
+  test('does not flag the correct lowercase "title" fieldKey', async () => {
+    const dir = createTempDir('dev-cli-lint-page-definition-title-lowercase-');
+    const pageDefinition = {
+      pageElement: {
+        type: 'Root',
+        pageElements: [
+          {
+            type: 'Fragment',
+            fragmentFields: [
+              {
+                id: 'news-card-title',
+                value: {text: {mapping: {fieldKey: 'title'}}},
+              },
+            ],
+          },
+        ],
+      },
+    };
+    await writeFile(dir, 'layouts/news/page-definition.json', JSON.stringify(pageDefinition));
+
+    const result = await runLiferayResourceLintPageDefinition({dir});
+
+    expect(result.ok).toBe(true);
+    expect(result.findings).toHaveLength(0);
+  });
+
+  test('warns when numberOfItems is lower than numberOfItemsPerPage', async () => {
+    const dir = createTempDir('dev-cli-lint-page-definition-collection-cap-');
+    const pageDefinition = {
+      pageElement: {
+        type: 'Root',
+        pageElements: [
+          {
+            type: 'Collection',
+            config: {numberOfItems: 1, numberOfItemsPerPage: 9},
+          },
+        ],
+      },
+    };
+    await writeFile(dir, 'layouts/news/page-definition.json', JSON.stringify(pageDefinition));
+
+    const result = await runLiferayResourceLintPageDefinition({dir});
+
+    expect(result.summary.warnings).toBeGreaterThan(0);
+    expect(result.findings).toContainEqual(
+      expect.objectContaining({rule: 'collection-number-of-items-cap', severity: 'warning'}),
+    );
+  });
+
+  test('does not flag numberOfItems equal to numberOfItemsPerPage', async () => {
+    const dir = createTempDir('dev-cli-lint-page-definition-collection-cap-ok-');
+    const pageDefinition = {
+      pageElement: {
+        type: 'Root',
+        pageElements: [
+          {
+            type: 'Collection',
+            config: {numberOfItems: 9, numberOfItemsPerPage: 9},
+          },
+        ],
+      },
+    };
+    await writeFile(dir, 'layouts/news/page-definition.json', JSON.stringify(pageDefinition));
+
+    const result = await runLiferayResourceLintPageDefinition({dir});
+
+    expect(result.ok).toBe(true);
+    expect(result.findings).toHaveLength(0);
+  });
+
+  test('warns on a ddm-structures field name colliding with a reserved Info Item field', async () => {
+    const dir = createTempDir('dev-cli-lint-page-definition-ddm-reserved-');
+    const xml = `<?xml version="1.0"?>
+<root available-languages="en_US" default-languageId="en_US">
+  <dynamic-element dataType="string" name="authorName" type="text" index-type="">
+    <meta-data locale="en_US"><entry name="label">Author</entry></meta-data>
+  </dynamic-element>
+</root>
+`;
+    await writeFile(dir, 'ddm-structures/news.xml', xml);
+
+    const result = await runLiferayResourceLintPageDefinition({dir});
+
+    expect(result.summary.warnings).toBeGreaterThan(0);
+    expect(result.findings).toContainEqual(
+      expect.objectContaining({rule: 'reserved-info-item-field-name', severity: 'warning'}),
+    );
+  });
+
+  test('does not flag a non-reserved ddm-structures field name', async () => {
+    const dir = createTempDir('dev-cli-lint-page-definition-ddm-ok-');
+    const xml = `<?xml version="1.0"?>
+<root available-languages="en_US" default-languageId="en_US">
+  <dynamic-element dataType="string" name="authorFullName" type="text" index-type="">
+    <meta-data locale="en_US"><entry name="label">Author</entry></meta-data>
+  </dynamic-element>
+</root>
+`;
+    await writeFile(dir, 'ddm-structures/news.xml', xml);
+
+    const result = await runLiferayResourceLintPageDefinition({dir});
+
+    expect(result.ok).toBe(true);
+    expect(result.findings).toHaveLength(0);
+  });
+
+  test('lints a single --file target directly', async () => {
+    const dir = createTempDir('dev-cli-lint-page-definition-single-file-');
+    const file = await writeFile(dir, 'page-definition.json', JSON.stringify({pageElement: {pageElements: []}}));
+
+    const result = await runLiferayResourceLintPageDefinition({file});
+
+    expect(result.target).toBe(path.resolve(file));
+    expect(result.filesScanned).toBe(1);
+    expect(result.ok).toBe(false);
+  });
+
+  test('throws when the directory has no page-definition.json or ddm-structures xml', async () => {
+    const dir = createTempDir('dev-cli-lint-page-definition-empty-');
+
+    await expect(runLiferayResourceLintPageDefinition({dir})).rejects.toThrow(/No page-definition.json/);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `ldev resource lint-page-definition` and `ldev resource lint-fragments` as pure, network-free static linters, addressing four Liferay authoring traps that currently fail silently at runtime with no log line (documented in `docs/reference/liferay-site-initializer-gotchas.md`):
  - `lint-page-definition` flags a missing `"type": "Root"` on the top-level `pageElement`, a miscased reserved Info Item `fieldKey` (e.g. `"Title"` instead of the reserved lowercase `"title"`), a DDM structure field `name` colliding with a reserved Info Item field, and `numberOfItems` set lower than `numberOfItemsPerPage` in a Collection Display config.
  - `lint-fragments` parses fragment HTML and flags `data-lfr-editable-*` elements nested inside another editable (invisible to Liferay field mapping at render time), with a distinct message/severity for the image-in-link case (unfixable via mapping, needs an HTML change) versus text-in-link (fixable via combined mapping). Also flags editables missing id/type, unknown editable types, and duplicate editable ids.
- Both commands accept `--file <file>` for a single target or `--dir <dir>` (default `.`) for a recursive scan, support `--json`/`--format text`, and exit non-zero when any error-severity finding exists.
- New `ResourceLintFinding`/`ResourceLintResult` Zod contracts in `src/core/contracts/resource.schema.ts`, exported through `src/core/contracts/index.ts`.

## Naming deviation from the issue

The issue proposed `ldev resource fragments lint` as a nested subcommand. The `resource` command group in this codebase is a flat list of hyphenated verb-noun subcommands (`import-fragment`, `export-structure`, `migration-init`, etc.) registered via `registerResourceWorkflow`, not nested command trees, and `resource fragments` is already taken by the existing read command that lists fragment collections/entries for a site. To stay consistent with the existing convention (and avoid a collision), this PR registers `lint-page-definition` and `lint-fragments` as flat subcommands instead.

## Validation against a real fragments project

Beyond the synthetic fixtures in the unit tests, `lint-fragments` was run against a real, unrelated fragments project (19 production `index.html` fragment files). That surfaced a real gap: several of those fragments use a FreeMarker dynamic tag name for a configurable heading wrapper (`<${configuration.headingLevel}>`), and the HTML tokenizer only recognized tag names starting with a plain letter, so it silently skipped those tags — and any `data-lfr-editable-*` attributes declared directly on them — instead of flagging or even seeing them. Fixed the tokenizer to also recognize `${...}` dynamic tag names, with a synthetic regression test added alongside the existing fixtures, and re-verified against the same real project (clean pass, no false positives/negatives).

## Test plan

- [x] `npm run lint` (0 errors; pre-existing unrelated `max-lines` warnings only)
- [x] `npm run typecheck`
- [x] `npm run test:unit` (120 files / 1307 tests passing, including 26 new tests across `tests/unit/liferay-resource-lint-page-definition.test.ts` and `tests/unit/liferay-resource-lint-fragments.test.ts`)
- [x] `npm run format:check`
- [x] Manual smoke test of both commands against good/bad fixtures in text and JSON output, confirming exit codes
- [x] Manual validation of `lint-fragments` against a real, unrelated fragments project (19 fragment files), which surfaced and led to fixing the FreeMarker dynamic tag name gap described above
- [x] Pre-push hook (`verify:push`: lint, format, typecheck, unit tests, build, smoke tests) passed on push (twice, once per commit)

Fixes #169