### PR TITLE
feat(resource): add plan command composing owner, duplicates and where-used impact

### DIFF
--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -24,7 +24,7 @@ If you want to understand what `ldev` is for, start with:
 - [Data and Deploy](/commands/data-and-deploy) — db sync/import, document
   library, deploy module/theme/all, content prune
 - [Resources](/commands/resources) — structures, templates, ADTs, fragments,
-  migration
+  migration, plan
 - [Project and AI](/commands/project-and-ai) — project init, ai
   install/update/status/bootstrap
 - [Advanced](/commands/advanced) — OSGi, worktrees, portal MCP probe, reindex, search,

--- a/docs/commands/resources.md
+++ b/docs/commands/resources.md
@@ -11,6 +11,33 @@ The `ldev resource` namespace treats structures, templates, ADTs and fragments a
 ldev resource --preflight export-structures --all-sites
 ```
 
+## Plan
+
+Compose the read-before-write investigation an agent would otherwise chain by
+hand (owner lookup, duplicate check, `where-used`, import command) into one
+report:
+
+```bash
+ldev resource plan BASIC
+ldev resource plan UB_TPL_DESTACATS_MULTIMEDIA --type template
+ldev resource plan card-hero --type fragment --site /guest
+ldev resource plan UB_ADT_STUDIES_SEARCH --skip-usage --json
+```
+
+- `<resource>` — structure/template/ADT/fragment key, ERC, or numeric id
+- `--type <structure|template|adt|fragment>` — inferred when omitted
+- `--site <site>` — repeatable; limits discovery and the `where-used` scan (defaults to all accessible sites)
+- `--skip-usage` — skip the `where-used` impact scan and only report owner/duplicates/suggested command
+- `--include-private`, `--site-limit`, `--max-depth`, `--concurrency`, `--page-size` — tune the underlying `where-used` scan
+
+The report includes: the real owner (resolved via runtime inventory, not
+grep), any duplicate occurrences across sites, `where-used` page impact, a
+suggested `import-*` command with `--check-only` where available, and the
+expected read-back/validation steps. When a key exists in more than one site,
+all occurrences are reported as duplicates and the `/global` site (or the
+first found site) is reported as the owner — confirm the intended site before
+importing.
+
 ## Read and inspect
 
 ```bash

--- a/src/commands/resource/resource-plan-command.ts
+++ b/src/commands/resource/resource-plan-command.ts
@@ -1,0 +1,75 @@
+import type {Command} from 'commander';
+
+import {addOutputFormatOption, createFormattedArgumentAction} from '../../cli/command-helpers.js';
+import {
+  formatLiferayResourcePlan,
+  runLiferayResourcePlan,
+} from '../../features/liferay/resource/liferay-resource-plan.js';
+import {collectRepeatableOption} from './resource.command.js';
+
+type ResourcePlanCommandOptions = {
+  type?: string;
+  site: string[];
+  includePrivate?: boolean;
+  skipUsage?: boolean;
+  siteLimit?: string;
+  maxDepth?: string;
+  concurrency?: string;
+  pageSize?: string;
+};
+
+export function registerResourcePlanCommand(resource: Command): void {
+  addOutputFormatOption(
+    resource
+      .command('plan')
+      .description('Compose owner, duplicates, where-used impact and a suggested import command for one resource')
+      .argument('<resource>', 'Structure/template/ADT/fragment key, ERC or numeric id')
+      .option('--type <type>', 'Resource type: structure | template | adt | fragment; inferred when omitted')
+      .option(
+        '--site <site>',
+        'Limit discovery and where-used scan to one or more sites (repeatable; defaults to all accessible sites)',
+        collectRepeatableOption,
+        [] as string[],
+      )
+      .option('--include-private', 'Also scan private layouts during the where-used impact check')
+      .option('--skip-usage', 'Skip the where-used impact scan and only report owner/duplicates/suggested command')
+      .option('--site-limit <n>', 'Maximum number of sites to scan for where-used when --site is not provided')
+      .option('--max-depth <maxDepth>', 'Maximum page tree recursion depth for the where-used scan', '12')
+      .option('--concurrency <n>', 'Parallel page fetches per site for the where-used scan', '4')
+      .option('--page-size <pageSize>', 'Headless page size used for discovery and where-used listings', '200')
+      .addHelpText(
+        'after',
+        `
+Examples:
+  ldev resource plan BASIC
+  ldev resource plan UB_TPL_DESTACATS_MULTIMEDIA --type template
+  ldev resource plan card-hero --type fragment --site /guest
+  ldev resource plan UB_ADT_STUDIES_SEARCH --skip-usage --json
+
+Notes:
+  - Owner is resolved via the runtime inventory (structures, templates, ADTs or fragments), not by grepping local files.
+  - When the key exists in more than one site, all occurrences are reported as duplicates and the /global site
+    (or the first found site) is reported as the owner; confirm the intended site before importing.
+  - The suggested import command always uses --check-only for structure/template/adt (fragment import has no
+    check-only preview, so an export baseline is recommended first instead).
+`,
+      ),
+    'text',
+  ).action(
+    createFormattedArgumentAction(
+      async (context, resourceArg: string, options: ResourcePlanCommandOptions) =>
+        runLiferayResourcePlan(context.config, {
+          resource: resourceArg,
+          type: options.type,
+          sites: options.site.length > 0 ? options.site : undefined,
+          includePrivate: Boolean(options.includePrivate),
+          skipUsage: Boolean(options.skipUsage),
+          siteLimit: options.siteLimit !== undefined ? Number.parseInt(options.siteLimit, 10) : undefined,
+          maxDepth: options.maxDepth !== undefined ? Number.parseInt(options.maxDepth, 10) : undefined,
+          concurrency: options.concurrency !== undefined ? Number.parseInt(options.concurrency, 10) : undefined,
+          pageSize: options.pageSize !== undefined ? Number.parseInt(options.pageSize, 10) : undefined,
+        }),
+      {text: formatLiferayResourcePlan},
+    ),
+  );
+}

--- a/src/commands/resource/resource.command.ts
+++ b/src/commands/resource/resource.command.ts
@@ -9,6 +9,7 @@ import {runLiferayPreflight} from '../../features/liferay/liferay-preflight.js';
 import {registerResourceExportCommands} from './resource-export-commands.js';
 import {registerResourceImportCommands} from './resource-import-commands.js';
 import {registerResourceMigrationCommand} from './resource-migration-command.js';
+import {registerResourcePlanCommand} from './resource-plan-command.js';
 import {registerResourceReadCommands} from './resource-read-commands.js';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -164,6 +165,7 @@ export function buildResourceCommand(options: ResourceCommandOptions): Command {
   registerResourceExportCommands(resource);
   registerResourceImportCommands(resource);
   registerResourceMigrationCommand(resource);
+  registerResourcePlanCommand(resource);
 
   return resource;
 }
@@ -187,8 +189,12 @@ Import:
 Migration:
   migration-init, migration-pipeline
 
+Plan:
+  plan <resource-id-or-key>  Owner, duplicates, where-used impact and suggested import command in one report
+
 Recommended:
   migration-pipeline for normal end-to-end migrations
+  plan before changing a structure/template/ADT/fragment when the owner or usage is uncertain
 `,
   });
 }

--- a/src/features/liferay/resource/liferay-resource-plan-discovery.ts
+++ b/src/features/liferay/resource/liferay-resource-plan-discovery.ts
@@ -1,0 +1,174 @@
+import type {AppConfig} from '../../../core/config/load-config.js';
+import {mapConcurrent} from '../../../core/concurrency.js';
+import type {LiferayInventorySite} from '../inventory/liferay-inventory-sites.js';
+import type {ResourceDependencies} from './liferay-resource-artifact-shared.js';
+import type {
+  ResourcePlanMatchedBy,
+  ResourcePlanOccurrence,
+  ResourcePlanPrimitives,
+  ResourcePlanResourceType,
+} from './liferay-resource-plan-types.js';
+
+const DISCOVERY_CONCURRENCY = 4;
+
+export type ResourcePlanDiscoverySkip = {
+  siteFriendlyUrl: string;
+  type: ResourcePlanResourceType;
+  reason: string;
+};
+
+export type ResourcePlanDiscoveryResult = {
+  byType: Map<ResourcePlanResourceType, ResourcePlanOccurrence[]>;
+  skipped: ResourcePlanDiscoverySkip[];
+};
+
+export async function discoverOccurrences(
+  config: AppConfig,
+  resource: string,
+  types: ResourcePlanResourceType[],
+  sites: LiferayInventorySite[],
+  primitives: ResourcePlanPrimitives,
+  dependencies?: ResourceDependencies,
+): Promise<ResourcePlanDiscoveryResult> {
+  const byType = new Map<ResourcePlanResourceType, ResourcePlanOccurrence[]>();
+  const skipped: ResourcePlanDiscoverySkip[] = [];
+
+  const tasks = sites.flatMap((site) => types.map((type) => ({site, type})));
+  const results = await mapConcurrent(tasks, DISCOVERY_CONCURRENCY, async ({site, type}) => {
+    try {
+      return {
+        type,
+        occurrences: await discoverOccurrencesForSite(config, resource, type, site, primitives, dependencies),
+      };
+    } catch (error) {
+      skipped.push({
+        siteFriendlyUrl: site.siteFriendlyUrl,
+        type,
+        reason: error instanceof Error ? error.message : String(error),
+      });
+      return {type, occurrences: [] as ResourcePlanOccurrence[]};
+    }
+  });
+
+  for (const result of results) {
+    if (result.occurrences.length === 0) {
+      continue;
+    }
+
+    const rows = byType.get(result.type) ?? [];
+    rows.push(...result.occurrences);
+    byType.set(result.type, rows);
+  }
+
+  for (const rows of byType.values()) {
+    rows.sort((left, right) => left.siteFriendlyUrl.localeCompare(right.siteFriendlyUrl));
+  }
+
+  return {byType, skipped};
+}
+
+async function discoverOccurrencesForSite(
+  config: AppConfig,
+  resource: string,
+  type: ResourcePlanResourceType,
+  site: LiferayInventorySite,
+  primitives: ResourcePlanPrimitives,
+  dependencies?: ResourceDependencies,
+): Promise<ResourcePlanOccurrence[]> {
+  const base = {
+    siteFriendlyUrl: site.siteFriendlyUrl,
+    siteName: site.name,
+    groupId: site.groupId,
+  };
+
+  if (type === 'structure') {
+    const result = await primitives.listStructures(config, {site: site.siteFriendlyUrl}, dependencies);
+    return result.sites
+      .flatMap((row) => row.structures)
+      .flatMap((structure) => {
+        const matchedBy = matchResource(resource, {
+          key: structure.key,
+          id: String(structure.id),
+          name: structure.name,
+        });
+        return matchedBy
+          ? [{...base, id: String(structure.id), key: structure.key, name: structure.name, matchedBy}]
+          : [];
+      });
+  }
+
+  if (type === 'template') {
+    const templates = await primitives.listTemplates(config, {site: site.siteFriendlyUrl}, dependencies);
+    return templates.flatMap((template) => {
+      const matchedBy = matchResource(resource, {
+        key: template.externalReferenceCode,
+        id: template.id,
+        name: template.name,
+      });
+      return matchedBy
+        ? [{...base, id: template.id, key: template.externalReferenceCode, name: template.name, matchedBy}]
+        : [];
+    });
+  }
+
+  if (type === 'adt') {
+    const adts = await primitives.listAdts(config, {site: site.siteFriendlyUrl}, dependencies);
+    return adts.flatMap((adt) => {
+      const matchedBy = matchResource(resource, {key: adt.templateKey, id: String(adt.templateId), name: adt.adtName});
+      return matchedBy
+        ? [
+            {
+              ...base,
+              id: String(adt.templateId),
+              key: adt.templateKey,
+              name: adt.adtName,
+              matchedBy,
+              widgetType: adt.widgetType,
+            },
+          ]
+        : [];
+    });
+  }
+
+  const fragments = await primitives.listFragments(config, {site: site.siteFriendlyUrl}, dependencies);
+  return fragments.flatMap((fragment) => {
+    const matchedBy = matchResource(resource, {
+      key: fragment.fragmentKey,
+      id: String(fragment.fragmentId),
+      name: fragment.fragmentName,
+    });
+    return matchedBy
+      ? [
+          {
+            ...base,
+            id: String(fragment.fragmentId),
+            key: fragment.fragmentKey,
+            name: fragment.fragmentName,
+            matchedBy,
+            collectionName: fragment.collectionName,
+          },
+        ]
+      : [];
+  });
+}
+
+function matchResource(
+  resource: string,
+  candidate: {key: string; id: string; name: string},
+): ResourcePlanMatchedBy | undefined {
+  const needle = resource.toLowerCase();
+
+  if (candidate.key.toLowerCase() === needle) {
+    return 'key';
+  }
+
+  if (candidate.id !== '' && candidate.id === resource) {
+    return 'id';
+  }
+
+  if (candidate.name.toLowerCase() === needle) {
+    return 'name';
+  }
+
+  return undefined;
+}

--- a/src/features/liferay/resource/liferay-resource-plan-format.ts
+++ b/src/features/liferay/resource/liferay-resource-plan-format.ts
@@ -1,0 +1,65 @@
+import type {ResourcePlanResult} from './liferay-resource-plan-types.js';
+
+export function formatLiferayResourcePlan(result: ResourcePlanResult): string {
+  const lines: string[] = [];
+
+  lines.push(`plan resource=${result.input.resource} type=${result.resolved.type} key=${result.resolved.key}`);
+  lines.push('');
+  lines.push('Owner:');
+  lines.push(
+    `  site=${result.owner.siteFriendlyUrl} groupId=${result.owner.groupId} id=${result.owner.id} ` +
+      `name=${result.owner.name} matchedBy=${result.resolved.matchedBy}` +
+      (result.ownerAmbiguous ? ' (ambiguous: key exists in multiple sites)' : ''),
+  );
+
+  lines.push('');
+  if (result.duplicates.duplicated) {
+    lines.push(`Duplicates: ${result.duplicates.count} occurrences`);
+    for (const occurrence of result.duplicates.occurrences) {
+      lines.push(`  - site=${occurrence.siteFriendlyUrl} id=${occurrence.id} name=${occurrence.name}`);
+    }
+  } else {
+    lines.push('Duplicates: none');
+  }
+
+  lines.push('');
+  if (result.usage.scanned) {
+    lines.push(
+      `Usage: ${result.usage.totalMatchedPages} matched pages ` +
+        `(scanned ${result.usage.totalScannedPages} pages across ${result.usage.scannedSites.length} sites, ` +
+        `${result.usage.totalFailedPages} failed)`,
+    );
+    for (const page of result.usage.pages) {
+      lines.push(
+        `  - site=${page.siteFriendlyUrl} url=${page.fullUrl} name=${page.pageName} matches=${page.matchCount}` +
+          (page.privateLayout ? ' (private)' : ''),
+      );
+    }
+  } else {
+    lines.push(`Usage: not scanned - ${result.usage.reason}`);
+    lines.push(`  Run manually: ${result.usage.suggestedCommand}`);
+  }
+
+  if (result.discovery.skipped.length > 0) {
+    lines.push('');
+    lines.push('Discovery warnings:');
+    for (const skip of result.discovery.skipped) {
+      lines.push(`  - site=${skip.siteFriendlyUrl} type=${skip.type} reason=${skip.reason}`);
+    }
+  }
+
+  lines.push('');
+  lines.push('Suggested import:');
+  lines.push(`  ${result.suggestedImport.command}`);
+  for (const note of result.suggestedImport.notes) {
+    lines.push(`  note: ${note}`);
+  }
+
+  lines.push('');
+  lines.push('Validation steps:');
+  result.validation.steps.forEach((step, index) => {
+    lines.push(`  ${index + 1}. ${step}`);
+  });
+
+  return lines.join('\n');
+}

--- a/src/features/liferay/resource/liferay-resource-plan-suggest.ts
+++ b/src/features/liferay/resource/liferay-resource-plan-suggest.ts
@@ -1,0 +1,92 @@
+import type {
+  ResourcePlanOccurrence,
+  ResourcePlanOptions,
+  ResourcePlanResourceType,
+  ResourcePlanSuggestedImport,
+} from './liferay-resource-plan-types.js';
+
+export function buildWhereUsedCommand(type: ResourcePlanResourceType, key: string, sites?: string[]): string {
+  const siteFlags = (sites ?? []).map((site) => ` --site ${site}`).join('');
+  return `ldev portal inventory where-used --type ${type} --key ${key}${siteFlags}`;
+}
+
+export function buildSuggestedImport(
+  type: ResourcePlanResourceType,
+  owner: ResourcePlanOccurrence,
+  occurrences: ResourcePlanOccurrence[],
+): ResourcePlanSuggestedImport {
+  const notes: string[] = [];
+
+  if (occurrences.length > 1) {
+    const sites = occurrences.map((occurrence) => occurrence.siteFriendlyUrl).join(', ');
+    notes.push(
+      `Key '${owner.key}' exists in ${occurrences.length} sites (${sites}). ` +
+        'Confirm the owner site before importing; importing into the wrong site creates a divergent duplicate.',
+    );
+  }
+
+  if (type === 'fragment') {
+    notes.push(
+      'Fragment import has no --check-only preview. Export the current fragment first as a rollback baseline.',
+    );
+    return {
+      command: `ldev resource import-fragment --site ${owner.siteFriendlyUrl} --fragment ${owner.key}`,
+      checkOnly: false,
+      notes,
+    };
+  }
+
+  const flag = {structure: '--structure', template: '--template', adt: '--adt'}[type];
+  const commandName = {structure: 'import-structure', template: 'import-template', adt: 'import-adt'}[type];
+
+  if (type === 'adt' && owner.widgetType) {
+    notes.push(`ADT widget type: ${owner.widgetType}. Pass --widget-type ${owner.widgetType} if inference fails.`);
+  }
+
+  return {
+    command: `ldev resource ${commandName} --site ${owner.siteFriendlyUrl} ${flag} ${owner.key} --check-only`,
+    checkOnly: true,
+    notes,
+  };
+}
+
+export function buildValidationSteps(
+  type: ResourcePlanResourceType,
+  owner: ResourcePlanOccurrence,
+  suggestedImport: ResourcePlanSuggestedImport,
+  options: ResourcePlanOptions,
+): string[] {
+  const site = owner.siteFriendlyUrl;
+  const key = owner.key;
+  const exportCommand = {
+    structure: `ldev resource export-structure --site ${site} --structure ${key}`,
+    template: `ldev resource export-template --site ${site} --template ${key}`,
+    adt: `ldev resource export-adt --site ${site} --adt ${key}`,
+    fragment: `ldev resource export-fragment --site ${site} --fragment ${key}`,
+  }[type];
+  const readBackCommand = {
+    structure: `ldev resource structure --structure ${key} --site ${site} --json`,
+    template: `ldev resource template --template ${key} --site ${site} --json`,
+    adt: `ldev resource adt --adt ${key} --site ${site} --json`,
+    fragment: `ldev resource fragments --site ${site} --json`,
+  }[type];
+
+  const steps = [
+    `Export the current portal state as a baseline: ${exportCommand}`,
+    suggestedImport.checkOnly
+      ? `Validate the local file without writing: ${suggestedImport.command}`
+      : `Import the local resource (no preview available): ${suggestedImport.command}`,
+  ];
+
+  if (suggestedImport.checkOnly) {
+    steps.push('Apply the change by re-running the import without --check-only.');
+  }
+
+  steps.push(
+    `Read back the imported resource and verify the content: ${readBackCommand}`,
+    `Re-check impacted pages: ${buildWhereUsedCommand(type, key, options.sites)}`,
+    'Open the matched page URLs from the usage section and verify they still render correctly.',
+  );
+
+  return steps;
+}

--- a/src/features/liferay/resource/liferay-resource-plan-types.ts
+++ b/src/features/liferay/resource/liferay-resource-plan-types.ts
@@ -1,0 +1,111 @@
+import type {runLiferayInventorySitesIncludingGlobal} from '../inventory/liferay-inventory-sites.js';
+import type {runLiferayInventoryStructures} from '../inventory/liferay-inventory-structures.js';
+import type {runLiferayInventoryTemplates} from '../inventory/liferay-inventory-templates.js';
+import type {runLiferayInventoryWhereUsed} from '../inventory/liferay-inventory-where-used.js';
+import type {ResourceDependencies} from './liferay-resource-artifact-shared.js';
+import type {runLiferayResourceListAdts} from './liferay-resource-list-adts.js';
+import type {runLiferayResourceListFragments} from './liferay-resource-list-fragments.js';
+
+export const RESOURCE_PLAN_TYPES = ['structure', 'template', 'adt', 'fragment'] as const;
+
+export type ResourcePlanResourceType = (typeof RESOURCE_PLAN_TYPES)[number];
+
+export type ResourcePlanMatchedBy = 'key' | 'id' | 'name';
+
+export type ResourcePlanOccurrence = {
+  siteFriendlyUrl: string;
+  siteName: string;
+  groupId: number;
+  id: string;
+  key: string;
+  name: string;
+  matchedBy: ResourcePlanMatchedBy;
+  widgetType?: string;
+  collectionName?: string;
+};
+
+export type ResourcePlanUsagePage = {
+  siteFriendlyUrl: string;
+  pageName: string;
+  fullUrl: string;
+  viewUrl?: string;
+  privateLayout: boolean;
+  matchCount: number;
+};
+
+export type ResourcePlanUsage =
+  | {
+      scanned: true;
+      scannedSites: string[];
+      totalScannedPages: number;
+      totalMatchedPages: number;
+      totalFailedPages: number;
+      pages: ResourcePlanUsagePage[];
+    }
+  | {
+      scanned: false;
+      reason: string;
+      suggestedCommand: string;
+    };
+
+export type ResourcePlanSuggestedImport = {
+  command: string;
+  checkOnly: boolean;
+  notes: string[];
+};
+
+export type ResourcePlanResult = {
+  planType: 'resourcePlan';
+  input: {
+    resource: string;
+    type?: ResourcePlanResourceType;
+    sites?: string[];
+  };
+  resolved: {
+    type: ResourcePlanResourceType;
+    key: string;
+    matchedBy: ResourcePlanMatchedBy;
+  };
+  owner: ResourcePlanOccurrence;
+  ownerAmbiguous: boolean;
+  duplicates: {
+    duplicated: boolean;
+    count: number;
+    occurrences: ResourcePlanOccurrence[];
+  };
+  discovery: {
+    sitesScanned: number;
+    types: ResourcePlanResourceType[];
+    skipped: Array<{siteFriendlyUrl: string; type: ResourcePlanResourceType; reason: string}>;
+  };
+  usage: ResourcePlanUsage;
+  suggestedImport: ResourcePlanSuggestedImport;
+  validation: {
+    steps: string[];
+  };
+};
+
+export type ResourcePlanOptions = {
+  resource: string;
+  type?: string;
+  sites?: string[];
+  includePrivate?: boolean;
+  skipUsage?: boolean;
+  siteLimit?: number;
+  maxDepth?: number;
+  concurrency?: number;
+  pageSize?: number;
+};
+
+export type ResourcePlanPrimitives = {
+  listSites: typeof runLiferayInventorySitesIncludingGlobal;
+  listStructures: typeof runLiferayInventoryStructures;
+  listTemplates: typeof runLiferayInventoryTemplates;
+  listAdts: typeof runLiferayResourceListAdts;
+  listFragments: typeof runLiferayResourceListFragments;
+  whereUsed: typeof runLiferayInventoryWhereUsed;
+};
+
+export type ResourcePlanDependencies = ResourceDependencies & {
+  primitives?: Partial<ResourcePlanPrimitives>;
+};

--- a/src/features/liferay/resource/liferay-resource-plan.ts
+++ b/src/features/liferay/resource/liferay-resource-plan.ts
@@ -1,0 +1,253 @@
+import type {AppConfig} from '../../../core/config/load-config.js';
+import type {WhereUsedResult} from '../../../core/contracts/inventory.schema.js';
+import {LiferayErrors} from '../errors/index.js';
+import {
+  runLiferayInventorySitesIncludingGlobal,
+  type LiferayInventorySite,
+} from '../inventory/liferay-inventory-sites.js';
+import {runLiferayInventoryStructures} from '../inventory/liferay-inventory-structures.js';
+import {runLiferayInventoryTemplates} from '../inventory/liferay-inventory-templates.js';
+import {runLiferayInventoryWhereUsed} from '../inventory/liferay-inventory-where-used.js';
+import {normalizeFriendlyUrl} from '../portal/site-resolution.js';
+import type {ResourceDependencies} from './liferay-resource-artifact-shared.js';
+import {discoverOccurrences} from './liferay-resource-plan-discovery.js';
+import {buildSuggestedImport, buildValidationSteps, buildWhereUsedCommand} from './liferay-resource-plan-suggest.js';
+import {
+  RESOURCE_PLAN_TYPES,
+  type ResourcePlanDependencies,
+  type ResourcePlanOccurrence,
+  type ResourcePlanOptions,
+  type ResourcePlanPrimitives,
+  type ResourcePlanResourceType,
+  type ResourcePlanResult,
+  type ResourcePlanUsage,
+} from './liferay-resource-plan-types.js';
+import {runLiferayResourceListAdts} from './liferay-resource-list-adts.js';
+import {runLiferayResourceListFragments} from './liferay-resource-list-fragments.js';
+
+export {formatLiferayResourcePlan} from './liferay-resource-plan-format.js';
+export type {ResourcePlanDiscoverySkip} from './liferay-resource-plan-discovery.js';
+export {
+  RESOURCE_PLAN_TYPES,
+  type ResourcePlanDependencies,
+  type ResourcePlanMatchedBy,
+  type ResourcePlanOccurrence,
+  type ResourcePlanOptions,
+  type ResourcePlanPrimitives,
+  type ResourcePlanResourceType,
+  type ResourcePlanResult,
+  type ResourcePlanSuggestedImport,
+  type ResourcePlanUsage,
+  type ResourcePlanUsagePage,
+} from './liferay-resource-plan-types.js';
+
+const DEFAULT_PRIMITIVES: ResourcePlanPrimitives = {
+  listSites: runLiferayInventorySitesIncludingGlobal,
+  listStructures: runLiferayInventoryStructures,
+  listTemplates: runLiferayInventoryTemplates,
+  listAdts: runLiferayResourceListAdts,
+  listFragments: runLiferayResourceListFragments,
+  whereUsed: runLiferayInventoryWhereUsed,
+};
+
+// ── Entry point ───────────────────────────────────────────────────────────────
+
+export async function runLiferayResourcePlan(
+  config: AppConfig,
+  options: ResourcePlanOptions,
+  dependencies?: ResourcePlanDependencies,
+): Promise<ResourcePlanResult> {
+  const resource = options.resource.trim();
+  if (resource === '') {
+    throw LiferayErrors.configError('plan requires a non-empty resource id or key.');
+  }
+
+  const requestedType = validatePlanType(options.type);
+  const primitives: ResourcePlanPrimitives = {...DEFAULT_PRIMITIVES, ...dependencies?.primitives};
+  const types: ResourcePlanResourceType[] = requestedType ? [requestedType] : [...RESOURCE_PLAN_TYPES];
+
+  const sites = await selectPlanSites(config, options, primitives, dependencies);
+  const discovery = await discoverOccurrences(config, resource, types, sites, primitives, dependencies);
+  const resolvedType = resolveSingleType(resource, requestedType, discovery.byType, sites);
+  const occurrences = discovery.byType.get(resolvedType) ?? [];
+  const owner = selectOwner(occurrences);
+  const ownerAmbiguous = occurrences.length > 1;
+  const usage = await collectUsage(config, resolvedType, owner.key, options, primitives, dependencies);
+  const suggestedImport = buildSuggestedImport(resolvedType, owner, occurrences);
+
+  return {
+    planType: 'resourcePlan',
+    input: {
+      resource,
+      ...(requestedType ? {type: requestedType} : {}),
+      ...(options.sites && options.sites.length > 0 ? {sites: options.sites} : {}),
+    },
+    resolved: {
+      type: resolvedType,
+      key: owner.key,
+      matchedBy: owner.matchedBy,
+    },
+    owner,
+    ownerAmbiguous,
+    duplicates: {
+      duplicated: occurrences.length > 1,
+      count: occurrences.length,
+      occurrences,
+    },
+    discovery: {
+      sitesScanned: sites.length,
+      types,
+      skipped: discovery.skipped,
+    },
+    usage,
+    suggestedImport,
+    validation: {
+      steps: buildValidationSteps(resolvedType, owner, suggestedImport, options),
+    },
+  };
+}
+
+// ── Validation ────────────────────────────────────────────────────────────────
+
+function validatePlanType(type: string | undefined): ResourcePlanResourceType | undefined {
+  if (type === undefined || type.trim() === '') {
+    return undefined;
+  }
+
+  const normalized = type.trim().toLowerCase();
+  if ((RESOURCE_PLAN_TYPES as readonly string[]).includes(normalized)) {
+    return normalized as ResourcePlanResourceType;
+  }
+
+  throw LiferayErrors.configError(`--type must be one of: ${RESOURCE_PLAN_TYPES.join(', ')}.`);
+}
+
+async function selectPlanSites(
+  config: AppConfig,
+  options: ResourcePlanOptions,
+  primitives: ResourcePlanPrimitives,
+  dependencies?: ResourceDependencies,
+): Promise<LiferayInventorySite[]> {
+  const sites = await primitives.listSites(config, {pageSize: options.pageSize ?? 200}, dependencies);
+
+  if (!options.sites || options.sites.length === 0) {
+    return sites;
+  }
+
+  const selected: LiferayInventorySite[] = [];
+  for (const requested of options.sites) {
+    const trimmed = requested.trim();
+    const match = sites.find(
+      (site) => site.siteFriendlyUrl === normalizeFriendlyUrl(trimmed) || String(site.groupId) === trimmed,
+    );
+
+    if (!match) {
+      throw LiferayErrors.siteNotFound(requested);
+    }
+
+    if (!selected.some((site) => site.groupId === match.groupId)) {
+      selected.push(match);
+    }
+  }
+
+  return selected;
+}
+
+function resolveSingleType(
+  resource: string,
+  requestedType: ResourcePlanResourceType | undefined,
+  byType: Map<ResourcePlanResourceType, ResourcePlanOccurrence[]>,
+  sites: LiferayInventorySite[],
+): ResourcePlanResourceType {
+  const matchedTypes = [...byType.keys()];
+
+  if (matchedTypes.length === 0) {
+    const scope = sites.length === 1 ? `site ${sites[0].siteFriendlyUrl}` : `${sites.length} accessible sites`;
+    throw LiferayErrors.resourceError(
+      `Resource '${resource}' was not found as ${requestedType ?? RESOURCE_PLAN_TYPES.join('|')} in ${scope}. ` +
+        'Check the key with: ldev portal inventory structures --all-sites, ldev portal inventory templates, ' +
+        'ldev resource adts, or ldev resource fragments.',
+    );
+  }
+
+  if (matchedTypes.length > 1) {
+    throw LiferayErrors.configError(
+      `Resource '${resource}' is ambiguous: it matches ${matchedTypes.join(' and ')}. Re-run with --type <type>.`,
+    );
+  }
+
+  return matchedTypes[0];
+}
+
+function selectOwner(occurrences: ResourcePlanOccurrence[]): ResourcePlanOccurrence {
+  const global = occurrences.find((occurrence) => occurrence.siteFriendlyUrl === '/global');
+  return global ?? occurrences[0];
+}
+
+// ── Usage (where-used) ────────────────────────────────────────────────────────
+
+async function collectUsage(
+  config: AppConfig,
+  type: ResourcePlanResourceType,
+  key: string,
+  options: ResourcePlanOptions,
+  primitives: ResourcePlanPrimitives,
+  dependencies?: ResourceDependencies,
+): Promise<ResourcePlanUsage> {
+  const suggestedCommand = buildWhereUsedCommand(type, key, options.sites);
+
+  if (options.skipUsage) {
+    return {scanned: false, reason: 'Usage scan skipped (--skip-usage).', suggestedCommand};
+  }
+
+  try {
+    const result = await primitives.whereUsed(
+      config,
+      {
+        type,
+        keys: [key],
+        ...(options.sites && options.sites.length > 0 ? {sites: options.sites} : {}),
+        includePrivate: Boolean(options.includePrivate),
+        ...(options.siteLimit !== undefined ? {siteLimit: options.siteLimit} : {}),
+        ...(options.maxDepth !== undefined ? {maxDepth: options.maxDepth} : {}),
+        ...(options.concurrency !== undefined ? {concurrency: options.concurrency} : {}),
+        ...(options.pageSize !== undefined ? {pageSize: options.pageSize} : {}),
+      },
+      dependencies,
+    );
+
+    if (result.inventoryType !== 'whereUsed') {
+      return {scanned: false, reason: 'Usage scan returned a plan instead of results.', suggestedCommand};
+    }
+
+    return summarizeUsage(result);
+  } catch (error) {
+    return {
+      scanned: false,
+      reason: `Usage scan failed: ${error instanceof Error ? error.message : String(error)}`,
+      suggestedCommand,
+    };
+  }
+}
+
+function summarizeUsage(result: WhereUsedResult): ResourcePlanUsage {
+  const pages = result.sites.flatMap((site) =>
+    site.matchedPages.map((page) => ({
+      siteFriendlyUrl: site.siteFriendlyUrl,
+      pageName: page.pageName,
+      fullUrl: page.fullUrl,
+      ...(page.viewUrl !== undefined ? {viewUrl: page.viewUrl} : {}),
+      privateLayout: page.privateLayout,
+      matchCount: page.matches.length,
+    })),
+  );
+
+  return {
+    scanned: true,
+    scannedSites: result.scope.sites,
+    totalScannedPages: result.summary.totalScannedPages,
+    totalMatchedPages: result.summary.totalMatchedPages,
+    totalFailedPages: result.summary.totalFailedPages,
+    pages,
+  };
+}

--- a/tests/unit/liferay-resource-plan.test.ts
+++ b/tests/unit/liferay-resource-plan.test.ts
@@ -1,0 +1,256 @@
+import {describe, expect, test, vi} from 'vitest';
+
+import type {AppConfig} from '../../src/core/config/load-config.js';
+import type {WhereUsedRunResult} from '../../src/core/contracts/inventory.schema.js';
+import {LiferayErrorCode} from '../../src/features/liferay/errors/liferay-error-codes.js';
+import type {LiferayInventoryStructuresResult} from '../../src/features/liferay/inventory/liferay-inventory-structures.js';
+import type {LiferayInventoryTemplate} from '../../src/features/liferay/inventory/liferay-inventory-templates.js';
+import type {LiferayResourceAdtRow} from '../../src/features/liferay/resource/liferay-resource-list-adts.js';
+import type {LiferayResourceFragmentRow} from '../../src/features/liferay/resource/liferay-resource-list-fragments.js';
+import {
+  formatLiferayResourcePlan,
+  runLiferayResourcePlan,
+  type ResourcePlanPrimitives,
+} from '../../src/features/liferay/resource/liferay-resource-plan.js';
+
+const CONFIG = {} as AppConfig;
+
+const SITE_GLOBAL = {groupId: 20121, siteFriendlyUrl: '/global', name: 'Global', pagesCommand: ''};
+const SITE_UB = {groupId: 30000, siteFriendlyUrl: '/ub', name: 'Universitat de Barcelona', pagesCommand: ''};
+
+function structuresResult(rows: Array<{id: number; key: string; name: string}>): LiferayInventoryStructuresResult {
+  return {
+    sites: [
+      {
+        siteGroupId: SITE_GLOBAL.groupId,
+        siteFriendlyUrl: SITE_GLOBAL.siteFriendlyUrl,
+        siteName: 'Global',
+        structures: rows,
+      },
+    ],
+    summary: {totalSites: 1, totalStructures: rows.length},
+  };
+}
+
+function emptyStructures(site: {
+  groupId: number;
+  siteFriendlyUrl: string;
+  name: string;
+}): LiferayInventoryStructuresResult {
+  return {
+    sites: [{siteGroupId: site.groupId, siteFriendlyUrl: site.siteFriendlyUrl, siteName: site.name, structures: []}],
+    summary: {totalSites: 1, totalStructures: 0},
+  };
+}
+
+function whereUsedFound(): WhereUsedRunResult {
+  return {
+    inventoryType: 'whereUsed',
+    query: {type: 'structure', keys: ['BASIC']},
+    scope: {
+      sites: ['/global'],
+      includePrivate: false,
+      concurrency: 4,
+      maxDepth: 12,
+      siteOrder: 'site',
+      excludedSites: [],
+      plan: false,
+    },
+    summary: {totalSites: 1, totalScannedPages: 3, totalMatchedPages: 1, totalFailedPages: 0, totalMatches: 1},
+    sites: [
+      {
+        siteFriendlyUrl: '/global',
+        siteName: 'Global',
+        groupId: 20121,
+        scannedPages: 3,
+        failedPages: 0,
+        matchedPages: [
+          {
+            pageType: 'regularPage',
+            pageName: 'Home',
+            friendlyUrl: '/home',
+            fullUrl: 'http://localhost:8080/web/guest/home',
+            privateLayout: false,
+            matches: [
+              {
+                resourceType: 'structure',
+                matchedKey: 'BASIC',
+                matchKind: 'journalArticleStructure',
+                label: 'BASIC',
+                detail: 'structure',
+                source: 'journalArticle',
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function buildPrimitives(overrides: Partial<ResourcePlanPrimitives> = {}): ResourcePlanPrimitives {
+  return {
+    listSites: vi.fn(() => Promise.resolve([SITE_GLOBAL])),
+    listStructures: vi.fn(() => Promise.resolve(emptyStructures(SITE_GLOBAL))),
+    listTemplates: vi.fn(() => Promise.resolve<LiferayInventoryTemplate[]>([])),
+    listAdts: vi.fn(() => Promise.resolve<LiferayResourceAdtRow[]>([])),
+    listFragments: vi.fn(() => Promise.resolve<LiferayResourceFragmentRow[]>([])),
+    whereUsed: vi.fn(() => Promise.resolve(whereUsedFound())),
+    ...overrides,
+  };
+}
+
+describe('runLiferayResourcePlan', () => {
+  test('rejects an empty resource id', async () => {
+    await expect(runLiferayResourcePlan(CONFIG, {resource: '  '}, {primitives: buildPrimitives()})).rejects.toThrow(
+      /non-empty resource/,
+    );
+  });
+
+  test('rejects an invalid --type', async () => {
+    await expect(
+      runLiferayResourcePlan(CONFIG, {resource: 'BASIC', type: 'bogus'}, {primitives: buildPrimitives()}),
+    ).rejects.toThrow(/--type must be one of/);
+  });
+
+  test('throws when the resource is not found in any type', async () => {
+    await expect(
+      runLiferayResourcePlan(CONFIG, {resource: 'MISSING'}, {primitives: buildPrimitives()}),
+    ).rejects.toMatchObject({code: LiferayErrorCode.RESOURCE_ERROR});
+  });
+
+  test('throws an ambiguous-type error when the key matches more than one resource type', async () => {
+    const primitives = buildPrimitives({
+      listStructures: vi.fn(() => Promise.resolve(structuresResult([{id: 1, key: 'DUP', name: 'Dup structure'}]))),
+      listTemplates: vi.fn(() =>
+        Promise.resolve<LiferayInventoryTemplate[]>([
+          {id: '2', name: 'Dup template', contentStructureId: 1, externalReferenceCode: 'DUP'},
+        ]),
+      ),
+    });
+
+    await expect(runLiferayResourcePlan(CONFIG, {resource: 'DUP'}, {primitives})).rejects.toThrow(
+      /is ambiguous.*--type/,
+    );
+  });
+
+  test('resolves owner, reports no duplicates, and scans usage for a single match', async () => {
+    const primitives = buildPrimitives({
+      listStructures: vi.fn(() => Promise.resolve(structuresResult([{id: 1, key: 'BASIC', name: 'Basic structure'}]))),
+    });
+
+    const result = await runLiferayResourcePlan(CONFIG, {resource: 'BASIC'}, {primitives});
+
+    expect(result.resolved).toEqual({type: 'structure', key: 'BASIC', matchedBy: 'key'});
+    expect(result.owner).toMatchObject({siteFriendlyUrl: '/global', id: '1', name: 'Basic structure'});
+    expect(result.ownerAmbiguous).toBe(false);
+    expect(result.duplicates).toEqual({duplicated: false, count: 1, occurrences: result.duplicates.occurrences});
+    expect(result.usage.scanned).toBe(true);
+    if (result.usage.scanned) {
+      expect(result.usage.totalMatchedPages).toBe(1);
+      expect(result.usage.pages).toHaveLength(1);
+    }
+    expect(result.suggestedImport).toEqual({
+      command: 'ldev resource import-structure --site /global --structure BASIC --check-only',
+      checkOnly: true,
+      notes: [],
+    });
+    expect(result.validation.steps.length).toBeGreaterThan(0);
+    expect(primitives.whereUsed).toHaveBeenCalledWith(
+      CONFIG,
+      expect.objectContaining({type: 'structure', keys: ['BASIC']}),
+      {primitives},
+    );
+  });
+
+  test('flags duplicates across sites and defaults the owner to /global', async () => {
+    const primitives = buildPrimitives({
+      listSites: vi.fn(() => Promise.resolve([SITE_GLOBAL, SITE_UB])),
+      listStructures: vi.fn((_config: AppConfig, options?: {site?: string}) => {
+        if (options?.site === '/ub') {
+          return Promise.resolve(structuresResult([{id: 99, key: 'BASIC', name: 'UB basic'}]));
+        }
+        return Promise.resolve(structuresResult([{id: 1, key: 'BASIC', name: 'Basic structure'}]));
+      }),
+    });
+
+    const result = await runLiferayResourcePlan(CONFIG, {resource: 'BASIC', skipUsage: true}, {primitives});
+
+    expect(result.duplicates.duplicated).toBe(true);
+    expect(result.duplicates.count).toBe(2);
+    expect(result.owner.siteFriendlyUrl).toBe('/global');
+    expect(result.suggestedImport.notes[0]).toMatch(/exists in 2 sites/);
+    expect(result.usage).toEqual({
+      scanned: false,
+      reason: 'Usage scan skipped (--skip-usage).',
+      suggestedCommand: 'ldev portal inventory where-used --type structure --key BASIC',
+    });
+  });
+
+  test('suggests a non-check-only import for fragments with a note about export baseline', async () => {
+    const primitives = buildPrimitives({
+      listFragments: vi.fn(() =>
+        Promise.resolve<LiferayResourceFragmentRow[]>([
+          {
+            fragmentId: 5,
+            fragmentKey: 'card-hero',
+            fragmentName: 'Card Hero',
+            collectionId: 1,
+            collectionName: 'Marketing',
+            collectionKey: 'marketing',
+            collectionDescription: '',
+            icon: '',
+            type: 1,
+          },
+        ]),
+      ),
+    });
+
+    const result = await runLiferayResourcePlan(CONFIG, {resource: 'card-hero', type: 'fragment'}, {primitives});
+
+    expect(result.resolved.type).toBe('fragment');
+    expect(result.suggestedImport.checkOnly).toBe(false);
+    expect(result.suggestedImport.command).toBe('ldev resource import-fragment --site /global --fragment card-hero');
+    expect(result.suggestedImport.notes.some((note) => note.includes('no --check-only preview'))).toBe(true);
+  });
+
+  test('rejects an unknown --site filter', async () => {
+    await expect(
+      runLiferayResourcePlan(CONFIG, {resource: 'BASIC', sites: ['/nope']}, {primitives: buildPrimitives()}),
+    ).rejects.toMatchObject({code: LiferayErrorCode.INVENTORY_SITE_NOT_FOUND});
+  });
+
+  test('reports a scan failure without throwing when where-used fails', async () => {
+    const primitives = buildPrimitives({
+      listStructures: vi.fn(() => Promise.resolve(structuresResult([{id: 1, key: 'BASIC', name: 'Basic structure'}]))),
+      whereUsed: vi.fn(() => Promise.reject(new Error('boom'))),
+    });
+
+    const result = await runLiferayResourcePlan(CONFIG, {resource: 'BASIC'}, {primitives});
+
+    expect(result.usage).toEqual({
+      scanned: false,
+      reason: 'Usage scan failed: boom',
+      suggestedCommand: 'ldev portal inventory where-used --type structure --key BASIC',
+    });
+  });
+});
+
+describe('formatLiferayResourcePlan', () => {
+  test('renders a readable text report', async () => {
+    const primitives = buildPrimitives({
+      listStructures: vi.fn(() => Promise.resolve(structuresResult([{id: 1, key: 'BASIC', name: 'Basic structure'}]))),
+    });
+
+    const result = await runLiferayResourcePlan(CONFIG, {resource: 'BASIC'}, {primitives});
+    const text = formatLiferayResourcePlan(result);
+
+    expect(text).toContain('plan resource=BASIC type=structure key=BASIC');
+    expect(text).toContain('Owner:');
+    expect(text).toContain('Duplicates: none');
+    expect(text).toContain('Usage: 1 matched pages');
+    expect(text).toContain('Suggested import:');
+    expect(text).toContain('ldev resource import-structure --site /global --structure BASIC --check-only');
+    expect(text).toContain('Validation steps:');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `ldev resource plan <resource-id-or-key>` composing existing primitives into one report: real owner site (resolved via runtime inventory, not grep), duplicate occurrences across sites, `where-used` page impact, and a suggested `import-*` command with `--check-only`.
- Discovery scans structures, templates, ADTs and fragments across accessible sites (or `--site`-scoped) via the same inventory/list primitives already used by `resource structure/template/adt/fragments` and `portal inventory`; per-site failures are reported as non-fatal discovery warnings.
- The `where-used` impact scan reuses `runLiferayInventoryWhereUsed` directly (in-process), and is skippable with `--skip-usage`; a scan failure is reported inline instead of failing the whole command.
- Suggested import command differs by type: `import-structure|import-template|import-adt` always get `--check-only`; `import-fragment` has no check-only preview, so the note recommends an export baseline first.
- Output supports `--json`/`--ndjson`/text via the existing `addOutputFormatOption`/`createFormattedArgumentAction` conventions.

## Design notes

- Logic is split across `liferay-resource-plan.ts` (orchestration), `-types.ts`, `-discovery.ts` (per-type occurrence lookup + matching by key/id/name), `-suggest.ts` (suggested import + validation steps), and `-format.ts` (text renderer), keeping each file under the repo's 300-line lint guidance.
- All dependencies on inventory/list primitives are injectable (`ResourcePlanDependencies.primitives`) so unit tests mock at the primitive boundary instead of HTTP.
- When a key matches more than one resource type (e.g. a structure and a template share the same key), the command fails fast asking for `--type`, rather than guessing.
- Validated end-to-end against a live local portal (`resource plan UB_STR_NOVEDAD`, `--type structure`, `--json`), including the discovery-warning path when a site fails to resolve.

Fixes #171

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:unit` (1291 tests)
- [x] `npm run build`
- [x] Manual run against a live local Liferay instance (text and `--json` output, `--skip-usage`, `--site` scoping, `--type` disambiguation)