### PR TITLE
feat(portal): add batch command with executeStatus polling

### DIFF
--- a/docs/commands/advanced.md
+++ b/docs/commands/advanced.md
@@ -123,3 +123,24 @@ Validate Clay icon coverage for a deployed theme.
 ```bash
 ldev portal theme-check --theme ub-theme --json
 ```
+
+## Batch Engine
+
+Wraps the Liferay headless-batch-engine API (the async import/export
+mechanism behind LAR Mirror imports for Pages, Object Entries, and other
+entities): submits a job, polls `executeStatus` until it reaches a terminal
+state, and reports failures with a read-back verification, following the same
+evidence-based contract as `ldev resource import-*`.
+
+```bash
+ldev portal batch import --class-name com.liferay.object.model.ObjectEntry --file entries.json
+ldev portal batch import --class-name com.liferay.object.model.ObjectEntry --file entries.json --no-poll
+ldev portal batch export --class-name com.liferay.object.model.ObjectEntry --poll
+ldev portal batch status --task 12345
+```
+
+- `import` — `--file` or `--data` (inline JSON), `--create-strategy` (`INSERT`/`UPSERT`), `--import-strategy` (`ON_ERROR_CONTINUE`/`ON_ERROR_FAIL`), `--external-reference-code`, `--field-name-mapping`, `--task-item-delegate-name`
+- `export` — `--content-type` (default `JSON`), `--field-names`, `--task-item-delegate-name`, `--poll` to wait for completion
+- `status` — `--task <id>` and `--operation import|export` to fetch the current `executeStatus` of a previously submitted task
+- `--poll-interval <seconds>` / `--poll-timeout <seconds>` — tune polling cadence; import polls by default, export requires `--poll` explicitly
+- `import` supports `--no-poll` to submit and return immediately without waiting

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -28,7 +28,7 @@ If you want to understand what `ldev` is for, start with:
 - [Project and AI](/commands/project-and-ai) — project init, ai
   install/update/status/bootstrap
 - [Advanced](/commands/advanced) — OSGi, worktrees, portal MCP probe, reindex, search,
-  page-layout, theme-check
+  page-layout, theme-check, Batch Engine
 
 ## Namespace overview
 

--- a/src/commands/liferay/batch.command.ts
+++ b/src/commands/liferay/batch.command.ts
@@ -1,0 +1,194 @@
+import {Command, InvalidArgumentError} from 'commander';
+
+import {addOutputFormatOption, createFormattedAction} from '../../cli/command-helpers.js';
+import {
+  DEFAULT_POLL_INTERVAL_SECONDS,
+  DEFAULT_POLL_TIMEOUT_SECONDS,
+  formatLiferayBatchExport,
+  formatLiferayBatchImport,
+  formatLiferayBatchStatus,
+  getLiferayBatchExportExitCode,
+  getLiferayBatchImportExitCode,
+  getLiferayBatchStatusExitCode,
+  runLiferayBatchExport,
+  runLiferayBatchImport,
+  runLiferayBatchStatus,
+} from '../../features/liferay/batch/liferay-batch-engine.js';
+
+type BatchImportCommandOptions = {
+  className: string;
+  file?: string;
+  data?: string;
+  createStrategy?: string;
+  importStrategy?: string;
+  externalReferenceCode?: string;
+  fieldNameMapping?: string;
+  taskItemDelegateName?: string;
+  poll?: boolean;
+  pollInterval: number;
+  pollTimeout: number;
+};
+
+type BatchExportCommandOptions = {
+  className: string;
+  contentType?: string;
+  fieldNames?: string;
+  taskItemDelegateName?: string;
+  poll?: boolean;
+  pollInterval: number;
+  pollTimeout: number;
+};
+
+type BatchStatusCommandOptions = {
+  task: number;
+  operation?: string;
+};
+
+function parsePositiveNumber(value: string, flag: string): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new InvalidArgumentError(`${flag} must be a positive number`);
+  }
+
+  return parsed;
+}
+
+function parseTaskId(value: string): number {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new InvalidArgumentError('--task must be a positive integer');
+  }
+
+  return parsed;
+}
+
+export function createBatchCommands(parent: Command): void {
+  const batch = new Command('batch')
+    .helpGroup('Batch Engine:')
+    .description('Batch Engine import/export wrapper with executeStatus polling')
+    .addHelpText(
+      'after',
+      `
+Wraps the Liferay headless-batch-engine API (the modern async import/export
+mechanism used by LAR Mirror imports for Pages, Object Entries, etc.).
+
+Submits a batch job, polls GET .../import-tasks/{id} or .../export-tasks/{id}
+until executeStatus is COMPLETED or FAILED, and reports failures with a
+read-back verification, following the same evidence-based contract as
+'ldev resource import-*'.
+
+Examples:
+  ldev portal batch import --class-name com.liferay.object.model.ObjectEntry --file entries.json
+  ldev portal batch import --class-name com.liferay.object.model.ObjectEntry --file entries.json --no-poll
+  ldev portal batch export --class-name com.liferay.object.model.ObjectEntry --poll
+  ldev portal batch status --task 12345
+`,
+    );
+
+  addOutputFormatOption(
+    batch
+      .command('import')
+      .description('Submit a Batch Engine import task and poll executeStatus until it finishes')
+      .requiredOption(
+        '--class-name <className>',
+        'Fully qualified DTO class name, e.g. com.liferay.object.model.ObjectEntry',
+      )
+      .option('--file <file>', 'JSON file with the import payload (array of items, or {items: [...]})')
+      .option('--data <json>', 'Inline JSON payload; alternative to --file')
+      .option('--create-strategy <strategy>', 'INSERT or UPSERT')
+      .option('--import-strategy <strategy>', 'ON_ERROR_CONTINUE or ON_ERROR_FAIL')
+      .option('--external-reference-code <erc>', 'External reference code for the batch task')
+      .option('--field-name-mapping <mapping>', 'Field name mapping override, as expected by the Batch Engine API')
+      .option('--task-item-delegate-name <name>', 'Task item delegate name override')
+      .option('--no-poll', 'Submit only; do not wait for executeStatus to reach a terminal state')
+      .option(
+        '--poll-interval <seconds>',
+        'Polling interval in seconds',
+        (value) => parsePositiveNumber(value, '--poll-interval'),
+        DEFAULT_POLL_INTERVAL_SECONDS,
+      )
+      .option(
+        '--poll-timeout <seconds>',
+        'Maximum time to poll before giving up, in seconds',
+        (value) => parsePositiveNumber(value, '--poll-timeout'),
+        DEFAULT_POLL_TIMEOUT_SECONDS,
+      ),
+  ).action(
+    createFormattedAction(
+      async (context, options: BatchImportCommandOptions) =>
+        runLiferayBatchImport(context.config, {
+          className: options.className,
+          file: options.file,
+          data: options.data,
+          createStrategy: options.createStrategy,
+          importStrategy: options.importStrategy,
+          externalReferenceCode: options.externalReferenceCode,
+          fieldNameMapping: options.fieldNameMapping,
+          taskItemDelegateName: options.taskItemDelegateName,
+          poll: options.poll,
+          pollIntervalSeconds: options.pollInterval,
+          pollTimeoutSeconds: options.pollTimeout,
+        }),
+      {text: formatLiferayBatchImport, exitCode: getLiferayBatchImportExitCode},
+    ),
+  );
+
+  addOutputFormatOption(
+    batch
+      .command('export')
+      .description('Submit a Batch Engine export task, optionally polling executeStatus until it finishes')
+      .requiredOption(
+        '--class-name <className>',
+        'Fully qualified DTO class name, e.g. com.liferay.object.model.ObjectEntry',
+      )
+      .option('--content-type <type>', 'Export content type, e.g. JSON, CSV, XML', 'JSON')
+      .option('--field-names <fields>', 'Comma-separated field names to export')
+      .option('--task-item-delegate-name <name>', 'Task item delegate name override')
+      .option('--poll', 'Wait for executeStatus to reach a terminal state before returning')
+      .option(
+        '--poll-interval <seconds>',
+        'Polling interval in seconds',
+        (value) => parsePositiveNumber(value, '--poll-interval'),
+        DEFAULT_POLL_INTERVAL_SECONDS,
+      )
+      .option(
+        '--poll-timeout <seconds>',
+        'Maximum time to poll before giving up, in seconds',
+        (value) => parsePositiveNumber(value, '--poll-timeout'),
+        DEFAULT_POLL_TIMEOUT_SECONDS,
+      ),
+  ).action(
+    createFormattedAction(
+      async (context, options: BatchExportCommandOptions) =>
+        runLiferayBatchExport(context.config, {
+          className: options.className,
+          contentType: options.contentType,
+          fieldNames: options.fieldNames,
+          taskItemDelegateName: options.taskItemDelegateName,
+          poll: Boolean(options.poll),
+          pollIntervalSeconds: options.pollInterval,
+          pollTimeoutSeconds: options.pollTimeout,
+        }),
+      {text: formatLiferayBatchExport, exitCode: getLiferayBatchExportExitCode},
+    ),
+  );
+
+  addOutputFormatOption(
+    batch
+      .command('status')
+      .description('Fetch the current executeStatus of a previously submitted batch task')
+      .requiredOption('--task <taskId>', 'Batch task id', parseTaskId)
+      .option('--operation <operation>', 'import or export', 'import'),
+  ).action(
+    createFormattedAction(
+      async (context, options: BatchStatusCommandOptions) =>
+        runLiferayBatchStatus(context.config, {
+          taskId: options.task,
+          operation: options.operation === 'export' ? 'export' : 'import',
+        }),
+      {text: formatLiferayBatchStatus, exitCode: getLiferayBatchStatusExitCode},
+    ),
+  );
+
+  parent.addCommand(batch);
+}

--- a/src/commands/liferay/liferay.command.ts
+++ b/src/commands/liferay/liferay.command.ts
@@ -2,6 +2,7 @@ import {Command} from 'commander';
 
 import {createReindexCommand} from '../reindex/reindex.command.js';
 import {createAuthCommands} from './auth.command.js';
+import {createBatchCommands} from './batch.command.js';
 import {createContentCommand} from './content.command.js';
 import {createLiferayConfigCommand} from './config.command.js';
 import {createInventoryCommands} from './inventory.command.js';
@@ -55,6 +56,7 @@ Main groups:
   theme-check  Validate Clay icon coverage in a deployed theme
   reindex      Reindex observation and temporary tuning
   content      Journal/web content management (prune for local environments)
+  batch        Batch Engine import/export wrapper with executeStatus polling
 `,
     );
 
@@ -67,6 +69,7 @@ Main groups:
   command.addCommand(createLiferaySearchCommand().helpGroup('Portal diagnostics:'));
   command.addCommand(createLiferayThemeCheckCommand().helpGroup('Portal diagnostics:'));
   command.addCommand(createReindexCommand().helpGroup('Portal diagnostics:'));
+  createBatchCommands(command);
 
   return command;
 }

--- a/src/features/liferay/batch/liferay-batch-engine.ts
+++ b/src/features/liferay/batch/liferay-batch-engine.ts
@@ -1,0 +1,410 @@
+/**
+ * Liferay Batch Engine wrapper (headless-batch-engine v1.0).
+ *
+ * Wraps the asynchronous import/export task API:
+ * - POST /o/headless-batch-engine/v1.0/import-tasks/{className}
+ * - GET  /o/headless-batch-engine/v1.0/import-tasks/{id}
+ * - GET  /o/headless-batch-engine/v1.0/import-tasks/{id}/failed-items
+ * - POST /o/headless-batch-engine/v1.0/export-tasks/{className}/{contentType}
+ * - GET  /o/headless-batch-engine/v1.0/export-tasks/{id}
+ *
+ * Follows the evidence-based contract of `ldev resource import-*`:
+ * the reported result is always backed by a read-back of the task
+ * (fresh executeStatus GET plus failed-items check for imports),
+ * never by assuming the submit call succeeded.
+ */
+
+import fs from 'fs-extra';
+
+import type {AppConfig} from '../../../core/config/load-config.js';
+import {sleep} from '../../../core/utils/async.js';
+import {LiferayErrors} from '../errors/index.js';
+import {createLiferayGateway, type LiferayGateway} from '../liferay-gateway.js';
+import {
+  BATCH_ENGINE_BASE_PATH,
+  DEFAULT_POLL_INTERVAL_SECONDS,
+  DEFAULT_POLL_TIMEOUT_SECONDS,
+  type BatchEngineDependencies,
+  type LiferayBatchExportOptions,
+  type LiferayBatchExportResult,
+  type LiferayBatchFailedItem,
+  type LiferayBatchImportOptions,
+  type LiferayBatchImportResult,
+  type LiferayBatchStatusOptions,
+  type LiferayBatchStatusResult,
+  type LiferayBatchTaskSnapshot,
+  type PollOutcome,
+} from './liferay-batch-types.js';
+
+export {
+  BATCH_ENGINE_BASE_PATH,
+  DEFAULT_POLL_INTERVAL_SECONDS,
+  DEFAULT_POLL_TIMEOUT_SECONDS,
+  type BatchEngineDependencies,
+  type LiferayBatchExportOptions,
+  type LiferayBatchExportResult,
+  type LiferayBatchFailedItem,
+  type LiferayBatchImportOptions,
+  type LiferayBatchImportResult,
+  type LiferayBatchStatusOptions,
+  type LiferayBatchStatusResult,
+  type LiferayBatchTaskSnapshot,
+} from './liferay-batch-types.js';
+export {
+  formatLiferayBatchExport,
+  formatLiferayBatchImport,
+  formatLiferayBatchStatus,
+  getLiferayBatchExportExitCode,
+  getLiferayBatchImportExitCode,
+  getLiferayBatchStatusExitCode,
+} from './liferay-batch-format.js';
+
+const TERMINAL_EXECUTE_STATUSES = new Set(['COMPLETED', 'FAILED']);
+const CREATE_STRATEGIES = new Set(['INSERT', 'UPSERT']);
+const IMPORT_STRATEGIES = new Set(['ON_ERROR_CONTINUE', 'ON_ERROR_FAIL']);
+
+// ── Import ────────────────────────────────────────────────────────────────────
+
+export async function runLiferayBatchImport(
+  config: AppConfig,
+  options: LiferayBatchImportOptions,
+  dependencies?: BatchEngineDependencies,
+): Promise<LiferayBatchImportResult> {
+  const className = requireClassName(options.className);
+  const createStrategy = normalizeChoice(options.createStrategy, CREATE_STRATEGIES, '--create-strategy');
+  const importStrategy = normalizeChoice(options.importStrategy, IMPORT_STRATEGIES, '--import-strategy');
+  const payload = await readImportPayload(options);
+  const gateway = createGateway(config, dependencies);
+
+  const query = buildQuery({
+    createStrategy,
+    importStrategy,
+    externalReferenceCode: options.externalReferenceCode,
+    fieldNameMapping: options.fieldNameMapping,
+    taskItemDelegateName: options.taskItemDelegateName,
+  });
+  const submitPath = `${BATCH_ENGINE_BASE_PATH}/import-tasks/${encodeURIComponent(className)}${query}`;
+  const submitted = toTaskSnapshot(
+    await gateway.postJson<unknown>(submitPath, payload.data, 'batch-import-submit'),
+    'batch-import-submit',
+  );
+
+  const poll = options.poll !== false;
+  const outcome = poll
+    ? await pollBatchTask(gateway, 'import-tasks', submitted.id, options, dependencies)
+    : {task: submitted, pollAttempts: 0, elapsedMs: 0, timedOut: false};
+
+  // Read-back verification: failed-items is checked whenever the task reached a
+  // terminal state, so a COMPLETED status is only reported as verified when the
+  // portal also reports zero failed items.
+  const shouldCheckFailedItems = poll && TERMINAL_EXECUTE_STATUSES.has(outcome.task.executeStatus);
+  const failedItems = shouldCheckFailedItems
+    ? await fetchFailedItems(gateway, submitted.id)
+    : {items: [], checked: false};
+
+  const verified =
+    poll && !outcome.timedOut && outcome.task.executeStatus === 'COMPLETED' && failedItems.checked
+      ? failedItems.items.length === 0
+      : false;
+
+  return {
+    operation: 'import',
+    className,
+    taskId: submitted.id,
+    submittedItems: payload.itemCount,
+    executeStatus: outcome.task.executeStatus,
+    errorMessage: outcome.task.errorMessage,
+    polled: poll,
+    pollAttempts: outcome.pollAttempts,
+    elapsedMs: outcome.elapsedMs,
+    timedOut: outcome.timedOut,
+    failedItems: failedItems.items,
+    failedItemsChecked: failedItems.checked,
+    verified,
+    task: outcome.task,
+  };
+}
+
+// ── Export ────────────────────────────────────────────────────────────────────
+
+export async function runLiferayBatchExport(
+  config: AppConfig,
+  options: LiferayBatchExportOptions,
+  dependencies?: BatchEngineDependencies,
+): Promise<LiferayBatchExportResult> {
+  const className = requireClassName(options.className);
+  const contentType = (options.contentType ?? 'JSON').trim();
+  if (contentType === '') {
+    throw LiferayErrors.batchError('--content-type must not be empty.');
+  }
+
+  const gateway = createGateway(config, dependencies);
+  const query = buildQuery({
+    fieldNames: options.fieldNames,
+    taskItemDelegateName: options.taskItemDelegateName,
+  });
+  const submitPath =
+    `${BATCH_ENGINE_BASE_PATH}/export-tasks/${encodeURIComponent(className)}/` +
+    `${encodeURIComponent(contentType)}${query}`;
+  const submitted = toTaskSnapshot(
+    await gateway.postJson<unknown>(submitPath, {}, 'batch-export-submit'),
+    'batch-export-submit',
+  );
+
+  const poll = Boolean(options.poll);
+  const outcome = poll
+    ? await pollBatchTask(gateway, 'export-tasks', submitted.id, options, dependencies)
+    : {task: submitted, pollAttempts: 0, elapsedMs: 0, timedOut: false};
+
+  return {
+    operation: 'export',
+    className,
+    contentType,
+    taskId: submitted.id,
+    executeStatus: outcome.task.executeStatus,
+    errorMessage: outcome.task.errorMessage,
+    polled: poll,
+    pollAttempts: outcome.pollAttempts,
+    elapsedMs: outcome.elapsedMs,
+    timedOut: outcome.timedOut,
+    contentPath: outcome.task.executeStatus === 'COMPLETED' ? exportContentPath(submitted.id) : undefined,
+    task: outcome.task,
+  };
+}
+
+// ── Status ────────────────────────────────────────────────────────────────────
+
+export async function runLiferayBatchStatus(
+  config: AppConfig,
+  options: LiferayBatchStatusOptions,
+  dependencies?: BatchEngineDependencies,
+): Promise<LiferayBatchStatusResult> {
+  if (!Number.isInteger(options.taskId) || options.taskId <= 0) {
+    throw LiferayErrors.batchError('--task must be a positive integer.');
+  }
+
+  const operation = options.operation ?? 'import';
+  const gateway = createGateway(config, dependencies);
+  const basePath = operation === 'import' ? 'import-tasks' : 'export-tasks';
+  const task = toTaskSnapshot(
+    await gateway.getJson<unknown>(`${BATCH_ENGINE_BASE_PATH}/${basePath}/${options.taskId}`, 'batch-status'),
+    'batch-status',
+  );
+
+  const failedItems =
+    operation === 'import' && TERMINAL_EXECUTE_STATUSES.has(task.executeStatus)
+      ? await fetchFailedItems(gateway, options.taskId)
+      : {items: [], checked: false};
+
+  return {
+    operation,
+    taskId: options.taskId,
+    executeStatus: task.executeStatus,
+    errorMessage: task.errorMessage,
+    failedItems: failedItems.items,
+    failedItemsChecked: failedItems.checked,
+    contentPath:
+      operation === 'export' && task.executeStatus === 'COMPLETED' ? exportContentPath(options.taskId) : undefined,
+    task,
+  };
+}
+
+// ── Shared internals ──────────────────────────────────────────────────────────
+
+function createGateway(config: AppConfig, dependencies?: BatchEngineDependencies): LiferayGateway {
+  return createLiferayGateway(config, dependencies?.apiClient, dependencies?.tokenClient);
+}
+
+function requireClassName(className: string | undefined): string {
+  const normalized = className?.trim() ?? '';
+  if (normalized === '') {
+    throw LiferayErrors.batchError('--class-name is required (fully qualified DTO class name).');
+  }
+
+  return normalized;
+}
+
+function normalizeChoice(value: string | undefined, allowed: Set<string>, flag: string): string | undefined {
+  const normalized = value?.trim().toUpperCase();
+  if (normalized === undefined || normalized === '') {
+    return undefined;
+  }
+
+  if (!allowed.has(normalized)) {
+    throw LiferayErrors.batchError(`${flag} must be one of: ${[...allowed].join(', ')}.`);
+  }
+
+  return normalized;
+}
+
+async function readImportPayload(options: {file?: string; data?: string}): Promise<{data: unknown; itemCount: number}> {
+  const file = options.file?.trim() ?? '';
+  const inline = options.data?.trim() ?? '';
+
+  if (file !== '' && inline !== '') {
+    throw LiferayErrors.batchError('Use either --file or --data, not both.');
+  }
+
+  if (file === '' && inline === '') {
+    throw LiferayErrors.batchError('One of --file or --data is required.');
+  }
+
+  let raw = inline;
+  if (file !== '') {
+    if (!(await fs.pathExists(file))) {
+      throw LiferayErrors.resourceFileNotFound(file);
+    }
+    raw = await fs.readFile(file, 'utf8');
+  }
+
+  let data: unknown;
+  try {
+    data = JSON.parse(raw);
+  } catch {
+    throw LiferayErrors.batchError(
+      file !== '' ? `Batch payload is not valid JSON: ${file}.` : 'Batch payload passed via --data is not valid JSON.',
+    );
+  }
+
+  return {data, itemCount: countPayloadItems(data)};
+}
+
+function countPayloadItems(payload: unknown): number {
+  if (Array.isArray(payload)) {
+    return payload.length;
+  }
+
+  if (payload !== null && typeof payload === 'object') {
+    const items = (payload as {items?: unknown}).items;
+    if (Array.isArray(items)) {
+      return items.length;
+    }
+  }
+
+  return 1;
+}
+
+function buildQuery(params: Record<string, string | undefined>): string {
+  const search = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    const normalized = value?.trim() ?? '';
+    if (normalized !== '') {
+      search.set(key, normalized);
+    }
+  }
+
+  const query = search.toString();
+  return query === '' ? '' : `?${query}`;
+}
+
+function toTaskSnapshot(data: unknown, label: string): LiferayBatchTaskSnapshot {
+  if (data === null || typeof data !== 'object') {
+    throw LiferayErrors.batchError(`${label}: unexpected batch engine response (not a task object).`);
+  }
+
+  const record = data as Record<string, unknown>;
+  const id =
+    typeof record.id === 'number'
+      ? record.id
+      : typeof record.id === 'string'
+        ? Number.parseInt(record.id, 10)
+        : Number.NaN;
+  if (!Number.isInteger(id) || id <= 0) {
+    throw LiferayErrors.batchError(`${label}: batch engine response has no task id.`);
+  }
+
+  return {
+    id,
+    executeStatus: typeof record.executeStatus === 'string' ? record.executeStatus : 'UNKNOWN',
+    errorMessage: asOptionalString(record.errorMessage),
+    className: asOptionalString(record.className),
+    contentType: asOptionalString(record.contentType),
+    externalReferenceCode: asOptionalString(record.externalReferenceCode),
+    operation: asOptionalString(record.operation),
+    startTime: asOptionalString(record.startTime),
+    endTime: asOptionalString(record.endTime),
+  };
+}
+
+function asOptionalString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() !== '' ? value : undefined;
+}
+
+async function pollBatchTask(
+  gateway: LiferayGateway,
+  basePath: 'import-tasks' | 'export-tasks',
+  taskId: number,
+  options: {pollIntervalSeconds?: number; pollTimeoutSeconds?: number},
+  dependencies?: BatchEngineDependencies,
+): Promise<PollOutcome> {
+  const intervalSeconds = options.pollIntervalSeconds ?? DEFAULT_POLL_INTERVAL_SECONDS;
+  const timeoutSeconds = options.pollTimeoutSeconds ?? DEFAULT_POLL_TIMEOUT_SECONDS;
+  if (!Number.isFinite(intervalSeconds) || intervalSeconds <= 0) {
+    throw LiferayErrors.batchError('--poll-interval must be a positive number of seconds.');
+  }
+  if (!Number.isFinite(timeoutSeconds) || timeoutSeconds < 0) {
+    throw LiferayErrors.batchError('--poll-timeout must be a non-negative number of seconds.');
+  }
+
+  const sleepImpl = dependencies?.sleep ?? sleep;
+  const now = dependencies?.now ?? Date.now;
+  const start = now();
+  const deadline = start + timeoutSeconds * 1000;
+  let pollAttempts = 0;
+
+  for (;;) {
+    const task = toTaskSnapshot(
+      await gateway.getJson<unknown>(`${BATCH_ENGINE_BASE_PATH}/${basePath}/${taskId}`, 'batch-poll'),
+      'batch-poll',
+    );
+    pollAttempts += 1;
+
+    if (TERMINAL_EXECUTE_STATUSES.has(task.executeStatus)) {
+      return {task, pollAttempts, elapsedMs: now() - start, timedOut: false};
+    }
+
+    if (now() >= deadline) {
+      return {task, pollAttempts, elapsedMs: now() - start, timedOut: true};
+    }
+
+    await sleepImpl(intervalSeconds * 1000);
+  }
+}
+
+async function fetchFailedItems(
+  gateway: LiferayGateway,
+  taskId: number,
+): Promise<{items: LiferayBatchFailedItem[]; checked: boolean}> {
+  const response = await gateway.getRaw<unknown>(`${BATCH_ENGINE_BASE_PATH}/import-tasks/${taskId}/failed-items`);
+  if (!response.ok) {
+    // Older portals do not expose failed-items; report the status honestly
+    // instead of failing the whole command after the task already finished.
+    return {items: [], checked: false};
+  }
+
+  const data = response.data;
+  const rawItems = Array.isArray(data)
+    ? data
+    : data !== null && typeof data === 'object' && Array.isArray((data as {items?: unknown}).items)
+      ? (data as {items: unknown[]}).items
+      : [];
+
+  const items: LiferayBatchFailedItem[] = [];
+  for (const raw of rawItems) {
+    if (raw === null || typeof raw !== 'object') {
+      continue;
+    }
+    const record = raw as Record<string, unknown>;
+    items.push({
+      itemIndex: typeof record.itemIndex === 'number' ? record.itemIndex : undefined,
+      message: asOptionalString(record.message),
+      item: asOptionalString(typeof record.item === 'string' ? record.item : JSON.stringify(record.item ?? '')),
+    });
+  }
+
+  return {items, checked: true};
+}
+
+function exportContentPath(taskId: number): string {
+  return `${BATCH_ENGINE_BASE_PATH}/export-tasks/${taskId}/content`;
+}

--- a/src/features/liferay/batch/liferay-batch-format.ts
+++ b/src/features/liferay/batch/liferay-batch-format.ts
@@ -1,0 +1,138 @@
+/**
+ * Text formatting and exit-code helpers for the Batch Engine wrapper commands.
+ */
+
+import type {
+  LiferayBatchExportResult,
+  LiferayBatchFailedItem,
+  LiferayBatchImportResult,
+  LiferayBatchStatusResult,
+} from './liferay-batch-types.js';
+
+export function getLiferayBatchImportExitCode(result: LiferayBatchImportResult): number {
+  if (!result.polled) {
+    return 0;
+  }
+
+  if (result.timedOut || result.executeStatus !== 'COMPLETED' || result.failedItems.length > 0) {
+    return 1;
+  }
+
+  return 0;
+}
+
+export function formatLiferayBatchImport(result: LiferayBatchImportResult): string {
+  const lines = [
+    `${result.timedOut ? 'TIMEOUT' : result.executeStatus}\timport\t${result.className}\ttask=${result.taskId}`,
+    `items: submitted=${result.submittedItems} failed=${result.failedItemsChecked ? result.failedItems.length : 'unknown'}`,
+  ];
+
+  if (result.polled) {
+    lines.push(`poll: attempts=${result.pollAttempts} elapsed=${result.elapsedMs}ms`);
+  } else {
+    lines.push('poll: skipped (--no-poll); task continues server-side');
+  }
+
+  if (result.errorMessage) {
+    lines.push(`error: ${result.errorMessage}`);
+  }
+
+  lines.push(...formatFailedItems(result.failedItems, result.failedItemsChecked, result.polled));
+
+  if (result.verified) {
+    lines.push(`verified: read-back executeStatus=COMPLETED with 0 failed items`);
+  } else if (result.timedOut) {
+    lines.push(
+      `hint: polling timed out with executeStatus=${result.executeStatus}; ` +
+        `re-check with: ldev portal batch status --task ${result.taskId}`,
+    );
+  } else if (!result.polled) {
+    lines.push(`hint: check progress with: ldev portal batch status --task ${result.taskId}`);
+  }
+
+  return lines.join('\n');
+}
+
+export function getLiferayBatchExportExitCode(result: LiferayBatchExportResult): number {
+  if (!result.polled) {
+    return 0;
+  }
+
+  return result.timedOut || result.executeStatus !== 'COMPLETED' ? 1 : 0;
+}
+
+export function formatLiferayBatchExport(result: LiferayBatchExportResult): string {
+  const lines = [
+    `${result.timedOut ? 'TIMEOUT' : result.executeStatus}\texport\t${result.className}\t` +
+      `contentType=${result.contentType}\ttask=${result.taskId}`,
+  ];
+
+  if (result.polled) {
+    lines.push(`poll: attempts=${result.pollAttempts} elapsed=${result.elapsedMs}ms`);
+  } else {
+    lines.push('poll: skipped (use --poll to wait for completion)');
+  }
+
+  if (result.errorMessage) {
+    lines.push(`error: ${result.errorMessage}`);
+  }
+
+  if (result.contentPath) {
+    lines.push(`content: GET ${result.contentPath} (authenticated) downloads the exported archive`);
+  } else if (result.timedOut) {
+    lines.push(
+      `hint: polling timed out with executeStatus=${result.executeStatus}; ` +
+        `re-check with: ldev portal batch status --task ${result.taskId} --operation export`,
+    );
+  } else if (!result.polled) {
+    lines.push(`hint: check progress with: ldev portal batch status --task ${result.taskId} --operation export`);
+  }
+
+  return lines.join('\n');
+}
+
+export function getLiferayBatchStatusExitCode(result: LiferayBatchStatusResult): number {
+  return result.executeStatus === 'FAILED' || result.failedItems.length > 0 ? 1 : 0;
+}
+
+export function formatLiferayBatchStatus(result: LiferayBatchStatusResult): string {
+  const lines = [`${result.executeStatus}\t${result.operation}\ttask=${result.taskId}`];
+
+  if (result.errorMessage) {
+    lines.push(`error: ${result.errorMessage}`);
+  }
+
+  if (result.operation === 'import') {
+    lines.push(...formatFailedItems(result.failedItems, result.failedItemsChecked, true));
+  }
+
+  if (result.contentPath) {
+    lines.push(`content: GET ${result.contentPath} (authenticated) downloads the exported archive`);
+  }
+
+  return lines.join('\n');
+}
+
+function formatFailedItems(items: LiferayBatchFailedItem[], checked: boolean, polled: boolean): string[] {
+  if (!checked) {
+    return polled ? ['failed items: not checked (endpoint unavailable or task not terminal)'] : [];
+  }
+
+  if (items.length === 0) {
+    return [];
+  }
+
+  const lines = [`failed items (${items.length}):`];
+  for (const item of items) {
+    const index = item.itemIndex !== undefined ? `#${item.itemIndex} ` : '';
+    const message = item.message ?? 'no message';
+    const excerpt = item.item !== undefined ? ` item=${truncate(item.item, 200)}` : '';
+    lines.push(`  ${index}${message}${excerpt}`);
+  }
+
+  return lines;
+}
+
+function truncate(text: string, maxLength: number): string {
+  return text.length <= maxLength ? text : `${text.slice(0, maxLength)}…`;
+}

--- a/src/features/liferay/batch/liferay-batch-types.ts
+++ b/src/features/liferay/batch/liferay-batch-types.ts
@@ -1,0 +1,115 @@
+/**
+ * Shared types for the Liferay Batch Engine wrapper (headless-batch-engine v1.0).
+ */
+
+import type {OAuthTokenClient} from '../../../core/http/auth.js';
+import type {HttpApiClient} from '../../../core/http/client.js';
+
+export const BATCH_ENGINE_BASE_PATH = '/o/headless-batch-engine/v1.0';
+
+export const DEFAULT_POLL_INTERVAL_SECONDS = 2;
+export const DEFAULT_POLL_TIMEOUT_SECONDS = 300;
+
+export type BatchEngineDependencies = {
+  apiClient?: HttpApiClient;
+  tokenClient?: OAuthTokenClient;
+  sleep?: (ms: number) => Promise<void>;
+  now?: () => number;
+};
+
+export type LiferayBatchTaskSnapshot = {
+  id: number;
+  executeStatus: string;
+  errorMessage?: string;
+  className?: string;
+  contentType?: string;
+  externalReferenceCode?: string;
+  operation?: string;
+  startTime?: string;
+  endTime?: string;
+};
+
+export type LiferayBatchFailedItem = {
+  itemIndex?: number;
+  message?: string;
+  item?: string;
+};
+
+export type PollOutcome = {
+  task: LiferayBatchTaskSnapshot;
+  pollAttempts: number;
+  elapsedMs: number;
+  timedOut: boolean;
+};
+
+export type LiferayBatchImportOptions = {
+  className: string;
+  file?: string;
+  data?: string;
+  createStrategy?: string;
+  importStrategy?: string;
+  externalReferenceCode?: string;
+  fieldNameMapping?: string;
+  taskItemDelegateName?: string;
+  poll?: boolean;
+  pollIntervalSeconds?: number;
+  pollTimeoutSeconds?: number;
+};
+
+export type LiferayBatchImportResult = {
+  operation: 'import';
+  className: string;
+  taskId: number;
+  submittedItems: number;
+  executeStatus: string;
+  errorMessage?: string;
+  polled: boolean;
+  pollAttempts: number;
+  elapsedMs: number;
+  timedOut: boolean;
+  failedItems: LiferayBatchFailedItem[];
+  failedItemsChecked: boolean;
+  verified: boolean;
+  task: LiferayBatchTaskSnapshot;
+};
+
+export type LiferayBatchExportOptions = {
+  className: string;
+  contentType?: string;
+  fieldNames?: string;
+  taskItemDelegateName?: string;
+  poll?: boolean;
+  pollIntervalSeconds?: number;
+  pollTimeoutSeconds?: number;
+};
+
+export type LiferayBatchExportResult = {
+  operation: 'export';
+  className: string;
+  contentType: string;
+  taskId: number;
+  executeStatus: string;
+  errorMessage?: string;
+  polled: boolean;
+  pollAttempts: number;
+  elapsedMs: number;
+  timedOut: boolean;
+  contentPath?: string;
+  task: LiferayBatchTaskSnapshot;
+};
+
+export type LiferayBatchStatusOptions = {
+  taskId: number;
+  operation?: 'import' | 'export';
+};
+
+export type LiferayBatchStatusResult = {
+  operation: 'import' | 'export';
+  taskId: number;
+  executeStatus: string;
+  errorMessage?: string;
+  failedItems: LiferayBatchFailedItem[];
+  failedItemsChecked: boolean;
+  contentPath?: string;
+  task: LiferayBatchTaskSnapshot;
+};

--- a/src/features/liferay/errors/liferay-error-codes.ts
+++ b/src/features/liferay/errors/liferay-error-codes.ts
@@ -20,6 +20,10 @@ export enum LiferayErrorCode {
   RESOURCE_FILE_AMBIGUOUS = 'LIFERAY_RESOURCE_FILE_AMBIGUOUS',
   RESOURCE_REPO_NOT_FOUND = 'LIFERAY_REPO_NOT_FOUND',
 
+  // Batch engine errors (headless-batch-engine import/export tasks)
+  BATCH_ERROR = 'LIFERAY_BATCH_ERROR',
+  BATCH_TIMEOUT = 'LIFERAY_BATCH_TIMEOUT',
+
   // Content errors
   CONTENT_PRUNE_ERROR = 'LIFERAY_CONTENT_PRUNE_ERROR',
   CONTENT_STATS_ERROR = 'LIFERAY_CONTENT_STATS_ERROR',
@@ -61,6 +65,9 @@ export const errorCodeMetadata: Record<
   [LiferayErrorCode.RESOURCE_FILE_NOT_FOUND]: {severity: 'error', retryable: false, logFullMessage: false},
   [LiferayErrorCode.RESOURCE_FILE_AMBIGUOUS]: {severity: 'error', retryable: false, logFullMessage: false},
   [LiferayErrorCode.RESOURCE_REPO_NOT_FOUND]: {severity: 'error', retryable: false, logFullMessage: false},
+
+  [LiferayErrorCode.BATCH_ERROR]: {severity: 'error', retryable: false, logFullMessage: false},
+  [LiferayErrorCode.BATCH_TIMEOUT]: {severity: 'warning', retryable: true, logFullMessage: false},
 
   [LiferayErrorCode.CONTENT_PRUNE_ERROR]: {severity: 'error', retryable: false, logFullMessage: false},
   [LiferayErrorCode.CONTENT_STATS_ERROR]: {severity: 'error', retryable: false, logFullMessage: false},

--- a/src/features/liferay/errors/liferay-error-factory.ts
+++ b/src/features/liferay/errors/liferay-error-factory.ts
@@ -94,6 +94,18 @@ export const LiferayErrors = {
     ),
 
   /**
+   * Batch engine operation failed (import-tasks/export-tasks).
+   */
+  batchError: (message: string, options?: LiferayErrorOptions): CliError =>
+    createLiferayError(message, LiferayErrorCode.BATCH_ERROR, options),
+
+  /**
+   * Batch engine polling timed out; the task may still complete server-side.
+   */
+  batchTimeout: (message: string, options?: LiferayErrorOptions): CliError =>
+    createLiferayError(message, LiferayErrorCode.BATCH_TIMEOUT, options),
+
+  /**
    * Content prune operation failed.
    */
   contentPruneError: (message: string, options?: LiferayErrorOptions): CliError =>

--- a/tests/unit/liferay-batch-engine.test.ts
+++ b/tests/unit/liferay-batch-engine.test.ts
@@ -1,0 +1,385 @@
+import {describe, expect, test} from 'vitest';
+
+import type {AppConfig} from '../../src/core/config/load-config.js';
+import {createLiferayApiClient} from '../../src/core/http/client.js';
+import {CliError} from '../../src/core/errors.js';
+import {
+  formatLiferayBatchExport,
+  formatLiferayBatchImport,
+  formatLiferayBatchStatus,
+  getLiferayBatchExportExitCode,
+  getLiferayBatchImportExitCode,
+  getLiferayBatchStatusExitCode,
+  runLiferayBatchExport,
+  runLiferayBatchImport,
+  runLiferayBatchStatus,
+} from '../../src/features/liferay/batch/liferay-batch-engine.js';
+import {createStaticTokenClient, createTestFetchImpl} from '../../src/testing/cli-test-helpers.js';
+
+const CONFIG: AppConfig = {
+  cwd: '/tmp/repo',
+  repoRoot: '/tmp/repo',
+  dockerDir: null,
+  liferayDir: null,
+  files: {
+    dockerEnv: null,
+    liferayProfile: null,
+  },
+  liferay: {
+    url: 'http://localhost:8080',
+    oauth2ClientId: 'client-id',
+    oauth2ClientSecret: 'client-secret',
+    scopeAliases: 'scope-a',
+    timeoutSeconds: 30,
+  },
+};
+
+const TOKEN_CLIENT = createStaticTokenClient({accessToken: 'token-abc'});
+const CLASS_NAME = 'com.liferay.object.model.ObjectEntry';
+
+function jsonResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {status});
+}
+
+function noopSleep(): Promise<void> {
+  return Promise.resolve();
+}
+
+function createClock(startMs: number, incrementMs: number): () => number {
+  let current = startMs;
+  return () => {
+    const value = current;
+    current += incrementMs;
+    return value;
+  };
+}
+
+type Handler = (url: string, init?: RequestInit) => Response;
+
+function makeApiClient(routes: Array<{match: (url: string, method: string) => boolean; handler: Handler}>) {
+  return createLiferayApiClient({
+    fetchImpl: createTestFetchImpl((url, init) => {
+      const method = init?.method ?? 'GET';
+      for (const route of routes) {
+        if (route.match(url, method)) {
+          return route.handler(url, init);
+        }
+      }
+      throw new Error(`Unexpected request: ${method} ${url}`);
+    }),
+  });
+}
+
+describe('runLiferayBatchImport', () => {
+  test('submits, polls through INITIAL/STARTED/COMPLETED, and verifies via failed-items read-back', async () => {
+    let pollCount = 0;
+    const apiClient = makeApiClient([
+      {
+        match: (url, method) => method === 'POST' && url.includes('/import-tasks/'),
+        handler: () => jsonResponse({id: 555, executeStatus: 'INITIAL'}),
+      },
+      {
+        match: (url, method) => method === 'GET' && url.includes('/import-tasks/555/failed-items'),
+        handler: () => jsonResponse([]),
+      },
+      {
+        match: (url, method) => method === 'GET' && url.includes('/import-tasks/555'),
+        handler: () => {
+          pollCount += 1;
+          const status = pollCount === 1 ? 'STARTED' : 'COMPLETED';
+          return jsonResponse({id: 555, executeStatus: status});
+        },
+      },
+    ]);
+
+    const result = await runLiferayBatchImport(
+      CONFIG,
+      {className: CLASS_NAME, data: JSON.stringify([{id: 1}, {id: 2}]), pollIntervalSeconds: 0.01},
+      {apiClient, tokenClient: TOKEN_CLIENT, sleep: noopSleep},
+    );
+
+    expect(result.taskId).toBe(555);
+    expect(result.executeStatus).toBe('COMPLETED');
+    expect(result.submittedItems).toBe(2);
+    expect(result.timedOut).toBe(false);
+    expect(result.failedItemsChecked).toBe(true);
+    expect(result.failedItems).toEqual([]);
+    expect(result.verified).toBe(true);
+    expect(getLiferayBatchImportExitCode(result)).toBe(0);
+
+    const text = formatLiferayBatchImport(result);
+    expect(text).toContain('COMPLETED');
+    expect(text).toContain('verified: read-back');
+  });
+
+  test('reports failed items and a non-zero exit code when the task fails', async () => {
+    const apiClient = makeApiClient([
+      {
+        match: (url, method) => method === 'POST' && url.includes('/import-tasks/'),
+        handler: () => jsonResponse({id: 777, executeStatus: 'INITIAL'}),
+      },
+      {
+        match: (url, method) => method === 'GET' && url.includes('/import-tasks/777/failed-items'),
+        handler: () => jsonResponse([{itemIndex: 0, message: 'Invalid field: name', item: '{"id":1}'}]),
+      },
+      {
+        match: (url, method) => method === 'GET' && url.includes('/import-tasks/777'),
+        handler: () => jsonResponse({id: 777, executeStatus: 'FAILED', errorMessage: 'Validation failed'}),
+      },
+    ]);
+
+    const result = await runLiferayBatchImport(
+      CONFIG,
+      {className: CLASS_NAME, data: '[{"id":1}]', pollIntervalSeconds: 0.01},
+      {apiClient, tokenClient: TOKEN_CLIENT, sleep: noopSleep},
+    );
+
+    expect(result.executeStatus).toBe('FAILED');
+    expect(result.errorMessage).toBe('Validation failed');
+    expect(result.failedItems).toHaveLength(1);
+    expect(result.verified).toBe(false);
+    expect(getLiferayBatchImportExitCode(result)).toBe(1);
+
+    const text = formatLiferayBatchImport(result);
+    expect(text).toContain('failed items (1)');
+    expect(text).toContain('Invalid field: name');
+  });
+
+  test('reports a timeout when executeStatus never reaches a terminal state', async () => {
+    const apiClient = makeApiClient([
+      {
+        match: (url, method) => method === 'POST' && url.includes('/import-tasks/'),
+        handler: () => jsonResponse({id: 888, executeStatus: 'INITIAL'}),
+      },
+      {
+        match: (url, method) => method === 'GET' && url.includes('/import-tasks/888'),
+        handler: () => jsonResponse({id: 888, executeStatus: 'STARTED'}),
+      },
+    ]);
+
+    const result = await runLiferayBatchImport(
+      CONFIG,
+      {className: CLASS_NAME, data: '[{"id":1}]', pollIntervalSeconds: 1, pollTimeoutSeconds: 2},
+      {apiClient, tokenClient: TOKEN_CLIENT, sleep: noopSleep, now: createClock(0, 1500)},
+    );
+
+    expect(result.timedOut).toBe(true);
+    expect(result.executeStatus).toBe('STARTED');
+    expect(result.verified).toBe(false);
+    expect(getLiferayBatchImportExitCode(result)).toBe(1);
+    expect(formatLiferayBatchImport(result)).toContain('TIMEOUT');
+  });
+
+  test('skips polling when --no-poll is requested', async () => {
+    const apiClient = makeApiClient([
+      {
+        match: (url, method) => method === 'POST' && url.includes('/import-tasks/'),
+        handler: () => jsonResponse({id: 999, executeStatus: 'INITIAL'}),
+      },
+    ]);
+
+    const result = await runLiferayBatchImport(
+      CONFIG,
+      {className: CLASS_NAME, data: '[{"id":1}]', poll: false},
+      {apiClient, tokenClient: TOKEN_CLIENT, sleep: noopSleep},
+    );
+
+    expect(result.polled).toBe(false);
+    expect(result.pollAttempts).toBe(0);
+    expect(result.executeStatus).toBe('INITIAL');
+    expect(getLiferayBatchImportExitCode(result)).toBe(0);
+    expect(formatLiferayBatchImport(result)).toContain('skipped (--no-poll)');
+  });
+
+  test('reads the payload from --file when provided', async () => {
+    const fs = await import('fs-extra');
+    const os = await import('node:os');
+    const path = await import('node:path');
+    const file = path.join(os.tmpdir(), `batch-import-${Date.now()}.json`);
+    await fs.writeJson(file, {items: [{id: 1}, {id: 2}, {id: 3}]});
+
+    try {
+      const apiClient = makeApiClient([
+        {
+          match: (url, method) => method === 'POST' && url.includes('/import-tasks/'),
+          handler: () => jsonResponse({id: 111, executeStatus: 'COMPLETED'}),
+        },
+      ]);
+
+      const result = await runLiferayBatchImport(
+        CONFIG,
+        {className: CLASS_NAME, file, poll: false},
+        {apiClient, tokenClient: TOKEN_CLIENT, sleep: noopSleep},
+      );
+
+      expect(result.submittedItems).toBe(3);
+    } finally {
+      await fs.remove(file);
+    }
+  });
+
+  test('throws when --file does not exist', async () => {
+    const apiClient = makeApiClient([]);
+
+    await expect(
+      runLiferayBatchImport(
+        CONFIG,
+        {className: CLASS_NAME, file: '/definitely/not/a/real/file.json'},
+        {apiClient, tokenClient: TOKEN_CLIENT},
+      ),
+    ).rejects.toThrow(CliError);
+  });
+
+  test('throws when both --file and --data are given', async () => {
+    const apiClient = makeApiClient([]);
+
+    await expect(
+      runLiferayBatchImport(
+        CONFIG,
+        {className: CLASS_NAME, file: 'x.json', data: '[]'},
+        {apiClient, tokenClient: TOKEN_CLIENT},
+      ),
+    ).rejects.toThrow(/Use either --file or --data/);
+  });
+
+  test('throws when neither --file nor --data are given', async () => {
+    const apiClient = makeApiClient([]);
+
+    await expect(
+      runLiferayBatchImport(CONFIG, {className: CLASS_NAME}, {apiClient, tokenClient: TOKEN_CLIENT}),
+    ).rejects.toThrow(/One of --file or --data is required/);
+  });
+
+  test('throws when --data is not valid JSON', async () => {
+    const apiClient = makeApiClient([]);
+
+    await expect(
+      runLiferayBatchImport(CONFIG, {className: CLASS_NAME, data: 'not-json'}, {apiClient, tokenClient: TOKEN_CLIENT}),
+    ).rejects.toThrow(/not valid JSON/);
+  });
+
+  test('throws when --class-name is empty', async () => {
+    const apiClient = makeApiClient([]);
+
+    await expect(
+      runLiferayBatchImport(CONFIG, {className: '  ', data: '[]'}, {apiClient, tokenClient: TOKEN_CLIENT}),
+    ).rejects.toThrow(/--class-name is required/);
+  });
+
+  test('throws when --create-strategy is invalid', async () => {
+    const apiClient = makeApiClient([]);
+
+    await expect(
+      runLiferayBatchImport(
+        CONFIG,
+        {className: CLASS_NAME, data: '[]', createStrategy: 'BOGUS'},
+        {apiClient, tokenClient: TOKEN_CLIENT},
+      ),
+    ).rejects.toThrow(/--create-strategy must be one of/);
+  });
+});
+
+describe('runLiferayBatchExport', () => {
+  test('submits without polling by default', async () => {
+    const apiClient = makeApiClient([
+      {
+        match: (url, method) => method === 'POST' && url.includes('/export-tasks/'),
+        handler: () => jsonResponse({id: 42, executeStatus: 'INITIAL'}),
+      },
+    ]);
+
+    const result = await runLiferayBatchExport(
+      CONFIG,
+      {className: CLASS_NAME},
+      {apiClient, tokenClient: TOKEN_CLIENT, sleep: noopSleep},
+    );
+
+    expect(result.polled).toBe(false);
+    expect(result.taskId).toBe(42);
+    expect(result.contentType).toBe('JSON');
+    expect(getLiferayBatchExportExitCode(result)).toBe(0);
+    expect(formatLiferayBatchExport(result)).toContain('skipped');
+  });
+
+  test('polls until COMPLETED and reports the content path', async () => {
+    const apiClient = makeApiClient([
+      {
+        match: (url, method) => method === 'POST' && url.includes('/export-tasks/'),
+        handler: () => jsonResponse({id: 43, executeStatus: 'INITIAL'}),
+      },
+      {
+        match: (url, method) => method === 'GET' && url.includes('/export-tasks/43'),
+        handler: () => jsonResponse({id: 43, executeStatus: 'COMPLETED'}),
+      },
+    ]);
+
+    const result = await runLiferayBatchExport(
+      CONFIG,
+      {className: CLASS_NAME, poll: true, pollIntervalSeconds: 0.01},
+      {apiClient, tokenClient: TOKEN_CLIENT, sleep: noopSleep},
+    );
+
+    expect(result.polled).toBe(true);
+    expect(result.executeStatus).toBe('COMPLETED');
+    expect(result.contentPath).toContain('/export-tasks/43/content');
+    expect(getLiferayBatchExportExitCode(result)).toBe(0);
+    expect(formatLiferayBatchExport(result)).toContain('content:');
+  });
+
+  test('throws when --content-type is empty', async () => {
+    const apiClient = makeApiClient([]);
+
+    await expect(
+      runLiferayBatchExport(CONFIG, {className: CLASS_NAME, contentType: '  '}, {apiClient, tokenClient: TOKEN_CLIENT}),
+    ).rejects.toThrow(/--content-type must not be empty/);
+  });
+});
+
+describe('runLiferayBatchStatus', () => {
+  test('fetches import task status and failed items when terminal', async () => {
+    const apiClient = makeApiClient([
+      {
+        match: (url, method) => method === 'GET' && url.includes('/import-tasks/321/failed-items'),
+        handler: () => jsonResponse([{message: 'boom'}]),
+      },
+      {
+        match: (url, method) => method === 'GET' && url.includes('/import-tasks/321'),
+        handler: () => jsonResponse({id: 321, executeStatus: 'FAILED', errorMessage: 'boom'}),
+      },
+    ]);
+
+    const result = await runLiferayBatchStatus(CONFIG, {taskId: 321}, {apiClient, tokenClient: TOKEN_CLIENT});
+
+    expect(result.executeStatus).toBe('FAILED');
+    expect(result.failedItems).toHaveLength(1);
+    expect(getLiferayBatchStatusExitCode(result)).toBe(1);
+    expect(formatLiferayBatchStatus(result)).toContain('failed items (1)');
+  });
+
+  test('fetches export task status without failed-items lookup', async () => {
+    const apiClient = makeApiClient([
+      {
+        match: (url, method) => method === 'GET' && url.includes('/export-tasks/654'),
+        handler: () => jsonResponse({id: 654, executeStatus: 'COMPLETED'}),
+      },
+    ]);
+
+    const result = await runLiferayBatchStatus(
+      CONFIG,
+      {taskId: 654, operation: 'export'},
+      {apiClient, tokenClient: TOKEN_CLIENT},
+    );
+
+    expect(result.executeStatus).toBe('COMPLETED');
+    expect(result.contentPath).toContain('/export-tasks/654/content');
+    expect(getLiferayBatchStatusExitCode(result)).toBe(0);
+  });
+
+  test('throws when --task is not a positive integer', async () => {
+    const apiClient = makeApiClient([]);
+
+    await expect(runLiferayBatchStatus(CONFIG, {taskId: 0}, {apiClient, tokenClient: TOKEN_CLIENT})).rejects.toThrow(
+      /--task must be a positive integer/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `ldev portal batch import|export|status`, a wrapper around the Liferay headless-batch-engine API (POST `/o/headless-batch-engine/v1.0/import-tasks/{className}`, `/export-tasks/{className}/{contentType}`, and the corresponding `GET .../{id}` status endpoints).
- `import` submits a payload (`--file` or `--data`), then polls `executeStatus` (`--poll-interval` / `--poll-timeout`, default 2s/300s) until it reaches `COMPLETED` or `FAILED`. On a terminal state it does a read-back verification via `GET .../import-tasks/{id}/failed-items`, so a "COMPLETED" report is only marked `verified` when the failed-items read-back also reports zero failures — following the same evidence-based contract as `ldev resource import-*`. `--no-poll` submits without waiting.
- `export` submits an export task and, with `--poll`, waits for the terminal `executeStatus` and reports the authenticated content download path.
- `status` re-checks a previously submitted task id (useful after `--no-poll` or a timeout) without resubmitting anything.
- All three commands support `--format json|ndjson` and default text output includes an itemized failed-items report and actionable hints (e.g. re-check command) on timeout.

## Design decisions

- Placed the command under the existing `portal` namespace (`src/commands/liferay/batch.command.ts`, registered from `liferay.command.ts`) rather than creating a new top-level command group, matching how `auth`, `content`, `search`, etc. are already grouped there. No new `portal` group was needed since it already existed.
- Feature logic lives in `src/features/liferay/batch/` (`liferay-batch-engine.ts` for orchestration, `liferay-batch-format.ts` for text rendering/exit codes, `liferay-batch-types.ts` for shared types), split to keep files under the repo's line-count lint guidance while reusing the existing `LiferayGateway` (auth, retry, timeout) for all HTTP calls.
- Added `LIFERAY_BATCH_ERROR` / `LIFERAY_BATCH_TIMEOUT` error codes and `LiferayErrors.batchError` / `.batchTimeout` factory helpers, consistent with the existing sanitized error-factory pattern.
- Polling is dependency-injected (`sleep`, `now`) so tests can simulate timeouts and multi-step `executeStatus` transitions without real waits.

## Test plan

- [x] `npm run lint` — 0 errors (pre-existing `max-lines` warnings on unrelated files only)
- [x] `npm run typecheck` — clean
- [x] `npm run test:unit` — 119 files / 1298 tests passed, including 17 new tests in `tests/unit/liferay-batch-engine.test.ts` covering: submit→poll→COMPLETED with failed-items read-back verification, FAILED status with failed-items reporting, polling timeout, `--no-poll`, `--file` payload reading, and input validation (missing/duplicate file+data, invalid JSON, invalid `--class-name`/`--create-strategy`, invalid `--content-type`, invalid `--task`).
- [x] `npm run build` and `npm run test:smoke` (via the `verify:push` pre-push hook) — passed.
- [x] Manually validated against a disposable local Liferay portal: OAuth2 token retrieval, request construction (`POST .../import-tasks/{className}`, `POST .../export-tasks/{className}/{type}`, `GET .../{id}`), and error surfacing (`LIFERAY_GATEWAY_ERROR` with status and path, non-zero exit code) all worked correctly against the live REST API. Could not exercise a full successful `COMPLETED` polling cycle because that instance had no entity with a registered Batch Engine delegate available to test against (several candidate class names all returned a genuine `404 NOT_FOUND` from the portal itself); the request/response/polling/error-handling plumbing is otherwise confirmed working end-to-end against a real server.

Fixes #173