### PR TITLE
feat(cli): add portal api discover for Headless REST contract discovery

### DIFF
--- a/docs/commands/discovery.md
+++ b/docs/commands/discovery.md
@@ -183,6 +183,41 @@ This is especially useful before changing a shared portal resource: it gives you
 read-before-write impact analysis without opening the UI or guessing where a
 resource might be referenced.
 
+## `ldev portal api discover`
+
+Resolve the OpenAPI spec of a Liferay Headless app and list its endpoints, schemas,
+filter/sort parameters, pagination support, and (optionally) a working curl/JS example.
+This is the operational bridge between "I need this entity" and a working request.
+
+```bash
+ldev portal api discover
+ldev portal api discover headless-delivery
+ldev portal api discover headless-delivery --path structured-contents
+ldev portal api discover headless-delivery --schema StructuredContent
+ldev portal api discover headless-delivery --example /sites/{siteId}/structured-contents
+ldev portal api discover headless-admin-user --json
+```
+
+Without an app name, it lists every Headless app registered at `/o/openapi`. With an app
+name, it resolves the spec (first from the `/o/openapi` catalog, then by the
+`/o/<app>/v1.0/openapi.json` pattern), then reports:
+
+- Every endpoint's path, method, and which of `page`/`pageSize`, `filter`, `sort`, and
+  `search` query parameters it accepts
+- Available schemas, with `--schema <name>` to inspect one schema's properties in full
+- Fixed pagination/auth/filter/sort conventions for the whole Headless surface
+- With `--example <path>`, a ready-to-run `curl` command and `fetch()` snippet for the
+  matching endpoint, authenticated with a Bearer token
+
+Options:
+
+- `--path <substring>` — only show endpoints whose path contains this substring
+- `--method <verb>` — only show endpoints with this HTTP method (also selects the `--example` method)
+- `--schema <name>` — show full property details for one schema
+- `--example <path>` — emit a curl + fetch example for the endpoint matching this path
+
+Pair this with `ldev portal auth token --raw` to get a token for the emitted examples.
+
 ## `ldev portal audit`
 
 Minimal runtime audit of accessible site metadata and API reachability. Defaults to JSON.

--- a/skills/developing-liferay/SKILL.md
+++ b/skills/developing-liferay/SKILL.md
@@ -39,7 +39,8 @@ Use the CLI for file exports/imports and file-backed resource mutations. For str
 - Liferay Objects -> `references/objects.md`
 - Structured content or site page mutation -> `references/site-building.md`
 - Workflow or publication state -> `references/workflow.md`
-- Headless/Groovy/OAuth2 support -> related files under `references/`
+- Headless REST contract discovery -> `references/headless-openapi.md` (`ldev portal api discover`)
+- Groovy console/OAuth2 support -> related files under `references/`
 - Structures/templates/ADTs/fragments -> `portal-resource-workflow`
 - Journal data movement or incompatible structure change -> `migrating-journal-structures`
 

--- a/skills/developing-liferay/references/headless-openapi.md
+++ b/skills/developing-liferay/references/headless-openapi.md
@@ -1,25 +1,31 @@
 # Liferay Headless OpenAPI Catalog
 
-Use `ldev context --json` and read `liferay.portalUrl`; replace `<portalUrl>` with
-that value instead of hardcoding a host or port. In a local runtime,
-`<portalUrl>` is often `http://127.0.0.1:8080` or `http://localhost:8080`.
+Prefer `ldev portal api discover` over raw `curl` for resolving a Headless
+app's contract:
 
-These URLs expose the OpenAPI specs for the headless REST modules available in
-the portal. Use them to inspect exact paths, schemas and operation IDs before
-writing ad hoc REST calls.
+```bash
+ldev portal api discover
+ldev portal api discover headless-delivery
+ldev portal api discover headless-delivery --schema StructuredContent
+ldev portal api discover headless-delivery --example /sites/{siteId}/structured-contents
+```
 
-## Useful workflow
+It resolves the spec (via the `/o/openapi` catalog, falling back to
+`/o/<app>/v1.0/openapi.json`), lists endpoints with their pagination/filter/sort
+support, and `--example` emits a ready-to-run curl + fetch snippet
+authenticated with a Bearer token from `ldev portal auth token --raw`. Use
+`--json` for agent consumption.
+
+Fall back to raw `curl` only when the app is not yet registered in the
+catalog or a spec detail is missing:
 
 ```bash
 ldev context --json
 curl "<portalUrl>/o/headless-delivery/v1.0/openapi.json"
-curl "<portalUrl>/o/headless-admin-site/v1.0/openapi.json"
-curl "<portalUrl>/o/data-engine/v2.0/openapi.json"
 ```
 
-If a spec endpoint requires authentication, use the OAuth2 configuration from
-`ldev context --json` or prefer the existing `ldev portal` and `ldev resource`
-commands when they already cover the workflow.
+Replace `<portalUrl>` with `liferay.portalUrl` from `ldev context --json`
+instead of hardcoding a host or port.
 
 ## OpenAPI endpoints
 

--- a/src/commands/liferay/api.command.ts
+++ b/src/commands/liferay/api.command.ts
@@ -1,0 +1,64 @@
+import {Command} from 'commander';
+
+import {addOutputFormatOption, createFormattedArgumentAction} from '../../cli/command-helpers.js';
+import {
+  formatLiferayApiDiscover,
+  runLiferayApiDiscover,
+  type ApiDiscoverResult,
+} from '../../features/liferay/liferay-api-discover.js';
+
+type ApiDiscoverCommandOptions = {
+  path?: string;
+  method?: string;
+  schema?: string;
+  example?: string;
+};
+
+export function createApiCommands(parent: Command): void {
+  const api = new Command('api')
+    .helpGroup('Discovery:')
+    .description('Headless REST API discovery: apps, endpoints, schemas and parameters');
+
+  addOutputFormatOption(
+    api
+      .command('discover')
+      .description('Resolve the OpenAPI spec of a Headless app and list endpoints, schemas and parameters')
+      .argument('[app]', 'Headless app name (e.g. headless-delivery); omit to list available apps')
+      .option('--path <substring>', 'Only show endpoints whose path contains this substring')
+      .option('--method <method>', 'Only show endpoints with this HTTP method (also selects the --example method)')
+      .option('--schema <name>', 'Show full property details for one schema')
+      .option('--example <path>', 'Emit a working curl + fetch example for the endpoint matching this path')
+      .addHelpText(
+        'after',
+        `
+Examples:
+  ldev portal api discover
+  ldev portal api discover headless-delivery
+  ldev portal api discover headless-delivery --path structured-contents
+  ldev portal api discover headless-delivery --schema StructuredContent
+  ldev portal api discover headless-delivery --example /sites/{siteId}/structured-contents
+  ldev portal api discover headless-admin-user --json
+
+Notes:
+  - Without an app name, lists every Headless app registered at /o/openapi.
+  - The spec is resolved from the /o/openapi catalog first, then by the /o/<app>/v1.0/openapi.json pattern.
+  - Endpoint capability tags show which of page/pageSize, filter, sort and search each endpoint accepts.
+  - Examples authenticate with a Bearer token; fetch one with: ldev portal auth token --raw
+`,
+      ),
+  ).action(
+    createFormattedArgumentAction<string | undefined, ApiDiscoverCommandOptions, ApiDiscoverResult>(
+      async (context, app, options) =>
+        runLiferayApiDiscover(context.config, {
+          app,
+          path: options.path,
+          method: options.method,
+          schema: options.schema,
+          example: options.example,
+        }),
+      {text: formatLiferayApiDiscover},
+    ),
+  );
+
+  parent.addCommand(api);
+}

--- a/src/commands/liferay/liferay.command.ts
+++ b/src/commands/liferay/liferay.command.ts
@@ -1,6 +1,7 @@
 import {Command} from 'commander';
 
 import {createReindexCommand} from '../reindex/reindex.command.js';
+import {createApiCommands} from './api.command.js';
 import {createAuthCommands} from './auth.command.js';
 import {createContentCommand} from './content.command.js';
 import {createLiferayConfigCommand} from './config.command.js';
@@ -39,16 +40,19 @@ For resource export, import and migration workflows, use the top-level 'resource
 Recommended starting points:
   check, auth   Connectivity and API access checks
   inventory     Main discovery workflow for agents and humans
+  api discover  Headless REST API discovery (endpoints, schemas, examples)
 
 Discovery examples:
   ldev portal inventory sites --json
   ldev portal inventory page --url /web/guest/home --json
+  ldev portal api discover headless-delivery
 
 Main groups:
   check        OAuth2 verification and basic API reachability
   auth         OAuth2 token retrieval for scripting
   config       Effective local portal-ext and OSGi config inspection
   inventory    Sites, pages, structures and templates
+  api          Headless REST API discovery (openapi specs, endpoints, schemas)
   audit        Minimal runtime audit of a site and API reachability
   page-layout  Export and diff of content pages
   search       Elasticsearch inspection and test queries
@@ -61,6 +65,7 @@ Main groups:
   createAuthCommands(command);
   command.addCommand(createLiferayConfigCommand().helpGroup('Portal diagnostics:'));
   createInventoryCommands(command);
+  createApiCommands(command);
   command.addCommand(createContentCommand().helpGroup('Content management:'));
   createLiferayAuditCommands(command);
   createPageLayoutCommands(command);

--- a/src/features/liferay/errors/liferay-error-codes.ts
+++ b/src/features/liferay/errors/liferay-error-codes.ts
@@ -28,6 +28,9 @@ export enum LiferayErrorCode {
   // Gateway/HTTP errors
   GATEWAY_ERROR = 'LIFERAY_GATEWAY_ERROR',
 
+  // Headless API discovery errors
+  API_DISCOVER_ERROR = 'LIFERAY_API_DISCOVER_ERROR',
+
   // Configuration errors
   CONFIG_ERROR = 'LIFERAY_CONFIG_ERROR',
   CONFIG_REPO_REQUIRED = 'LIFERAY_CONFIG_REPO_REQUIRED',
@@ -67,6 +70,8 @@ export const errorCodeMetadata: Record<
   [LiferayErrorCode.CONTENT_JOURNAL_ERROR]: {severity: 'error', retryable: false, logFullMessage: false},
 
   [LiferayErrorCode.GATEWAY_ERROR]: {severity: 'error', retryable: false, logFullMessage: false},
+
+  [LiferayErrorCode.API_DISCOVER_ERROR]: {severity: 'error', retryable: false, logFullMessage: false},
 
   [LiferayErrorCode.CONFIG_ERROR]: {severity: 'error', retryable: false, logFullMessage: false},
   [LiferayErrorCode.CONFIG_REPO_REQUIRED]: {severity: 'error', retryable: false, logFullMessage: false},

--- a/src/features/liferay/errors/liferay-error-factory.ts
+++ b/src/features/liferay/errors/liferay-error-factory.ts
@@ -118,6 +118,12 @@ export const LiferayErrors = {
     createLiferayError(message, LiferayErrorCode.GATEWAY_ERROR, options),
 
   /**
+   * Headless API discovery operation failed (spec resolution, schema lookup, example generation).
+   */
+  apiDiscoverError: (message: string, options?: LiferayErrorOptions): CliError =>
+    createLiferayError(message, LiferayErrorCode.API_DISCOVER_ERROR, options),
+
+  /**
    * Configuration error.
    */
   configError: (message: string, options?: LiferayErrorOptions): CliError =>

--- a/src/features/liferay/liferay-api-discover.ts
+++ b/src/features/liferay/liferay-api-discover.ts
@@ -1,0 +1,757 @@
+import YAML from 'yaml';
+
+import type {AppConfig} from '../../core/config/load-config.js';
+import type {OAuthTokenClient} from '../../core/http/auth.js';
+import type {HttpApiClient} from '../../core/http/client.js';
+import {LiferayErrors} from './errors/index.js';
+import {createLiferayGateway, type LiferayGateway} from './liferay-gateway.js';
+
+/** Query parameters that define the Liferay Headless operational contract. */
+const PAGINATION_PARAMS = ['page', 'pageSize'];
+const FILTER_PARAM = 'filter';
+const SORT_PARAM = 'sort';
+const SEARCH_PARAM = 'search';
+
+export type ApiDiscoverDependencies = {
+  gateway?: LiferayGateway;
+  apiClient?: HttpApiClient;
+  tokenClient?: OAuthTokenClient;
+};
+
+export type ApiDiscoverOptions = {
+  app?: string;
+  path?: string;
+  method?: string;
+  schema?: string;
+  example?: string;
+};
+
+export type ApiDiscoverApp = {
+  name: string;
+  specPaths: string[];
+};
+
+export type ApiDiscoverAppsResult = {
+  mode: 'apps';
+  apps: ApiDiscoverApp[];
+};
+
+export type ApiDiscoverParameter = {
+  name: string;
+  in: string;
+  required: boolean;
+  type?: string;
+  description?: string;
+};
+
+export type ApiDiscoverEndpoint = {
+  method: string;
+  path: string;
+  operationId?: string;
+  summary?: string;
+  parameters: ApiDiscoverParameter[];
+  supportsPagination: boolean;
+  supportsFilter: boolean;
+  supportsSort: boolean;
+  supportsSearch: boolean;
+  requestSchema?: string;
+  responseSchema?: string;
+};
+
+export type ApiDiscoverSchemaProperty = {
+  name: string;
+  type: string;
+  required: boolean;
+};
+
+export type ApiDiscoverSchemaSummary = {
+  name: string;
+  propertyCount: number;
+};
+
+export type ApiDiscoverSchemaDetail = ApiDiscoverSchemaSummary & {
+  properties: ApiDiscoverSchemaProperty[];
+};
+
+export type ApiDiscoverExample = {
+  method: string;
+  path: string;
+  url: string;
+  curl: string;
+  javascript: string;
+};
+
+export type ApiDiscoverConventions = {
+  auth: string;
+  pagination: string;
+  filter: string;
+  sort: string;
+  search: string;
+  fields: string;
+};
+
+export type ApiDiscoverSpecResult = {
+  mode: 'spec';
+  app: string;
+  specPath: string;
+  baseUrl: string;
+  title?: string;
+  version?: string;
+  endpointCount: number;
+  endpoints: ApiDiscoverEndpoint[];
+  schemaCount: number;
+  schemas: ApiDiscoverSchemaSummary[];
+  schemaDetail?: ApiDiscoverSchemaDetail;
+  conventions: ApiDiscoverConventions;
+  example?: ApiDiscoverExample;
+};
+
+export type ApiDiscoverResult = ApiDiscoverAppsResult | ApiDiscoverSpecResult;
+
+type OpenApiSchemaObject = {
+  type?: string;
+  $ref?: string;
+  description?: string;
+  properties?: Record<string, OpenApiSchemaObject>;
+  required?: string[];
+  items?: OpenApiSchemaObject;
+  format?: string;
+};
+
+type OpenApiParameterObject = {
+  name?: string;
+  in?: string;
+  required?: boolean;
+  description?: string;
+  schema?: OpenApiSchemaObject;
+};
+
+type OpenApiMediaTypeObject = {
+  schema?: OpenApiSchemaObject;
+};
+
+type OpenApiOperationObject = {
+  operationId?: string;
+  summary?: string;
+  description?: string;
+  parameters?: OpenApiParameterObject[];
+  requestBody?: {content?: Record<string, OpenApiMediaTypeObject>};
+  responses?: Record<string, {content?: Record<string, OpenApiMediaTypeObject>}>;
+};
+
+type OpenApiDocument = {
+  openapi?: string;
+  info?: {title?: string; version?: string};
+  paths?: Record<string, unknown>;
+  components?: {schemas?: Record<string, OpenApiSchemaObject>};
+};
+
+const HTTP_METHODS = ['get', 'post', 'put', 'patch', 'delete', 'head', 'options'];
+
+export const API_DISCOVER_CONVENTIONS: ApiDiscoverConventions = {
+  auth: "Send 'Authorization: Bearer <token>'. Fetch a token with: ldev portal auth token --raw",
+  pagination:
+    'List endpoints accept page (1-based) and pageSize. Responses wrap results as {items, page, pageSize, totalCount, lastPage}; iterate while page <= lastPage.',
+  filter: "OData-style, e.g. filter=title eq 'News', filter=contains(title,'news'), filter=creatorId eq 20123",
+  sort: 'Comma-separated field:direction pairs, e.g. sort=title:asc,dateCreated:desc',
+  search: 'Keyword search across searchable fields, e.g. search=welcome',
+  fields: 'Restrict returned fields with fields=id,title; expand related entities with nestedFields=<name>',
+};
+
+export async function runLiferayApiDiscover(
+  config: AppConfig,
+  options?: ApiDiscoverOptions,
+  dependencies?: ApiDiscoverDependencies,
+): Promise<ApiDiscoverResult> {
+  const gateway = resolveGateway(config, dependencies);
+  const appName = normalizeAppName(options?.app ?? '');
+
+  if (appName === '') {
+    const apps = await listOpenApiApps(gateway);
+    return {mode: 'apps', apps};
+  }
+
+  const {specPath, document} = await resolveOpenApiSpec(gateway, appName);
+  return buildSpecResult(config, appName, specPath, document, options ?? {});
+}
+
+function resolveGateway(config: AppConfig, dependencies?: ApiDiscoverDependencies): LiferayGateway {
+  if (dependencies?.gateway) {
+    return dependencies.gateway;
+  }
+
+  return createLiferayGateway(config, dependencies?.apiClient, dependencies?.tokenClient);
+}
+
+export function normalizeAppName(app: string): string {
+  return app
+    .trim()
+    .replace(/^\/?o\//, '')
+    .replace(/^\/+|\/+$/g, '');
+}
+
+/**
+ * List available Headless apps from the /o/openapi catalog.
+ * The catalog maps app names to arrays of spec URLs (json + yaml).
+ */
+export async function listOpenApiApps(gateway: LiferayGateway): Promise<ApiDiscoverApp[]> {
+  const response = await gateway.getRaw<Record<string, unknown>>('/o/openapi');
+
+  if (!response.ok) {
+    throw LiferayErrors.apiDiscoverError(
+      `Could not list Headless apps: GET /o/openapi failed with status=${response.status}. ` +
+        'Check portal availability and OAuth2 scopes.',
+    );
+  }
+
+  const catalog = parseCatalog(response.data);
+  if (catalog === null) {
+    throw LiferayErrors.apiDiscoverError('GET /o/openapi returned an unexpected payload; cannot list Headless apps.');
+  }
+
+  return catalog;
+}
+
+function parseCatalog(data: unknown): ApiDiscoverApp[] | null {
+  if (data === null || typeof data !== 'object' || Array.isArray(data)) {
+    return null;
+  }
+
+  const apps: ApiDiscoverApp[] = [];
+  for (const [name, value] of Object.entries(data as Record<string, unknown>)) {
+    const rawEntries = Array.isArray(value) ? value : typeof value === 'string' ? [value] : [];
+    const specPaths = rawEntries
+      .filter((entry): entry is string => typeof entry === 'string')
+      .map(toSpecPath)
+      .filter((entry) => entry !== '');
+
+    if (specPaths.length > 0) {
+      apps.push({name, specPaths});
+    }
+  }
+
+  apps.sort((left, right) => left.name.localeCompare(right.name));
+  return apps.length > 0 ? apps : null;
+}
+
+function toSpecPath(specUrl: string): string {
+  const trimmed = specUrl.trim();
+  if (trimmed === '') {
+    return '';
+  }
+
+  if (trimmed.startsWith('/')) {
+    return trimmed;
+  }
+
+  try {
+    return new URL(trimmed).pathname;
+  } catch {
+    return '';
+  }
+}
+
+async function tryListOpenApiApps(gateway: LiferayGateway): Promise<ApiDiscoverApp[] | null> {
+  try {
+    return await listOpenApiApps(gateway);
+  } catch {
+    return null;
+  }
+}
+
+async function resolveOpenApiSpec(
+  gateway: LiferayGateway,
+  appName: string,
+): Promise<{specPath: string; document: OpenApiDocument}> {
+  const catalog = await tryListOpenApiApps(gateway);
+
+  const candidates = buildSpecCandidates(appName, catalog);
+
+  for (const candidate of candidates) {
+    const response = await gateway.getRaw<unknown>(candidate);
+    if (!response.ok) {
+      continue;
+    }
+
+    const document = parseSpecBody(response.data, response.body);
+    if (document !== null) {
+      return {specPath: candidate, document};
+    }
+  }
+
+  const availableApps = catalog?.map((app) => app.name) ?? [];
+  const hint =
+    availableApps.length > 0
+      ? ` Available apps: ${availableApps.join(', ')}`
+      : ' Run without an app name to list available apps.';
+
+  throw LiferayErrors.apiDiscoverError(`Could not resolve an OpenAPI spec for app '${appName}'.${hint}`);
+}
+
+function buildSpecCandidates(appName: string, catalog: ApiDiscoverApp[] | null): string[] {
+  const candidates: string[] = [];
+
+  const catalogEntry = catalog?.find((app) => app.name.toLowerCase() === appName.toLowerCase());
+  if (catalogEntry) {
+    // Prefer JSON specs; the HTTP client parses JSON natively.
+    const jsonFirst = [...catalogEntry.specPaths].sort((left, right) => scoreSpecPath(right) - scoreSpecPath(left));
+    candidates.push(...jsonFirst);
+  }
+
+  for (const pattern of [
+    `/o/${appName}/v1.0/openapi.json`,
+    `/o/${appName}/v2.0/openapi.json`,
+    `/o/${appName}/openapi.json`,
+    `/o/${appName}/v1.0/openapi.yaml`,
+  ]) {
+    if (!candidates.includes(pattern)) {
+      candidates.push(pattern);
+    }
+  }
+
+  return candidates;
+}
+
+function scoreSpecPath(specPath: string): number {
+  return specPath.endsWith('.json') ? 1 : 0;
+}
+
+function parseSpecBody(data: unknown, body: string): OpenApiDocument | null {
+  const candidate = data ?? parseYamlSafely(body);
+
+  if (candidate === null || typeof candidate !== 'object' || Array.isArray(candidate)) {
+    return null;
+  }
+
+  const document = candidate as OpenApiDocument;
+  if (document.paths === undefined && document.openapi === undefined) {
+    return null;
+  }
+
+  return document;
+}
+
+function parseYamlSafely(body: string): unknown {
+  if (body.trim() === '') {
+    return null;
+  }
+
+  try {
+    return YAML.parse(body);
+  } catch {
+    return null;
+  }
+}
+
+function buildSpecResult(
+  config: AppConfig,
+  appName: string,
+  specPath: string,
+  document: OpenApiDocument,
+  options: ApiDiscoverOptions,
+): ApiDiscoverSpecResult {
+  const allEndpoints = extractEndpoints(document);
+  const basePath = resolveSpecBasePath(specPath, allEndpoints);
+  const baseUrl = `${config.liferay.url.replace(/\/+$/, '')}${basePath}`;
+
+  const endpoints = filterEndpoints(allEndpoints, options);
+  const schemas = extractSchemaSummaries(document);
+  const schemaDetail = options.schema ? extractSchemaDetail(document, options.schema) : undefined;
+
+  if (options.schema && schemaDetail === undefined) {
+    const available = schemas.map((schema) => schema.name);
+    throw LiferayErrors.apiDiscoverError(
+      `Schema '${options.schema}' not found in ${specPath}.` +
+        (available.length > 0 ? ` Available schemas: ${available.join(', ')}` : ''),
+    );
+  }
+
+  const example = options.example ? buildExample(allEndpoints, baseUrl, options) : undefined;
+
+  return {
+    mode: 'spec',
+    app: appName,
+    specPath,
+    baseUrl,
+    title: document.info?.title,
+    version: document.info?.version,
+    endpointCount: endpoints.length,
+    endpoints,
+    schemaCount: schemas.length,
+    schemas,
+    ...(schemaDetail !== undefined ? {schemaDetail} : {}),
+    conventions: API_DISCOVER_CONVENTIONS,
+    ...(example !== undefined ? {example} : {}),
+  };
+}
+
+/**
+ * Resolve the base path to prepend to every endpoint path.
+ *
+ * Most OpenAPI specs declare endpoint paths relative to the spec's own location
+ * (e.g. spec at /o/headless-delivery/v1.0/openapi.json, path /structured-contents),
+ * so the version segment from the spec path belongs in the base path.
+ *
+ * Some Liferay-generated specs instead bake the version segment into every path
+ * itself (e.g. spec at /o/headless-delivery/v1.0/openapi.json, path
+ * /v1.0/structured-contents). Prefixing the version-included base path in that
+ * case would duplicate the version segment in every generated URL, so the base
+ * path is trimmed to the app root instead.
+ */
+function resolveSpecBasePath(specPath: string, endpoints: ApiDiscoverEndpoint[]): string {
+  const basePathWithVersion = specPath.replace(/\/openapi\.(json|yaml)$/i, '');
+  const versionMatch = /^(.*)(\/v[\d.]+)$/i.exec(basePathWithVersion);
+
+  if (versionMatch === null) {
+    return basePathWithVersion;
+  }
+
+  const [, appRoot, versionSegment] = versionMatch;
+  const pathsEmbedVersion = endpoints.some(
+    (endpoint) => endpoint.path === versionSegment || endpoint.path.startsWith(`${versionSegment}/`),
+  );
+
+  return pathsEmbedVersion ? appRoot : basePathWithVersion;
+}
+
+function extractEndpoints(document: OpenApiDocument): ApiDiscoverEndpoint[] {
+  const endpoints: ApiDiscoverEndpoint[] = [];
+  const paths = document.paths ?? {};
+
+  for (const [path, rawPathItem] of Object.entries(paths)) {
+    if (rawPathItem === null || typeof rawPathItem !== 'object') {
+      continue;
+    }
+
+    const pathItem = rawPathItem as Record<string, unknown>;
+    const pathLevelParameters = Array.isArray(pathItem.parameters)
+      ? (pathItem.parameters as OpenApiParameterObject[])
+      : [];
+
+    for (const method of HTTP_METHODS) {
+      const operation = pathItem[method];
+      if (operation === null || typeof operation !== 'object') {
+        continue;
+      }
+
+      endpoints.push(buildEndpoint(path, method, operation as OpenApiOperationObject, pathLevelParameters));
+    }
+  }
+
+  endpoints.sort((left, right) => left.path.localeCompare(right.path) || left.method.localeCompare(right.method));
+  return endpoints;
+}
+
+function buildEndpoint(
+  path: string,
+  method: string,
+  operation: OpenApiOperationObject,
+  pathLevelParameters: OpenApiParameterObject[],
+): ApiDiscoverEndpoint {
+  const merged = [...pathLevelParameters, ...(operation.parameters ?? [])];
+  const parameters: ApiDiscoverParameter[] = merged
+    .filter((parameter) => typeof parameter.name === 'string' && parameter.name !== '')
+    .map((parameter) => ({
+      name: parameter.name as string,
+      in: parameter.in ?? 'query',
+      required: Boolean(parameter.required),
+      ...(parameter.schema?.type !== undefined ? {type: parameter.schema.type} : {}),
+      ...(parameter.description !== undefined ? {description: parameter.description} : {}),
+    }));
+
+  const queryNames = new Set(
+    parameters.filter((parameter) => parameter.in === 'query').map((parameter) => parameter.name),
+  );
+
+  return {
+    method: method.toUpperCase(),
+    path,
+    ...(operation.operationId !== undefined ? {operationId: operation.operationId} : {}),
+    ...(operation.summary !== undefined || operation.description !== undefined
+      ? {summary: operation.summary ?? operation.description}
+      : {}),
+    parameters,
+    supportsPagination: PAGINATION_PARAMS.every((name) => queryNames.has(name)),
+    supportsFilter: queryNames.has(FILTER_PARAM),
+    supportsSort: queryNames.has(SORT_PARAM),
+    supportsSearch: queryNames.has(SEARCH_PARAM),
+    ...buildSchemaRefs(operation),
+  };
+}
+
+function buildSchemaRefs(operation: OpenApiOperationObject): {requestSchema?: string; responseSchema?: string} {
+  const requestSchema = refName(firstMediaTypeSchema(operation.requestBody?.content));
+
+  let responseSchema: string | undefined;
+  for (const response of Object.values(operation.responses ?? {})) {
+    responseSchema = refName(firstMediaTypeSchema(response.content));
+    if (responseSchema !== undefined) {
+      break;
+    }
+  }
+
+  return {
+    ...(requestSchema !== undefined ? {requestSchema} : {}),
+    ...(responseSchema !== undefined ? {responseSchema} : {}),
+  };
+}
+
+function firstMediaTypeSchema(content?: Record<string, OpenApiMediaTypeObject>): OpenApiSchemaObject | undefined {
+  if (content === undefined) {
+    return undefined;
+  }
+
+  const values = Object.values(content);
+  if (values.length === 0) {
+    return undefined;
+  }
+
+  const preferred = content['application/json'] ?? values[0];
+  return preferred.schema;
+}
+
+function refName(schema?: OpenApiSchemaObject): string | undefined {
+  if (schema === undefined) {
+    return undefined;
+  }
+
+  const ref = schema.$ref ?? schema.items?.$ref;
+  if (typeof ref !== 'string') {
+    return schema.type;
+  }
+
+  const name = ref.split('/').pop() ?? '';
+  return name !== '' ? name : undefined;
+}
+
+function filterEndpoints(endpoints: ApiDiscoverEndpoint[], options: ApiDiscoverOptions): ApiDiscoverEndpoint[] {
+  let filtered = endpoints;
+
+  if (options.path) {
+    const needle = options.path.toLowerCase();
+    filtered = filtered.filter((endpoint) => endpoint.path.toLowerCase().includes(needle));
+  }
+
+  if (options.method) {
+    const method = options.method.toUpperCase();
+    filtered = filtered.filter((endpoint) => endpoint.method === method);
+  }
+
+  return filtered;
+}
+
+function extractSchemaSummaries(document: OpenApiDocument): ApiDiscoverSchemaSummary[] {
+  const schemas = document.components?.schemas ?? {};
+
+  return Object.entries(schemas)
+    .map(([name, schema]) => ({
+      name,
+      propertyCount: Object.keys(schema.properties ?? {}).length,
+    }))
+    .sort((left, right) => left.name.localeCompare(right.name));
+}
+
+function extractSchemaDetail(document: OpenApiDocument, schemaName: string): ApiDiscoverSchemaDetail | undefined {
+  const schemas = document.components?.schemas ?? {};
+  const entry = Object.entries(schemas).find(([name]) => name.toLowerCase() === schemaName.toLowerCase());
+  if (entry === undefined) {
+    return undefined;
+  }
+
+  const [name, schema] = entry;
+  const required = new Set(schema.required ?? []);
+  const properties = Object.entries(schema.properties ?? {}).map(([propertyName, property]) => ({
+    name: propertyName,
+    type: describePropertyType(property),
+    required: required.has(propertyName),
+  }));
+
+  return {name, propertyCount: properties.length, properties};
+}
+
+function describePropertyType(property: OpenApiSchemaObject): string {
+  if (property.$ref !== undefined) {
+    return refName(property) ?? 'object';
+  }
+
+  if (property.type === 'array') {
+    const itemType = property.items !== undefined ? (refName(property.items) ?? 'object') : 'object';
+    return `array<${itemType}>`;
+  }
+
+  return property.type ?? 'object';
+}
+
+function buildExample(
+  endpoints: ApiDiscoverEndpoint[],
+  baseUrl: string,
+  options: ApiDiscoverOptions,
+): ApiDiscoverExample {
+  const endpoint = selectExampleEndpoint(endpoints, options);
+  const query = buildExampleQuery(endpoint);
+  const url = `${baseUrl}${endpoint.path}${query}`;
+
+  const isWrite = endpoint.method !== 'GET' && endpoint.method !== 'DELETE' && endpoint.method !== 'HEAD';
+  const bodyHint = endpoint.requestSchema !== undefined ? `<${endpoint.requestSchema} JSON>` : '<JSON payload>';
+
+  const curlLines = [`curl -H "Authorization: Bearer $(ldev portal auth token --raw)" \\`];
+  if (endpoint.method !== 'GET') {
+    curlLines.push(`  -X ${endpoint.method} \\`);
+  }
+  if (isWrite) {
+    curlLines.push(`  -H "Content-Type: application/json" \\`, `  -d '${bodyHint}' \\`);
+  }
+  curlLines.push(`  "${url}"`);
+
+  const jsLines = [
+    `const response = await fetch('${url}', {`,
+    ...(endpoint.method !== 'GET' ? [`  method: '${endpoint.method}',`] : []),
+    `  headers: {`,
+    `    Authorization: \`Bearer \${accessToken}\`,`,
+    ...(isWrite ? [`    'Content-Type': 'application/json',`] : []),
+    `  },`,
+    ...(isWrite ? [`  body: JSON.stringify(payload), // ${bodyHint}`] : []),
+    `});`,
+    `const data = await response.json();`,
+  ];
+
+  return {
+    method: endpoint.method,
+    path: endpoint.path,
+    url,
+    curl: curlLines.join('\n'),
+    javascript: jsLines.join('\n'),
+  };
+}
+
+function selectExampleEndpoint(endpoints: ApiDiscoverEndpoint[], options: ApiDiscoverOptions): ApiDiscoverEndpoint {
+  const examplePath = options.example ?? '';
+  const method = options.method?.toUpperCase();
+
+  const byMethod = (candidates: ApiDiscoverEndpoint[]): ApiDiscoverEndpoint | undefined => {
+    if (method !== undefined) {
+      return candidates.find((endpoint) => endpoint.method === method);
+    }
+
+    return candidates.find((endpoint) => endpoint.method === 'GET') ?? candidates[0];
+  };
+
+  const exactMatches = endpoints.filter((endpoint) => endpoint.path === examplePath);
+  const exact = byMethod(exactMatches);
+  if (exact !== undefined) {
+    return exact;
+  }
+
+  const needle = examplePath.toLowerCase();
+  const partialMatches = endpoints.filter((endpoint) => endpoint.path.toLowerCase().includes(needle));
+  const partial = byMethod(partialMatches);
+  if (partial !== undefined) {
+    return partial;
+  }
+
+  throw LiferayErrors.apiDiscoverError(
+    `No endpoint matches --example '${examplePath}'${method !== undefined ? ` with method ${method}` : ''}. ` +
+      'Use the endpoint list to pick a valid path.',
+  );
+}
+
+function buildExampleQuery(endpoint: ApiDiscoverEndpoint): string {
+  if (endpoint.method !== 'GET' || !endpoint.supportsPagination) {
+    return '';
+  }
+
+  return '?page=1&pageSize=20';
+}
+
+export function formatLiferayApiDiscover(result: ApiDiscoverResult): string {
+  if (result.mode === 'apps') {
+    return formatAppsResult(result);
+  }
+
+  return formatSpecResult(result);
+}
+
+function formatAppsResult(result: ApiDiscoverAppsResult): string {
+  if (result.apps.length === 0) {
+    return 'No Headless apps discovered at /o/openapi';
+  }
+
+  const lines = ['Headless apps (from /o/openapi):', ''];
+  for (const app of result.apps) {
+    const jsonSpec = app.specPaths.find((specPath) => specPath.endsWith('.json')) ?? app.specPaths[0];
+    lines.push(`- ${app.name}  spec=${jsonSpec}`);
+  }
+
+  lines.push('', `total=${result.apps.length}`, '', 'Next: ldev portal api discover <app-name>');
+  return lines.join('\n');
+}
+
+function formatSpecResult(result: ApiDiscoverSpecResult): string {
+  const lines: string[] = [];
+
+  lines.push(`${result.title ?? result.app} ${result.version ?? ''}`.trim());
+  lines.push(`app=${result.app} spec=${result.specPath}`);
+  lines.push(`baseUrl=${result.baseUrl}`);
+  lines.push('');
+
+  lines.push(`Endpoints (${result.endpointCount}):`);
+  for (const endpoint of result.endpoints) {
+    lines.push(`  ${endpoint.method.padEnd(6)} ${endpoint.path}${formatEndpointCapabilities(endpoint)}`);
+  }
+
+  if (result.schemaDetail !== undefined) {
+    lines.push('', `Schema ${result.schemaDetail.name} (${result.schemaDetail.propertyCount} properties):`);
+    for (const property of result.schemaDetail.properties) {
+      lines.push(`  - ${property.name}: ${property.type}${property.required ? ' (required)' : ''}`);
+    }
+  } else {
+    lines.push('', `Schemas (${result.schemaCount}):`);
+    for (const schema of result.schemas) {
+      lines.push(`  - ${schema.name} (${schema.propertyCount} properties)`);
+    }
+    lines.push('', 'Tip: --schema <name> shows full property details for one schema.');
+  }
+
+  lines.push('', 'Conventions:');
+  lines.push(`  auth:       ${result.conventions.auth}`);
+  lines.push(`  pagination: ${result.conventions.pagination}`);
+  lines.push(`  filter:     ${result.conventions.filter}`);
+  lines.push(`  sort:       ${result.conventions.sort}`);
+  lines.push(`  search:     ${result.conventions.search}`);
+  lines.push(`  fields:     ${result.conventions.fields}`);
+
+  if (result.example !== undefined) {
+    lines.push('', `Example (${result.example.method} ${result.example.path}):`);
+    lines.push('', 'curl:');
+    lines.push(indentBlock(result.example.curl));
+    lines.push('', 'javascript:');
+    lines.push(indentBlock(result.example.javascript));
+  }
+
+  return lines.join('\n');
+}
+
+function formatEndpointCapabilities(endpoint: ApiDiscoverEndpoint): string {
+  const capabilities: string[] = [];
+  if (endpoint.supportsPagination) {
+    capabilities.push('page');
+  }
+  if (endpoint.supportsFilter) {
+    capabilities.push('filter');
+  }
+  if (endpoint.supportsSort) {
+    capabilities.push('sort');
+  }
+  if (endpoint.supportsSearch) {
+    capabilities.push('search');
+  }
+
+  return capabilities.length > 0 ? `  [${capabilities.join(',')}]` : '';
+}
+
+function indentBlock(block: string): string {
+  return block
+    .split('\n')
+    .map((line) => `  ${line}`)
+    .join('\n');
+}

--- a/tests/unit/liferay-api-discover.test.ts
+++ b/tests/unit/liferay-api-discover.test.ts
@@ -1,0 +1,386 @@
+import {describe, expect, test} from 'vitest';
+
+import {createLiferayApiClient} from '../../src/core/http/client.js';
+import {isCliError} from '../../src/core/errors.js';
+import {
+  formatLiferayApiDiscover,
+  runLiferayApiDiscover,
+  type ApiDiscoverAppsResult,
+  type ApiDiscoverSpecResult,
+} from '../../src/features/liferay/liferay-api-discover.js';
+import {
+  createStaticTokenClient,
+  createTestFetchImpl,
+  createTestJsonResponse,
+} from '../../src/testing/cli-test-helpers.js';
+
+const CONFIG = {
+  cwd: '/tmp/repo',
+  repoRoot: '/tmp/repo',
+  dockerDir: '/tmp/repo/docker',
+  liferayDir: '/tmp/repo/liferay',
+  files: {
+    dockerEnv: '/tmp/repo/docker/.env',
+    liferayProfile: '/tmp/repo/.liferay-cli.yml',
+  },
+  liferay: {
+    url: 'http://localhost:8080',
+    oauth2ClientId: 'client-id',
+    oauth2ClientSecret: 'client-secret',
+    scopeAliases: 'scope-a',
+    timeoutSeconds: 30,
+  },
+};
+
+const TOKEN_CLIENT = createStaticTokenClient();
+
+const OPENAPI_CATALOG = {
+  'headless-delivery': ['http://localhost:8080/o/headless-delivery/v1.0/openapi.json'],
+  'headless-admin-user': ['http://localhost:8080/o/headless-admin-user/v1.0/openapi.json'],
+};
+
+const HEADLESS_DELIVERY_SPEC = {
+  openapi: '3.0.1',
+  info: {title: 'Headless Delivery', version: 'v1.0'},
+  paths: {
+    '/sites/{siteId}/structured-contents': {
+      get: {
+        operationId: 'getSiteStructuredContentsPage',
+        summary: 'Retrieve structured contents for a site',
+        parameters: [
+          {name: 'siteId', in: 'path', required: true, schema: {type: 'integer'}},
+          {name: 'page', in: 'query', required: false, schema: {type: 'integer'}},
+          {name: 'pageSize', in: 'query', required: false, schema: {type: 'integer'}},
+          {name: 'filter', in: 'query', required: false, schema: {type: 'string'}},
+          {name: 'sort', in: 'query', required: false, schema: {type: 'string'}},
+          {name: 'search', in: 'query', required: false, schema: {type: 'string'}},
+        ],
+        responses: {
+          '200': {
+            content: {
+              'application/json': {
+                schema: {type: 'array', items: {$ref: '#/components/schemas/StructuredContent'}},
+              },
+            },
+          },
+        },
+      },
+      post: {
+        operationId: 'postSiteStructuredContent',
+        summary: 'Create a structured content',
+        parameters: [{name: 'siteId', in: 'path', required: true, schema: {type: 'integer'}}],
+        requestBody: {
+          content: {
+            'application/json': {schema: {$ref: '#/components/schemas/StructuredContent'}},
+          },
+        },
+        responses: {
+          '200': {
+            content: {
+              'application/json': {schema: {$ref: '#/components/schemas/StructuredContent'}},
+            },
+          },
+        },
+      },
+    },
+    '/structured-contents/{structuredContentId}': {
+      delete: {
+        operationId: 'deleteStructuredContent',
+        parameters: [{name: 'structuredContentId', in: 'path', required: true, schema: {type: 'integer'}}],
+        responses: {'204': {}},
+      },
+    },
+  },
+  components: {
+    schemas: {
+      StructuredContent: {
+        type: 'object',
+        required: ['title'],
+        properties: {
+          id: {type: 'integer'},
+          title: {type: 'string'},
+          contentFields: {type: 'array', items: {type: 'object'}},
+        },
+      },
+      ContentField: {
+        type: 'object',
+        properties: {
+          name: {type: 'string'},
+        },
+      },
+    },
+  },
+};
+
+function createDiscoverFetchImpl() {
+  return createTestFetchImpl((url) => {
+    if (url.includes('/o/openapi')) {
+      return createTestJsonResponse(OPENAPI_CATALOG);
+    }
+
+    if (url.includes('/o/headless-delivery/v1.0/openapi.json')) {
+      return createTestJsonResponse(HEADLESS_DELIVERY_SPEC);
+    }
+
+    return new Response('not found', {status: 404});
+  });
+}
+
+describe('liferay portal api discover', () => {
+  test('lists available Headless apps when no app name is given', async () => {
+    const apiClient = createLiferayApiClient({fetchImpl: createDiscoverFetchImpl()});
+
+    const result = (await runLiferayApiDiscover(
+      CONFIG,
+      {},
+      {apiClient, tokenClient: TOKEN_CLIENT},
+    )) as ApiDiscoverAppsResult;
+
+    expect(result.mode).toBe('apps');
+    expect(result.apps.map((app) => app.name)).toEqual(['headless-admin-user', 'headless-delivery']);
+    expect(formatLiferayApiDiscover(result)).toContain('headless-delivery');
+    expect(formatLiferayApiDiscover(result)).toContain('ldev portal api discover <app-name>');
+  });
+
+  test('resolves the spec and lists endpoints with capability tags', async () => {
+    const apiClient = createLiferayApiClient({fetchImpl: createDiscoverFetchImpl()});
+
+    const result = (await runLiferayApiDiscover(
+      CONFIG,
+      {app: 'headless-delivery'},
+      {apiClient, tokenClient: TOKEN_CLIENT},
+    )) as ApiDiscoverSpecResult;
+
+    expect(result.mode).toBe('spec');
+    expect(result.app).toBe('headless-delivery');
+    expect(result.specPath).toBe('/o/headless-delivery/v1.0/openapi.json');
+    expect(result.baseUrl).toBe('http://localhost:8080/o/headless-delivery/v1.0');
+    expect(result.endpointCount).toBe(3);
+
+    const getEndpoint = result.endpoints.find(
+      (endpoint) => endpoint.method === 'GET' && endpoint.path === '/sites/{siteId}/structured-contents',
+    );
+    expect(getEndpoint).toBeDefined();
+    expect(getEndpoint?.supportsPagination).toBe(true);
+    expect(getEndpoint?.supportsFilter).toBe(true);
+    expect(getEndpoint?.supportsSort).toBe(true);
+    expect(getEndpoint?.supportsSearch).toBe(true);
+    expect(getEndpoint?.responseSchema).toBe('StructuredContent');
+
+    const postEndpoint = result.endpoints.find((endpoint) => endpoint.method === 'POST');
+    expect(postEndpoint?.supportsPagination).toBe(false);
+    expect(postEndpoint?.requestSchema).toBe('StructuredContent');
+
+    expect(result.schemaCount).toBe(2);
+    expect(result.schemas.map((schema) => schema.name)).toEqual(['ContentField', 'StructuredContent']);
+
+    const text = formatLiferayApiDiscover(result);
+    expect(text).toContain('GET    /sites/{siteId}/structured-contents  [page,filter,sort,search]');
+    expect(text).toContain('auth:');
+    expect(text).toContain('ldev portal auth token --raw');
+  });
+
+  test('accepts an app name prefixed with /o/', async () => {
+    const apiClient = createLiferayApiClient({fetchImpl: createDiscoverFetchImpl()});
+
+    const result = (await runLiferayApiDiscover(
+      CONFIG,
+      {app: '/o/headless-delivery'},
+      {apiClient, tokenClient: TOKEN_CLIENT},
+    )) as ApiDiscoverSpecResult;
+
+    expect(result.mode).toBe('spec');
+    expect(result.app).toBe('headless-delivery');
+  });
+
+  test('filters endpoints by --path substring', async () => {
+    const apiClient = createLiferayApiClient({fetchImpl: createDiscoverFetchImpl()});
+
+    const result = (await runLiferayApiDiscover(
+      CONFIG,
+      {app: 'headless-delivery', path: 'structured-contents/'},
+      {apiClient, tokenClient: TOKEN_CLIENT},
+    )) as ApiDiscoverSpecResult;
+
+    expect(result.endpoints).toHaveLength(1);
+    expect(result.endpoints[0].method).toBe('DELETE');
+  });
+
+  test('filters endpoints by --method', async () => {
+    const apiClient = createLiferayApiClient({fetchImpl: createDiscoverFetchImpl()});
+
+    const result = (await runLiferayApiDiscover(
+      CONFIG,
+      {app: 'headless-delivery', method: 'post'},
+      {apiClient, tokenClient: TOKEN_CLIENT},
+    )) as ApiDiscoverSpecResult;
+
+    expect(result.endpoints).toHaveLength(1);
+    expect(result.endpoints[0].method).toBe('POST');
+  });
+
+  test('--schema returns full property details for one schema', async () => {
+    const apiClient = createLiferayApiClient({fetchImpl: createDiscoverFetchImpl()});
+
+    const result = (await runLiferayApiDiscover(
+      CONFIG,
+      {app: 'headless-delivery', schema: 'structuredcontent'},
+      {apiClient, tokenClient: TOKEN_CLIENT},
+    )) as ApiDiscoverSpecResult;
+
+    expect(result.schemaDetail?.name).toBe('StructuredContent');
+    expect(result.schemaDetail?.properties).toEqual(
+      expect.arrayContaining([
+        {name: 'id', type: 'integer', required: false},
+        {name: 'title', type: 'string', required: true},
+        {name: 'contentFields', type: 'array<object>', required: false},
+      ]),
+    );
+  });
+
+  test('unknown --schema throws a CliError listing available schemas', async () => {
+    const apiClient = createLiferayApiClient({fetchImpl: createDiscoverFetchImpl()});
+
+    await expect(
+      runLiferayApiDiscover(
+        CONFIG,
+        {app: 'headless-delivery', schema: 'DoesNotExist'},
+        {apiClient, tokenClient: TOKEN_CLIENT},
+      ),
+    ).rejects.toSatisfy((error: unknown) => {
+      expect(isCliError(error)).toBe(true);
+      expect((error as Error).message).toContain('StructuredContent');
+      return true;
+    });
+  });
+
+  test('--example emits a working curl and fetch snippet', async () => {
+    const apiClient = createLiferayApiClient({fetchImpl: createDiscoverFetchImpl()});
+
+    const result = (await runLiferayApiDiscover(
+      CONFIG,
+      {app: 'headless-delivery', example: '/sites/{siteId}/structured-contents'},
+      {apiClient, tokenClient: TOKEN_CLIENT},
+    )) as ApiDiscoverSpecResult;
+
+    expect(result.example?.method).toBe('GET');
+    expect(result.example?.url).toBe(
+      'http://localhost:8080/o/headless-delivery/v1.0/sites/{siteId}/structured-contents?page=1&pageSize=20',
+    );
+    expect(result.example?.curl).toContain('Authorization: Bearer $(ldev portal auth token --raw)');
+    expect(result.example?.javascript).toContain('await fetch(');
+  });
+
+  test('--example combined with --method selects the write endpoint', async () => {
+    const apiClient = createLiferayApiClient({fetchImpl: createDiscoverFetchImpl()});
+
+    const result = (await runLiferayApiDiscover(
+      CONFIG,
+      {app: 'headless-delivery', example: '/sites/{siteId}/structured-contents', method: 'post'},
+      {apiClient, tokenClient: TOKEN_CLIENT},
+    )) as ApiDiscoverSpecResult;
+
+    expect(result.example?.method).toBe('POST');
+    expect(result.example?.curl).toContain('-X POST');
+    expect(result.example?.curl).toContain('Content-Type: application/json');
+    expect(result.example?.curl).toContain('<StructuredContent JSON>');
+  });
+
+  test('unknown --example path throws a CliError', async () => {
+    const apiClient = createLiferayApiClient({fetchImpl: createDiscoverFetchImpl()});
+
+    await expect(
+      runLiferayApiDiscover(
+        CONFIG,
+        {app: 'headless-delivery', example: '/does/not/exist'},
+        {apiClient, tokenClient: TOKEN_CLIENT},
+      ),
+    ).rejects.toSatisfy((error: unknown) => {
+      expect(isCliError(error)).toBe(true);
+      return true;
+    });
+  });
+
+  test('unresolvable app throws a CliError hinting available apps', async () => {
+    const apiClient = createLiferayApiClient({fetchImpl: createDiscoverFetchImpl()});
+
+    await expect(
+      runLiferayApiDiscover(CONFIG, {app: 'not-a-real-app'}, {apiClient, tokenClient: TOKEN_CLIENT}),
+    ).rejects.toSatisfy((error: unknown) => {
+      expect(isCliError(error)).toBe(true);
+      expect((error as Error).message).toContain('headless-delivery');
+      return true;
+    });
+  });
+
+  test('does not duplicate the version segment when endpoint paths already embed it', async () => {
+    const versionEmbeddedSpec = {
+      openapi: '3.0.1',
+      info: {title: 'Headless Delivery', version: 'v1.0'},
+      paths: {
+        '/v1.0/asset-libraries/{assetLibraryId}/structured-contents': {
+          get: {
+            operationId: 'getAssetLibraryStructuredContentsPage',
+            parameters: [
+              {name: 'assetLibraryId', in: 'path', required: true, schema: {type: 'integer'}},
+              {name: 'page', in: 'query', schema: {type: 'integer'}},
+              {name: 'pageSize', in: 'query', schema: {type: 'integer'}},
+            ],
+            responses: {'200': {}},
+          },
+        },
+      },
+      components: {schemas: {}},
+    };
+
+    const apiClient = createLiferayApiClient({
+      fetchImpl: createTestFetchImpl((url) => {
+        if (url.includes('/o/openapi')) {
+          return new Response('forbidden', {status: 403});
+        }
+
+        if (url.includes('/o/headless-delivery/v1.0/openapi.json')) {
+          return createTestJsonResponse(versionEmbeddedSpec);
+        }
+
+        return new Response('not found', {status: 404});
+      }),
+    });
+
+    const result = (await runLiferayApiDiscover(
+      CONFIG,
+      {app: 'headless-delivery', example: 'structured-contents'},
+      {apiClient, tokenClient: TOKEN_CLIENT},
+    )) as ApiDiscoverSpecResult;
+
+    expect(result.baseUrl).toBe('http://localhost:8080/o/headless-delivery');
+    expect(result.example?.url).toBe(
+      'http://localhost:8080/o/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/structured-contents?page=1&pageSize=20',
+    );
+  });
+
+  test('falls back to the /o/<app>/v1.0/openapi.json pattern when the catalog lookup fails', async () => {
+    const apiClient = createLiferayApiClient({
+      fetchImpl: createTestFetchImpl((url) => {
+        if (url.includes('/o/openapi')) {
+          return new Response('forbidden', {status: 403});
+        }
+
+        if (url.includes('/o/headless-delivery/v1.0/openapi.json')) {
+          return createTestJsonResponse(HEADLESS_DELIVERY_SPEC);
+        }
+
+        return new Response('not found', {status: 404});
+      }),
+    });
+
+    const result = (await runLiferayApiDiscover(
+      CONFIG,
+      {app: 'headless-delivery'},
+      {apiClient, tokenClient: TOKEN_CLIENT},
+    )) as ApiDiscoverSpecResult;
+
+    expect(result.mode).toBe('spec');
+    expect(result.specPath).toBe('/o/headless-delivery/v1.0/openapi.json');
+  });
+});


### PR DESCRIPTION
## Summary

Adds `ldev portal api discover [app-name]`, closing the P0 #1 gap tracked in `docs/skills/ROADMAP.md`: Liferay's Headless REST surface had no operational discovery contract in ldev (no guidance on pagination, auth, filter/sort syntax, or how to go from "I need this entity" to a working endpoint).

- Without an app name: lists every Headless app registered at `/o/openapi`.
- With an app name: resolves its OpenAPI spec (catalog lookup first, then the `/o/<app>/v1.0/openapi.json` pattern as fallback, with YAML parsing support since some Liferay-generated catalogs only expose `.yaml` specs) and reports:
  - Every endpoint's path/method plus which of `page`/`pageSize`, `filter`, `sort`, `search` it accepts
  - Available schemas, with `--schema <name>` for full property details on one schema
  - Fixed conventions for auth, pagination, filter, sort, search, fields across the whole Headless surface
  - `--example <path>` (optionally combined with `--method`): a ready-to-run curl command + `fetch()` snippet, authenticated with a Bearer token
- `--path` / `--method` filter the endpoint listing.
- Supports `--json`/`--ndjson`/`--strict` like the rest of the CLI's output conventions.

### Design decisions

- Registered as `api discover` under the existing `portal` command group (alongside `inventory`, `auth`, `check`), since that's where the rest of the Headless discovery surface already lives (`portal inventory`, `portal auth token`, `portal check`). No new top-level command group was introduced.
- Reused the existing `LiferayGateway` (OAuth token caching, 401 retry, unified error handling) and `HttpApiClient` instead of a new HTTP client.
- Added `LiferayErrorCode.API_DISCOVER_ERROR` / `LiferayErrors.apiDiscoverError` following the existing error-factory convention rather than throwing raw `CliError`s with ad-hoc codes.
- Handles a real-world Liferay quirk found while validating against a live portal: some Headless specs (e.g. `headless-delivery`) bake the API version into every path (`/v1.0/...`) rather than relying on the version segment in the spec's own base path. The base URL resolution detects this and avoids duplicating the version segment in generated examples.

### Verification

- `npm run lint` — clean (pre-existing `max-lines` warnings only, no errors)
- `npm run typecheck` — clean
- `npm run test:unit` — 119 files / 1294 tests passed, including a new `tests/unit/liferay-api-discover.test.ts` (13 tests) covering: app listing, spec resolution + capability tagging, `/o/` prefix normalization, `--path`/`--method` filtering, `--schema` detail/error, `--example` generation (GET and write methods), unresolvable app/example errors, catalog-lookup fallback, and the version-duplication fix
- Manually validated against a live local Liferay instance: listed all 48 registered Headless apps, resolved `headless-delivery` (497 endpoints) and `headless-admin-user`, and confirmed a generated `--example` curl command actually returns `200` against the running portal

Fixes #170