### PR TITLE
feat(verify): add unified visual page verification command

### DIFF
--- a/docs/commands/advanced.md
+++ b/docs/commands/advanced.md
@@ -123,3 +123,28 @@ Validate Clay icon coverage for a deployed theme.
 ```bash
 ldev portal theme-check --theme ub-theme --json
 ```
+
+## Verify page
+
+Browser-driven post-change visual verification, replacing the manual
+login/navigate/screenshot/console-check sequence with one command. Requires
+`playwright` as a local dependency (`npm install --save-dev playwright && npx
+playwright install chromium`) — it is intentionally not a hard `ldev`
+dependency, so installing `ldev` never forces a Chromium download.
+
+```bash
+ldev verify page --url /web/guest/home
+ldev verify page --url /web/guest/home --skip-login --json
+ldev verify page --url /web/guest/home --screenshot .tmp/verify/home.png
+```
+
+- `--url <friendlyUrl>` — required; a friendly URL or full http(s) URL
+- `--skip-login` — for public pages that do not require authentication
+- `--login-email` / `--login-password` — override `LDEV_VERIFY_LOGIN_EMAIL` / `LDEV_VERIFY_LOGIN_PASSWORD` (default `test@liferay.com` / `test`)
+- `--screenshot <path>` — output path (default `.tmp/verify/<slug>-<timestamp>.png`)
+
+Runs login, navigation, console error capture, a screenshot, and DOM sanity
+checks, then — when the project tracks a local resource catalog under
+`liferay/resources` — diffs the rendered page's structures/templates/adts/fragments
+against those files. Returns a structured pass/fail report and exits non-zero
+on failure.

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -28,7 +28,7 @@ If you want to understand what `ldev` is for, start with:
 - [Project and AI](/commands/project-and-ai) — project init, ai
   install/update/status/bootstrap
 - [Advanced](/commands/advanced) — OSGi, worktrees, portal MCP probe, reindex, search,
-  page-layout, theme-check
+  page-layout, theme-check, verify page
 
 ## Namespace overview
 

--- a/src/cli/command-groups.ts
+++ b/src/cli/command-groups.ts
@@ -19,6 +19,7 @@ import {createOAuthCommand} from '../commands/oauth/oauth.command.js';
 import {createProjectCommand} from '../commands/project/project.command.js';
 import {createResourceCommand} from '../commands/resource/resource.command.js';
 import {createDashboardCommand} from '../commands/dashboard/dashboard.command.js';
+import {createVerifyCommand} from '../commands/verify/verify.command.js';
 import {createWorktreeCommand} from '../commands/worktree/worktree.command.js';
 
 export const coreGroup: CommandGroup = {
@@ -48,6 +49,7 @@ export const portalGroup: CommandGroup = {
   register(program) {
     program.addCommand(createPortalCommand().helpGroup(this.group!));
     program.addCommand(createOAuthCommand().helpGroup(this.group!));
+    program.addCommand(createVerifyCommand().helpGroup(this.group!));
   },
 };
 

--- a/src/commands/verify/verify.command.ts
+++ b/src/commands/verify/verify.command.ts
@@ -1,0 +1,71 @@
+import {Command} from 'commander';
+
+import {addOutputFormatOption, createFormattedAction} from '../../cli/command-helpers.js';
+import {formatVerifyPage} from '../../features/verify/verify-page-format.js';
+import {resolveVerifyLoginCredentials} from '../../features/verify/verify-login-credentials.js';
+import {runVerifyPage} from '../../features/verify/verify-page.js';
+
+type VerifyPageCommandOptions = {
+  url: string;
+  screenshot?: string;
+  skipLogin?: boolean;
+  loginEmail?: string;
+  loginPassword?: string;
+};
+
+export function createVerifyCommand(): Command {
+  const command = new Command('verify').description(
+    'Run browser-driven visual verification against a running Liferay portal',
+  );
+
+  addOutputFormatOption(
+    command
+      .command('page')
+      .description('Log in, navigate to a page, and report console errors, a screenshot, and DOM sanity checks')
+      .requiredOption('--url <friendlyUrl>', 'Friendly URL to verify, e.g. /web/guest/home, or a full http(s) URL')
+      .option('--screenshot <path>', 'Screenshot output path (default: .tmp/verify/<slug>-<timestamp>.png)')
+      .option('--skip-login', 'Skip the login step (use for public pages)')
+      .option('--login-email <email>', 'Login email (default: LDEV_VERIFY_LOGIN_EMAIL or test@liferay.com)')
+      .option('--login-password <password>', 'Login password (default: LDEV_VERIFY_LOGIN_PASSWORD or test)')
+      .addHelpText(
+        'after',
+        `
+Runs the full post-change visual verification sequence in one call: login, navigation,
+console error capture, screenshot, DOM sanity checks, and (when the project has a local
+resource catalog) a diff of the rendered page's structures/templates/adts/fragments
+against the files tracked under liferay/resources.
+
+Requires 'playwright' to be installed as a local dependency:
+  npm install --save-dev playwright && npx playwright install chromium
+
+Examples:
+  ldev verify page --url /web/guest/home
+  ldev verify page --url /web/guest/home --skip-login --json
+  ldev verify page --url /web/guest/home --screenshot .tmp/verify/home.png
+`,
+      ),
+    'text',
+  ).action(
+    createFormattedAction(
+      async (context, options: VerifyPageCommandOptions) => {
+        const credentials = resolveVerifyLoginCredentials({
+          email: options.loginEmail,
+          password: options.loginPassword,
+        });
+
+        return runVerifyPage(context.project, {
+          url: options.url,
+          credentials,
+          screenshotPath: options.screenshot,
+          skipLogin: options.skipLogin,
+        });
+      },
+      {
+        text: formatVerifyPage,
+        exitCode: (result) => (result.ok ? 0 : 1),
+      },
+    ),
+  );
+
+  return command;
+}

--- a/src/features/verify/browser-runner-types.ts
+++ b/src/features/verify/browser-runner-types.ts
@@ -1,0 +1,40 @@
+/**
+ * Injectable browser runner contract used by `ldev verify page`.
+ *
+ * Keeping this as a narrow interface lets the orchestration in verify-page.ts
+ * be unit-tested against a fake implementation, with no real browser involved.
+ * `createPlaywrightBrowserRunner` (verify-browser-runner.ts) is the only
+ * production implementation.
+ */
+export type BrowserNavigationResult = {
+  url: string;
+  title: string;
+  status: number | null;
+};
+
+export type BrowserDomSnapshot = {
+  title: string;
+  bodyTextLength: number;
+  headingCount: number;
+  hasVisibleErrorBanner: boolean;
+};
+
+export type BrowserLoginCredentials = {
+  email: string;
+  password: string;
+};
+
+export interface BrowserRunner {
+  /** Navigate to a login page and submit credentials using Liferay's default login form ids. */
+  login(loginUrl: string, credentials: BrowserLoginCredentials): Promise<BrowserNavigationResult>;
+  /** Navigate to the target URL. */
+  open(url: string): Promise<BrowserNavigationResult>;
+  /** Console errors observed since the runner was created. */
+  getConsoleErrors(): Promise<string[]>;
+  /** Capture a full-page screenshot to the given path. */
+  captureScreenshot(path: string): Promise<void>;
+  /** Lightweight DOM sanity snapshot of the current page. */
+  getDomSnapshot(): Promise<BrowserDomSnapshot>;
+  /** Release all browser resources. Must be safe to call multiple times. */
+  close(): Promise<void>;
+}

--- a/src/features/verify/dom-globals.d.ts
+++ b/src/features/verify/dom-globals.d.ts
@@ -1,0 +1,15 @@
+/**
+ * Minimal ambient DOM globals for the callback passed to Playwright's
+ * `page.evaluate` in verify-browser-runner.ts.
+ *
+ * That callback is serialized and executed inside the real browser, not in
+ * this Node process, so the project's Node-only `lib` (ES2022, no "dom")
+ * has no notion of `document`. Only the surface actually touched by the
+ * evaluate callback is declared here.
+ */
+declare const document: {
+  title: string;
+  body: {readonly innerText: string} | null;
+  querySelectorAll(selectors: string): {length: number};
+  querySelector(selectors: string): unknown;
+};

--- a/src/features/verify/playwright-types.d.ts
+++ b/src/features/verify/playwright-types.d.ts
@@ -1,0 +1,51 @@
+/**
+ * Minimal ambient typing for the optional `playwright` package.
+ *
+ * `playwright` is intentionally NOT a declared dependency of this CLI (see
+ * verify-browser-runner.ts for the rationale). Declaring this ambient module
+ * lets `src/features/verify` type-check and lint cleanly without requiring
+ * `playwright` to be installed in every consumer's node_modules. At runtime,
+ * `createPlaywrightBrowserRunner` dynamically imports the real package and
+ * fails with a clear install message when it is missing.
+ *
+ * Keep this surface limited to what the runner actually uses.
+ */
+declare module 'playwright' {
+  export interface ConsoleMessage {
+    type(): string;
+    text(): string;
+  }
+
+  export interface Response {
+    status(): number;
+  }
+
+  export interface Locator {
+    fill(value: string): Promise<void>;
+    click(): Promise<void>;
+    first(): Locator;
+  }
+
+  export interface Page {
+    goto(url: string, options?: {waitUntil?: 'load' | 'domcontentloaded' | 'networkidle'}): Promise<Response | null>;
+    title(): Promise<string>;
+    url(): string;
+    locator(selector: string): Locator;
+    screenshot(options: {path: string; fullPage?: boolean}): Promise<Buffer>;
+    evaluate<T>(pageFunction: () => T): Promise<T>;
+    on(event: 'console', listener: (message: ConsoleMessage) => void): void;
+    waitForLoadState(state?: 'load' | 'domcontentloaded' | 'networkidle'): Promise<void>;
+    close(): Promise<void>;
+  }
+
+  export interface Browser {
+    newPage(): Promise<Page>;
+    close(): Promise<void>;
+  }
+
+  export interface BrowserType {
+    launch(options?: {headless?: boolean}): Promise<Browser>;
+  }
+
+  export const chromium: BrowserType;
+}

--- a/src/features/verify/playwright-types.d.ts
+++ b/src/features/verify/playwright-types.d.ts
@@ -35,6 +35,7 @@ declare module 'playwright' {
     evaluate<T>(pageFunction: () => T): Promise<T>;
     on(event: 'console', listener: (message: ConsoleMessage) => void): void;
     waitForLoadState(state?: 'load' | 'domcontentloaded' | 'networkidle'): Promise<void>;
+    waitForNavigation(options?: {waitUntil?: 'load' | 'domcontentloaded' | 'networkidle'}): Promise<Response | null>;
     close(): Promise<void>;
   }
 

--- a/src/features/verify/verify-browser-runner.ts
+++ b/src/features/verify/verify-browser-runner.ts
@@ -1,0 +1,112 @@
+import {CliError} from '../../core/errors.js';
+import type * as PlaywrightModule from 'playwright';
+import type {Browser, ConsoleMessage, Page} from 'playwright';
+import type {
+  BrowserDomSnapshot,
+  BrowserLoginCredentials,
+  BrowserNavigationResult,
+  BrowserRunner,
+} from './browser-runner-types.js';
+
+const LIFERAY_LOGIN_EMAIL_SELECTOR = '#_com_liferay_login_web_portlet_LoginPortlet_login';
+const LIFERAY_LOGIN_PASSWORD_SELECTOR = '#_com_liferay_login_web_portlet_LoginPortlet_password';
+const LIFERAY_LOGIN_SUBMIT_SELECTOR = 'button[type=submit]';
+
+/**
+ * `playwright` is intentionally NOT a package.json dependency.
+ *
+ * Rationale: ldev is a globally-installed CLI. Bundling Playwright (and its
+ * browser binaries) would force every install to download Chromium even for
+ * users who never run `ldev verify page`. Instead we treat it as a runtime-
+ * detected, optionally-installed capability: `doctor` already reports on
+ * `playwright-cli` in the same spirit. Users who want `verify page` install
+ * `playwright` themselves once; everyone else pays no cost.
+ */
+export async function createPlaywrightBrowserRunner(): Promise<BrowserRunner> {
+  const playwright = await loadPlaywrightModule();
+  const browser = await playwright.chromium.launch({headless: true});
+  const page = await browser.newPage();
+  const consoleErrors: string[] = [];
+
+  page.on('console', (message: ConsoleMessage) => {
+    if (message.type() === 'error') {
+      consoleErrors.push(message.text());
+    }
+  });
+
+  return {
+    async login(loginUrl, credentials: BrowserLoginCredentials): Promise<BrowserNavigationResult> {
+      await page.goto(loginUrl, {waitUntil: 'domcontentloaded'});
+      await page.locator(LIFERAY_LOGIN_EMAIL_SELECTOR).fill(credentials.email);
+      await page.locator(LIFERAY_LOGIN_PASSWORD_SELECTOR).fill(credentials.password);
+      await page.locator(LIFERAY_LOGIN_SUBMIT_SELECTOR).first().click();
+      await page.waitForLoadState('domcontentloaded');
+      return readNavigationResult(page, null);
+    },
+
+    async open(url): Promise<BrowserNavigationResult> {
+      const response = await page.goto(url, {waitUntil: 'domcontentloaded'});
+      return readNavigationResult(page, response ? response.status() : null);
+    },
+
+    getConsoleErrors(): Promise<string[]> {
+      return Promise.resolve([...consoleErrors]);
+    },
+
+    async captureScreenshot(path): Promise<void> {
+      await page.screenshot({path, fullPage: true});
+    },
+
+    getDomSnapshot(): Promise<BrowserDomSnapshot> {
+      return page.evaluate(() => ({
+        title: document.title,
+        bodyTextLength: document.body?.innerText.trim().length ?? 0,
+        headingCount: document.querySelectorAll('h1, h2, h3').length,
+        hasVisibleErrorBanner: Boolean(
+          document.querySelector('.alert-danger, .portlet-msg-error, [data-testid="error-boundary"]'),
+        ),
+      }));
+    },
+
+    async close(): Promise<void> {
+      await closeQuietly(page);
+      await closeBrowserQuietly(browser);
+    },
+  };
+}
+
+async function readNavigationResult(page: Page, status: number | null): Promise<BrowserNavigationResult> {
+  return {
+    url: page.url(),
+    title: await page.title(),
+    status,
+  };
+}
+
+async function closeQuietly(page: Page): Promise<void> {
+  try {
+    await page.close();
+  } catch {
+    // Page may already be closed (e.g. navigation crashed it); nothing else to do.
+  }
+}
+
+async function closeBrowserQuietly(browser: Browser): Promise<void> {
+  try {
+    await browser.close();
+  } catch {
+    // Browser may already be closed; nothing else to do.
+  }
+}
+
+async function loadPlaywrightModule(): Promise<typeof PlaywrightModule> {
+  try {
+    return await import('playwright');
+  } catch {
+    throw new CliError(
+      "Playwright is not installed. 'ldev verify page' drives a real browser and needs it as a local dependency.\n" +
+        'Install it once with: npm install --save-dev playwright && npx playwright install chromium',
+      {code: 'VERIFY_BROWSER_UNAVAILABLE'},
+    );
+  }
+}

--- a/src/features/verify/verify-browser-runner.ts
+++ b/src/features/verify/verify-browser-runner.ts
@@ -1,3 +1,5 @@
+import {createRequire} from 'node:module';
+
 import {CliError} from '../../core/errors.js';
 import type * as PlaywrightModule from 'playwright';
 import type {Browser, ConsoleMessage, Page} from 'playwright';
@@ -21,9 +23,15 @@ const LIFERAY_LOGIN_SUBMIT_SELECTOR = 'button[type=submit]';
  * detected, optionally-installed capability: `doctor` already reports on
  * `playwright-cli` in the same spirit. Users who want `verify page` install
  * `playwright` themselves once; everyone else pays no cost.
+ *
+ * Because ldev runs from its own global install location, a bare
+ * `import('playwright')` would resolve node_modules relative to *that*
+ * location, not the Liferay project the user installed playwright into.
+ * `cwd` (the project directory) is threaded through so resolution is rooted
+ * where the user actually ran `npm install --save-dev playwright`.
  */
-export async function createPlaywrightBrowserRunner(): Promise<BrowserRunner> {
-  const playwright = await loadPlaywrightModule();
+export async function createPlaywrightBrowserRunner(cwd: string): Promise<BrowserRunner> {
+  const playwright = loadPlaywrightModule(cwd);
   const browser = await playwright.chromium.launch({headless: true});
   const page = await browser.newPage();
   const consoleErrors: string[] = [];
@@ -99,9 +107,15 @@ async function closeBrowserQuietly(browser: Browser): Promise<void> {
   }
 }
 
-async function loadPlaywrightModule(): Promise<typeof PlaywrightModule> {
+function loadPlaywrightModule(cwd: string): typeof PlaywrightModule {
   try {
-    return await import('playwright');
+    const require = createRequire(import.meta.url);
+    const resolvedEntry = require.resolve('playwright', {paths: [cwd]});
+    // A plain CJS require (not a dynamic import) here: playwright's entry point
+    // re-exports a runtime object via `module.exports = require(...).inprocess.playwright`,
+    // a pattern cjs-module-lexer can't follow, so ESM interop would only expose it
+    // as `.default` and leave `.chromium` undefined on the namespace object.
+    return require(resolvedEntry) as typeof PlaywrightModule;
   } catch {
     throw new CliError(
       "Playwright is not installed. 'ldev verify page' drives a real browser and needs it as a local dependency.\n" +

--- a/src/features/verify/verify-browser-runner.ts
+++ b/src/features/verify/verify-browser-runner.ts
@@ -47,8 +47,15 @@ export async function createPlaywrightBrowserRunner(cwd: string): Promise<Browse
       await page.goto(loginUrl, {waitUntil: 'domcontentloaded'});
       await page.locator(LIFERAY_LOGIN_EMAIL_SELECTOR).fill(credentials.email);
       await page.locator(LIFERAY_LOGIN_PASSWORD_SELECTOR).fill(credentials.password);
-      await page.locator(LIFERAY_LOGIN_SUBMIT_SELECTOR).first().click();
-      await page.waitForLoadState('domcontentloaded');
+      // waitForLoadState('domcontentloaded') right after click() is unreliable here: if that
+      // load state is already satisfied on the pre-click page, it resolves immediately instead
+      // of waiting for the login form's own navigation, so callers would race the next
+      // page.goto() against Liferay's still in-flight post-login redirect (net::ERR_ABORTED).
+      // Pairing the click with waitForNavigation closes that window.
+      await Promise.all([
+        page.waitForNavigation({waitUntil: 'domcontentloaded'}),
+        page.locator(LIFERAY_LOGIN_SUBMIT_SELECTOR).first().click(),
+      ]);
       return readNavigationResult(page, null);
     },
 

--- a/src/features/verify/verify-login-credentials.ts
+++ b/src/features/verify/verify-login-credentials.ts
@@ -1,0 +1,32 @@
+import type {BrowserLoginCredentials} from './browser-runner-types.js';
+
+const DEFAULT_TEST_EMAIL = 'test@liferay.com';
+const DEFAULT_TEST_PASSWORD = 'test';
+
+export type ResolveVerifyLoginCredentialsInput = {
+  email?: string;
+  password?: string;
+  env?: NodeJS.ProcessEnv;
+};
+
+/**
+ * Resolves the login credentials used by `ldev verify page`.
+ * Precedence: explicit CLI flag > environment variable > local Liferay default test user.
+ */
+export function resolveVerifyLoginCredentials(input: ResolveVerifyLoginCredentialsInput): BrowserLoginCredentials {
+  const env = input.env ?? process.env;
+
+  return {
+    email: firstNonEmpty(input.email, env.LDEV_VERIFY_LOGIN_EMAIL, DEFAULT_TEST_EMAIL),
+    password: firstNonEmpty(input.password, env.LDEV_VERIFY_LOGIN_PASSWORD, DEFAULT_TEST_PASSWORD),
+  };
+}
+
+function firstNonEmpty(...values: (string | undefined)[]): string {
+  for (const value of values) {
+    if (value && value.trim() !== '') {
+      return value.trim();
+    }
+  }
+  return '';
+}

--- a/src/features/verify/verify-page-dom-checks.ts
+++ b/src/features/verify/verify-page-dom-checks.ts
@@ -1,0 +1,47 @@
+import type {BrowserDomSnapshot} from './browser-runner-types.js';
+import type {VerifyDomCheck, VerifyDomSanityResult} from './verify-page-types.js';
+
+const MIN_BODY_TEXT_LENGTH = 1;
+
+/**
+ * Pure translation of a raw DOM snapshot into pass/fail sanity checks.
+ * Kept separate from the orchestrator so the rules can be unit-tested
+ * without a browser or fake runner.
+ */
+export function evaluateDomSanity(snapshot: BrowserDomSnapshot): VerifyDomSanityResult {
+  const checks: VerifyDomCheck[] = [
+    {
+      id: 'has-title',
+      status: snapshot.title.trim() !== '' ? 'pass' : 'fail',
+      detail: snapshot.title.trim() !== '' ? `Page title: "${snapshot.title}"` : 'Page title is empty.',
+    },
+    {
+      id: 'has-body-content',
+      status: snapshot.bodyTextLength >= MIN_BODY_TEXT_LENGTH ? 'pass' : 'fail',
+      detail:
+        snapshot.bodyTextLength >= MIN_BODY_TEXT_LENGTH
+          ? `Body text length: ${snapshot.bodyTextLength}.`
+          : 'Body text is empty; the page may have failed to render.',
+    },
+    {
+      id: 'has-heading',
+      status: snapshot.headingCount > 0 ? 'pass' : 'fail',
+      detail:
+        snapshot.headingCount > 0
+          ? `Found ${snapshot.headingCount} heading element(s).`
+          : 'No h1/h2/h3 heading elements found.',
+    },
+    {
+      id: 'no-visible-error-banner',
+      status: snapshot.hasVisibleErrorBanner ? 'fail' : 'pass',
+      detail: snapshot.hasVisibleErrorBanner
+        ? 'A visible error banner (.alert-danger / .portlet-msg-error) was detected.'
+        : 'No visible error banner detected.',
+    },
+  ];
+
+  return {
+    status: checks.every((check) => check.status === 'pass') ? 'pass' : 'fail',
+    checks,
+  };
+}

--- a/src/features/verify/verify-page-format.ts
+++ b/src/features/verify/verify-page-format.ts
@@ -1,0 +1,55 @@
+import type {VerifyPageReport, VerifyStepStatus} from './verify-page-types.js';
+
+export function formatVerifyPage(report: VerifyPageReport): string {
+  const lines = [`${report.ok ? '[PASS]' : '[FAIL]'} ldev verify page ${report.url}`, ''];
+
+  lines.push(`${formatStatus(report.login.status)} login       ${report.login.detail}`);
+  lines.push(`${formatStatus(report.navigation.status)} navigation  ${report.navigation.detail}`);
+  lines.push(
+    `${formatStatus(report.consoleErrors.status)} console     ${
+      report.consoleErrors.errors.length === 0
+        ? 'No console errors.'
+        : `${report.consoleErrors.errors.length} console error(s): ${report.consoleErrors.errors.join(' | ')}`
+    }`,
+  );
+  lines.push(`${formatStatus(report.screenshot.status)} screenshot  ${report.screenshot.detail}`);
+  lines.push(`${formatStatus(report.domSanity.status)} dom sanity  ${summarizeDomSanity(report)}`);
+  lines.push(`${formatStatus(report.resourceCatalog.status)} catalog     ${report.resourceCatalog.detail}`);
+
+  if (report.domSanity.checks.length > 0) {
+    lines.push('', 'DOM checks:');
+    for (const check of report.domSanity.checks) {
+      lines.push(`  ${formatStatus(check.status)} ${check.id}: ${check.detail}`);
+    }
+  }
+
+  if (report.resourceCatalog.diffs.length > 0) {
+    lines.push('', 'Resource catalog diffs:');
+    for (const diff of report.resourceCatalog.diffs) {
+      lines.push(`  [MISSING] ${diff.resourceType} "${diff.key}": ${diff.detail}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+function summarizeDomSanity(report: VerifyPageReport): string {
+  const failed = report.domSanity.checks.filter((check) => check.status === 'fail');
+  if (report.domSanity.status === 'skipped') {
+    return 'Skipped (navigation did not succeed).';
+  }
+  return failed.length === 0
+    ? `All ${report.domSanity.checks.length} DOM sanity checks passed.`
+    : `${failed.length}/${report.domSanity.checks.length} DOM sanity checks failed.`;
+}
+
+function formatStatus(status: VerifyStepStatus): string {
+  switch (status) {
+    case 'pass':
+      return '[PASS]';
+    case 'fail':
+      return '[FAIL]';
+    case 'skipped':
+      return '[SKIP]';
+  }
+}

--- a/src/features/verify/verify-page-types.ts
+++ b/src/features/verify/verify-page-types.ts
@@ -1,0 +1,59 @@
+export type VerifyStepStatus = 'pass' | 'fail' | 'skipped';
+
+export type VerifyLoginResult = {
+  status: VerifyStepStatus;
+  detail: string;
+};
+
+export type VerifyNavigationResult = {
+  status: VerifyStepStatus;
+  url: string;
+  title: string | null;
+  httpStatus: number | null;
+  detail: string;
+};
+
+export type VerifyConsoleErrorsResult = {
+  status: VerifyStepStatus;
+  errors: string[];
+};
+
+export type VerifyScreenshotResult = {
+  status: VerifyStepStatus;
+  path: string | null;
+  detail: string;
+};
+
+export type VerifyDomCheck = {
+  id: string;
+  status: VerifyStepStatus;
+  detail: string;
+};
+
+export type VerifyDomSanityResult = {
+  status: VerifyStepStatus;
+  checks: VerifyDomCheck[];
+};
+
+export type VerifyResourceCatalogDiff = {
+  resourceType: string;
+  key: string;
+  detail: string;
+};
+
+export type VerifyResourceCatalogResult = {
+  status: VerifyStepStatus;
+  detail: string;
+  diffs: VerifyResourceCatalogDiff[];
+};
+
+export type VerifyPageReport = {
+  ok: boolean;
+  url: string;
+  login: VerifyLoginResult;
+  navigation: VerifyNavigationResult;
+  consoleErrors: VerifyConsoleErrorsResult;
+  screenshot: VerifyScreenshotResult;
+  domSanity: VerifyDomSanityResult;
+  resourceCatalog: VerifyResourceCatalogResult;
+};

--- a/src/features/verify/verify-page.ts
+++ b/src/features/verify/verify-page.ts
@@ -1,0 +1,206 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import type {AppConfig} from '../../core/config/load-config.js';
+import type {ProjectContext} from '../../core/config/project-context.js';
+import {CliError} from '../../core/errors.js';
+import type {PageEvidence} from '../liferay/inventory/liferay-inventory-evidence-contract.js';
+import {extractPageEvidence} from '../liferay/inventory/liferay-inventory-page-evidence.js';
+import {runLiferayInventoryPage} from '../liferay/inventory/liferay-inventory-page.js';
+import type {BrowserLoginCredentials, BrowserRunner} from './browser-runner-types.js';
+import {createPlaywrightBrowserRunner} from './verify-browser-runner.js';
+import {evaluateDomSanity} from './verify-page-dom-checks.js';
+import type {
+  VerifyDomSanityResult,
+  VerifyLoginResult,
+  VerifyNavigationResult,
+  VerifyConsoleErrorsResult,
+  VerifyPageReport,
+  VerifyResourceCatalogResult,
+  VerifyScreenshotResult,
+} from './verify-page-types.js';
+import {
+  collectLocalResourceCatalog,
+  diffEvidenceAgainstCatalog,
+  type LocalResourceCatalog,
+} from './verify-resource-catalog.js';
+
+export type VerifyPageOptions = {
+  /** Friendly URL path (e.g. /web/guest/home) or a full http(s) URL. */
+  url: string;
+  credentials: BrowserLoginCredentials;
+  screenshotPath?: string;
+  skipLogin?: boolean;
+};
+
+export type VerifyPageDependencies = {
+  createRunner?: () => Promise<BrowserRunner> | BrowserRunner;
+  fetchPageEvidence?: (config: AppConfig, friendlyPath: string) => Promise<PageEvidence[]>;
+  resolveLocalCatalog?: (project: ProjectContext) => LocalResourceCatalog;
+};
+
+export type VerifyTarget = {
+  fullUrl: string;
+  friendlyPath: string;
+};
+
+export function resolveVerifyTarget(portalUrl: string, urlOption: string): VerifyTarget {
+  const trimmed = urlOption.trim();
+  if (/^https?:\/\//i.test(trimmed)) {
+    const parsed = new URL(trimmed);
+    return {fullUrl: trimmed, friendlyPath: `${parsed.pathname}${parsed.search}`};
+  }
+
+  const friendlyPath = trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+  return {fullUrl: `${portalUrl.replace(/\/+$/, '')}${friendlyPath}`, friendlyPath};
+}
+
+export async function runVerifyPage(
+  project: ProjectContext,
+  options: VerifyPageOptions,
+  dependencies?: VerifyPageDependencies,
+): Promise<VerifyPageReport> {
+  const portalUrl = project.env.portalUrl;
+  if (!portalUrl) {
+    throw new CliError(
+      'Cannot resolve a portal URL for this project. Configure liferay.url, run inside a repo, or pass a full --url.',
+      {code: 'VERIFY_PORTAL_URL_MISSING'},
+    );
+  }
+
+  const target = resolveVerifyTarget(portalUrl, options.url);
+  const screenshotPath = options.screenshotPath ?? defaultScreenshotPath(project.cwd, target.friendlyPath);
+  const createRunner = dependencies?.createRunner ?? createPlaywrightBrowserRunner;
+
+  let login: VerifyLoginResult = options.skipLogin
+    ? {status: 'skipped', detail: 'Login skipped (--skip-login).'}
+    : {status: 'fail', detail: 'Login was not attempted.'};
+  let consoleErrorsResult: VerifyConsoleErrorsResult = {status: 'skipped', errors: []};
+  let screenshot: VerifyScreenshotResult = {status: 'skipped', path: null, detail: 'Screenshot was not attempted.'};
+  let domSanity: VerifyDomSanityResult = {status: 'skipped', checks: []};
+  let navigation: VerifyNavigationResult;
+
+  const runner = await createRunner();
+  try {
+    if (!options.skipLogin) {
+      try {
+        const result = await runner.login(`${portalUrl.replace(/\/+$/, '')}/c/portal/login`, options.credentials);
+        login = {
+          status: 'pass',
+          detail: `Logged in as ${options.credentials.email}; landed on ${result.url}.`,
+        };
+      } catch (error) {
+        login = {status: 'fail', detail: `Login failed: ${errorMessage(error)}`};
+      }
+    }
+
+    try {
+      const result = await runner.open(target.fullUrl);
+      navigation = {
+        status: 'pass',
+        url: result.url,
+        title: result.title,
+        httpStatus: result.status,
+        detail: `Navigated to ${result.url} (status ${result.status ?? 'n/a'}).`,
+      };
+    } catch (error) {
+      navigation = {
+        status: 'fail',
+        url: target.fullUrl,
+        title: null,
+        httpStatus: null,
+        detail: `Navigation failed: ${errorMessage(error)}`,
+      };
+    }
+
+    if (navigation.status === 'pass') {
+      try {
+        const errors = await runner.getConsoleErrors();
+        consoleErrorsResult = {status: errors.length === 0 ? 'pass' : 'fail', errors};
+      } catch (error) {
+        consoleErrorsResult = {status: 'fail', errors: [errorMessage(error)]};
+      }
+
+      try {
+        await fs.mkdir(path.dirname(screenshotPath), {recursive: true});
+        await runner.captureScreenshot(screenshotPath);
+        screenshot = {status: 'pass', path: screenshotPath, detail: `Screenshot saved to ${screenshotPath}.`};
+      } catch (error) {
+        screenshot = {status: 'fail', path: null, detail: `Screenshot failed: ${errorMessage(error)}`};
+      }
+
+      try {
+        const snapshot = await runner.getDomSnapshot();
+        domSanity = evaluateDomSanity(snapshot);
+      } catch (error) {
+        domSanity = {
+          status: 'fail',
+          checks: [{id: 'dom-snapshot', status: 'fail', detail: `DOM snapshot failed: ${errorMessage(error)}`}],
+        };
+      }
+    }
+  } finally {
+    await runner.close().catch(() => undefined);
+  }
+
+  const resourceCatalog = await resolveResourceCatalogResult(project, target.friendlyPath, dependencies);
+
+  const ok = [
+    login.status,
+    navigation.status,
+    consoleErrorsResult.status,
+    screenshot.status,
+    domSanity.status,
+    resourceCatalog.status,
+  ].every((status) => status !== 'fail');
+
+  return {
+    ok,
+    url: target.fullUrl,
+    login,
+    navigation,
+    consoleErrors: consoleErrorsResult,
+    screenshot,
+    domSanity,
+    resourceCatalog,
+  };
+}
+
+async function resolveResourceCatalogResult(
+  project: ProjectContext,
+  friendlyPath: string,
+  dependencies?: VerifyPageDependencies,
+): Promise<VerifyResourceCatalogResult> {
+  const fetchPageEvidence = dependencies?.fetchPageEvidence ?? defaultFetchPageEvidence;
+  const resolveLocalCatalog = dependencies?.resolveLocalCatalog ?? collectLocalResourceCatalog;
+
+  try {
+    const evidence = await fetchPageEvidence(project.config, friendlyPath);
+    const catalog = resolveLocalCatalog(project);
+    return diffEvidenceAgainstCatalog(evidence, catalog);
+  } catch (error) {
+    return {
+      status: 'skipped',
+      detail: `Resource catalog comparison skipped: ${errorMessage(error)}`,
+      diffs: [],
+    };
+  }
+}
+
+async function defaultFetchPageEvidence(config: AppConfig, friendlyPath: string): Promise<PageEvidence[]> {
+  const pageResult = await runLiferayInventoryPage(config, {url: friendlyPath});
+  return extractPageEvidence(pageResult);
+}
+
+function defaultScreenshotPath(cwd: string, friendlyPath: string): string {
+  const slug =
+    friendlyPath
+      .replace(/^\/+/, '')
+      .replace(/[^a-zA-Z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '') || 'home';
+  return path.join(cwd, '.tmp', 'verify', `${slug}-${Date.now()}.png`);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/features/verify/verify-page.ts
+++ b/src/features/verify/verify-page.ts
@@ -70,7 +70,7 @@ export async function runVerifyPage(
 
   const target = resolveVerifyTarget(portalUrl, options.url);
   const screenshotPath = options.screenshotPath ?? defaultScreenshotPath(project.cwd, target.friendlyPath);
-  const createRunner = dependencies?.createRunner ?? createPlaywrightBrowserRunner;
+  const createRunner = dependencies?.createRunner ?? (() => createPlaywrightBrowserRunner(project.cwd));
 
   let login: VerifyLoginResult = options.skipLogin
     ? {status: 'skipped', detail: 'Login skipped (--skip-login).'}

--- a/src/features/verify/verify-resource-catalog.ts
+++ b/src/features/verify/verify-resource-catalog.ts
@@ -13,12 +13,32 @@ type PageEvidenceResourceType = PageEvidenceResourceTypeValue;
 /** Evidence resourceTypes that map 1:1 to a project resource catalog directory. */
 const CATALOG_RESOURCE_TYPES: readonly PageEvidenceResourceType[] = ['structure', 'template', 'adt', 'fragment'];
 
+/** Marker file `ldev resource export-fragment(s)` writes at the root of every exported fragment directory. */
+const FRAGMENT_MARKER_FILE = 'fragment.json';
+
+/**
+ * Prefix Liferay puts on a widget's `displayStyle` preference when it points at an ADT
+ * (e.g. `ddmTemplate_UB_ADT_FOO`). The evidence key carries this raw value so `where-used`
+ * can match on exactly what's stored in the portlet configuration; the exported ADT file
+ * is named after the bare template key, so the prefix has to be stripped before comparing.
+ */
+const ADT_DISPLAY_STYLE_PREFIX = 'ddmTemplate_';
+
+/**
+ * Fragment key prefixes Liferay ships out of the box (e.g. the "Basic Components"
+ * collection, seeded into every site). These never live under the project's own
+ * fragments directory, so flagging them as "missing" would just be noise.
+ */
+const OOTB_FRAGMENT_KEY_PREFIXES: readonly string[] = ['BASIC_COMPONENT-'];
+
 export type LocalResourceCatalog = Partial<Record<PageEvidenceResourceType, Set<string>>>;
 
 /**
  * Scans the project's own resource directories (liferay/resources/journal/structures,
- * templates, application_display templates, fragments) and collects file basenames
- * (without extension) as the set of keys the project tracks locally for each type.
+ * templates, application_display templates, fragments) and collects the set of keys
+ * the project tracks locally for each type: file basenames (without extension) for
+ * structures/templates/adts, and fragment directory names for fragments (a fragment
+ * is exported as a directory of files, so its key is the directory, not any file in it).
  *
  * Returns an empty catalog entry for a resource type when its directory does not
  * exist, so callers can distinguish "project has no catalog for this type" from
@@ -47,7 +67,8 @@ export function collectLocalResourceCatalog(project: ProjectContext): LocalResou
     if (!fs.existsSync(absolutePath)) {
       continue;
     }
-    catalog[resourceType] = collectBasenames(absolutePath);
+    catalog[resourceType] =
+      resourceType === 'fragment' ? collectFragmentDirectoryNames(absolutePath) : collectBasenames(absolutePath);
   }
 
   return catalog;
@@ -73,13 +94,18 @@ export function diffEvidenceAgainstCatalog(
   }
 
   const diffs: VerifyResourceCatalogDiff[] = [];
+  let consideredCount = 0;
 
-  for (const item of evidence) {
+  for (const item of dropRedundantContentStructureIds(evidence)) {
     if (!trackedTypes.includes(item.resourceType)) {
       continue;
     }
+    if (item.resourceType === 'fragment' && isOotbFragmentKey(item.key)) {
+      continue;
+    }
+    consideredCount += 1;
     const localKeys = catalog[item.resourceType];
-    if (localKeys && !localKeys.has(item.key)) {
+    if (localKeys && !localKeys.has(toCatalogKey(item))) {
       diffs.push({
         resourceType: item.resourceType,
         key: item.key,
@@ -92,10 +118,84 @@ export function diffEvidenceAgainstCatalog(
     status: diffs.length === 0 ? 'pass' : 'fail',
     detail:
       diffs.length === 0
-        ? `All ${evidence.length} evidence entries with a local catalog match the project's resource files.`
+        ? `All ${consideredCount} evidence entries with a local catalog match the project's resource files.`
         : `${diffs.length} rendered resource(s) are missing from the local catalog.`,
     diffs,
   };
+}
+
+function isOotbFragmentKey(key: string): boolean {
+  return OOTB_FRAGMENT_KEY_PREFIXES.some((prefix) => key.startsWith(prefix));
+}
+
+/** Maps an evidence key to the identifier the local catalog actually stores it under. */
+function toCatalogKey(item: PageEvidence): string {
+  if (item.resourceType === 'adt' && item.key.startsWith(ADT_DISPLAY_STYLE_PREFIX)) {
+    return item.key.slice(ADT_DISPLAY_STYLE_PREFIX.length);
+  }
+  return item.key;
+}
+
+/**
+ * `buildContentStructureEvidence` intentionally emits both the human key and the numeric
+ * contentStructureId as separate evidence entries for the same structure, so `where-used`
+ * queries can match on either identifier. For the local catalog that's one physical file,
+ * not two: drop the numeric-id candidate whenever a sibling entry for the same
+ * contentStructureId carries the real key, so it isn't flagged as "missing" on its own.
+ */
+function dropRedundantContentStructureIds(evidence: PageEvidence[]): PageEvidence[] {
+  const structureIdsWithKey = new Set<number>();
+  for (const item of evidence) {
+    if (item.resourceType === 'structure' && item.kind === 'contentStructure' && !isNumericKey(item.key)) {
+      const structureId = item.context?.contentStructureId;
+      if (structureId !== undefined) {
+        structureIdsWithKey.add(structureId);
+      }
+    }
+  }
+
+  return evidence.filter((item) => {
+    if (item.resourceType !== 'structure' || item.kind !== 'contentStructure' || !isNumericKey(item.key)) {
+      return true;
+    }
+    const structureId = item.context?.contentStructureId;
+    return structureId === undefined || !structureIdsWithKey.has(structureId);
+  });
+}
+
+function isNumericKey(key: string): boolean {
+  return /^\d+$/.test(key);
+}
+
+/**
+ * Fragments are exported as a directory of files (fragment.json, configuration.json,
+ * index.html/css/js), so the key is the directory name, not any file basename inside it.
+ * Walks the tree and records the directory name whenever it directly contains
+ * `fragment.json`, without descending into that directory's own files.
+ */
+function collectFragmentDirectoryNames(dir: string): Set<string> {
+  const names = new Set<string>();
+  const stack: string[] = [dir];
+
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!current) {
+      continue;
+    }
+    const entries = fs.readdirSync(current, {withFileTypes: true});
+    const isFragmentRoot = entries.some((entry) => entry.isFile() && entry.name === FRAGMENT_MARKER_FILE);
+    if (isFragmentRoot) {
+      names.add(path.basename(current));
+      continue;
+    }
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        stack.push(path.join(current, entry.name));
+      }
+    }
+  }
+
+  return names;
 }
 
 function collectBasenames(dir: string): Set<string> {

--- a/src/features/verify/verify-resource-catalog.ts
+++ b/src/features/verify/verify-resource-catalog.ts
@@ -1,0 +1,122 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import type {ProjectContext} from '../../core/config/project-context.js';
+import type {
+  PageEvidence,
+  PageEvidenceResourceTypeValue,
+} from '../liferay/inventory/liferay-inventory-evidence-contract.js';
+import type {VerifyResourceCatalogDiff, VerifyResourceCatalogResult} from './verify-page-types.js';
+
+type PageEvidenceResourceType = PageEvidenceResourceTypeValue;
+
+/** Evidence resourceTypes that map 1:1 to a project resource catalog directory. */
+const CATALOG_RESOURCE_TYPES: readonly PageEvidenceResourceType[] = ['structure', 'template', 'adt', 'fragment'];
+
+export type LocalResourceCatalog = Partial<Record<PageEvidenceResourceType, Set<string>>>;
+
+/**
+ * Scans the project's own resource directories (liferay/resources/journal/structures,
+ * templates, application_display templates, fragments) and collects file basenames
+ * (without extension) as the set of keys the project tracks locally for each type.
+ *
+ * Returns an empty catalog entry for a resource type when its directory does not
+ * exist, so callers can distinguish "project has no catalog for this type" from
+ * "catalog exists but the key is missing".
+ */
+export function collectLocalResourceCatalog(project: ProjectContext): LocalResourceCatalog {
+  const repoRoot = project.repo.root;
+  if (!repoRoot) {
+    return {};
+  }
+
+  const catalog: LocalResourceCatalog = {};
+  const pathsByType: Partial<Record<PageEvidenceResourceType, string>> = {
+    structure: project.paths.structures,
+    template: project.paths.templates,
+    adt: project.paths.adts,
+    fragment: project.paths.fragments,
+  };
+
+  for (const resourceType of CATALOG_RESOURCE_TYPES) {
+    const relativePath = pathsByType[resourceType];
+    if (!relativePath) {
+      continue;
+    }
+    const absolutePath = path.resolve(repoRoot, relativePath);
+    if (!fs.existsSync(absolutePath)) {
+      continue;
+    }
+    catalog[resourceType] = collectBasenames(absolutePath);
+  }
+
+  return catalog;
+}
+
+/**
+ * Compares page evidence (what the rendered page actually uses) against the
+ * project's local resource catalog. Only evidence resourceTypes with a known
+ * local catalog directory are considered; everything else is ignored.
+ */
+export function diffEvidenceAgainstCatalog(
+  evidence: PageEvidence[],
+  catalog: LocalResourceCatalog,
+): VerifyResourceCatalogResult {
+  const trackedTypes = CATALOG_RESOURCE_TYPES.filter((resourceType) => catalog[resourceType] !== undefined);
+
+  if (trackedTypes.length === 0) {
+    return {
+      status: 'skipped',
+      detail: 'Project has no local resource catalog (structures/templates/adts/fragments directories not found).',
+      diffs: [],
+    };
+  }
+
+  const diffs: VerifyResourceCatalogDiff[] = [];
+
+  for (const item of evidence) {
+    if (!trackedTypes.includes(item.resourceType)) {
+      continue;
+    }
+    const localKeys = catalog[item.resourceType];
+    if (localKeys && !localKeys.has(item.key)) {
+      diffs.push({
+        resourceType: item.resourceType,
+        key: item.key,
+        detail: `Rendered page uses ${item.resourceType} "${item.key}" which was not found in the local resource catalog.`,
+      });
+    }
+  }
+
+  return {
+    status: diffs.length === 0 ? 'pass' : 'fail',
+    detail:
+      diffs.length === 0
+        ? `All ${evidence.length} evidence entries with a local catalog match the project's resource files.`
+        : `${diffs.length} rendered resource(s) are missing from the local catalog.`,
+    diffs,
+  };
+}
+
+function collectBasenames(dir: string): Set<string> {
+  const basenames = new Set<string>();
+  const stack: string[] = [dir];
+
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!current) {
+      continue;
+    }
+    const entries = fs.readdirSync(current, {withFileTypes: true});
+    for (const entry of entries) {
+      const entryPath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(entryPath);
+      } else if (entry.isFile()) {
+        basenames.add(path.parse(entry.name).name);
+      }
+    }
+  }
+
+  return basenames;
+}

--- a/tests/unit/verify-browser-runner.test.ts
+++ b/tests/unit/verify-browser-runner.test.ts
@@ -4,7 +4,7 @@ import {createPlaywrightBrowserRunner} from '../../src/features/verify/verify-br
 
 describe('createPlaywrightBrowserRunner', () => {
   test('throws a clear, actionable error when playwright is not installed', async () => {
-    await expect(createPlaywrightBrowserRunner()).rejects.toThrow(/Playwright is not installed/);
-    await expect(createPlaywrightBrowserRunner()).rejects.toThrow(/npm install --save-dev playwright/);
+    await expect(createPlaywrightBrowserRunner(process.cwd())).rejects.toThrow(/Playwright is not installed/);
+    await expect(createPlaywrightBrowserRunner(process.cwd())).rejects.toThrow(/npm install --save-dev playwright/);
   });
 });

--- a/tests/unit/verify-browser-runner.test.ts
+++ b/tests/unit/verify-browser-runner.test.ts
@@ -1,0 +1,10 @@
+import {describe, expect, test} from 'vitest';
+
+import {createPlaywrightBrowserRunner} from '../../src/features/verify/verify-browser-runner.js';
+
+describe('createPlaywrightBrowserRunner', () => {
+  test('throws a clear, actionable error when playwright is not installed', async () => {
+    await expect(createPlaywrightBrowserRunner()).rejects.toThrow(/Playwright is not installed/);
+    await expect(createPlaywrightBrowserRunner()).rejects.toThrow(/npm install --save-dev playwright/);
+  });
+});

--- a/tests/unit/verify-command.test.ts
+++ b/tests/unit/verify-command.test.ts
@@ -1,0 +1,28 @@
+import {describe, expect, test} from 'vitest';
+
+import {createVerifyCommand} from '../../src/commands/verify/verify.command.js';
+
+describe('createVerifyCommand', () => {
+  test('registers a page subcommand with the expected options', () => {
+    const command = createVerifyCommand();
+    const page = command.commands.find((sub) => sub.name() === 'page');
+
+    expect(page).toBeDefined();
+    const optionNames = page?.options.map((option) => option.long) ?? [];
+
+    expect(optionNames).toContain('--url');
+    expect(optionNames).toContain('--screenshot');
+    expect(optionNames).toContain('--skip-login');
+    expect(optionNames).toContain('--login-email');
+    expect(optionNames).toContain('--login-password');
+    expect(optionNames).toContain('--json');
+  });
+
+  test('requires --url', () => {
+    const command = createVerifyCommand();
+    const page = command.commands.find((sub) => sub.name() === 'page');
+
+    const requiredOption = page?.options.find((option) => option.long === '--url');
+    expect(requiredOption?.mandatory).toBe(true);
+  });
+});

--- a/tests/unit/verify-login-credentials.test.ts
+++ b/tests/unit/verify-login-credentials.test.ts
@@ -1,0 +1,35 @@
+import {describe, expect, test} from 'vitest';
+
+import {resolveVerifyLoginCredentials} from '../../src/features/verify/verify-login-credentials.js';
+
+describe('resolveVerifyLoginCredentials', () => {
+  test('falls back to the default local Liferay test user', () => {
+    const credentials = resolveVerifyLoginCredentials({env: {}});
+
+    expect(credentials).toEqual({email: 'test@liferay.com', password: 'test'});
+  });
+
+  test('prefers environment variables over defaults', () => {
+    const credentials = resolveVerifyLoginCredentials({
+      env: {LDEV_VERIFY_LOGIN_EMAIL: 'env@example.com', LDEV_VERIFY_LOGIN_PASSWORD: 'env-pass'},
+    });
+
+    expect(credentials).toEqual({email: 'env@example.com', password: 'env-pass'});
+  });
+
+  test('prefers explicit values over environment variables and defaults', () => {
+    const credentials = resolveVerifyLoginCredentials({
+      email: 'flag@example.com',
+      password: 'flag-pass',
+      env: {LDEV_VERIFY_LOGIN_EMAIL: 'env@example.com', LDEV_VERIFY_LOGIN_PASSWORD: 'env-pass'},
+    });
+
+    expect(credentials).toEqual({email: 'flag@example.com', password: 'flag-pass'});
+  });
+
+  test('ignores blank explicit values', () => {
+    const credentials = resolveVerifyLoginCredentials({email: '   ', password: '', env: {}});
+
+    expect(credentials).toEqual({email: 'test@liferay.com', password: 'test'});
+  });
+});

--- a/tests/unit/verify-page-dom-checks.test.ts
+++ b/tests/unit/verify-page-dom-checks.test.ts
@@ -1,0 +1,49 @@
+import {describe, expect, test} from 'vitest';
+
+import {evaluateDomSanity} from '../../src/features/verify/verify-page-dom-checks.js';
+import type {BrowserDomSnapshot} from '../../src/features/verify/browser-runner-types.js';
+
+const HEALTHY_SNAPSHOT: BrowserDomSnapshot = {
+  title: 'Guest Home',
+  bodyTextLength: 500,
+  headingCount: 2,
+  hasVisibleErrorBanner: false,
+};
+
+describe('evaluateDomSanity', () => {
+  test('passes all checks for a healthy snapshot', () => {
+    const result = evaluateDomSanity(HEALTHY_SNAPSHOT);
+
+    expect(result.status).toBe('pass');
+    expect(result.checks).toHaveLength(4);
+    expect(result.checks.every((check) => check.status === 'pass')).toBe(true);
+  });
+
+  test('fails when the title is empty', () => {
+    const result = evaluateDomSanity({...HEALTHY_SNAPSHOT, title: '  '});
+
+    expect(result.status).toBe('fail');
+    expect(result.checks.find((check) => check.id === 'has-title')?.status).toBe('fail');
+  });
+
+  test('fails when body text is empty', () => {
+    const result = evaluateDomSanity({...HEALTHY_SNAPSHOT, bodyTextLength: 0});
+
+    expect(result.status).toBe('fail');
+    expect(result.checks.find((check) => check.id === 'has-body-content')?.status).toBe('fail');
+  });
+
+  test('fails when no heading elements are present', () => {
+    const result = evaluateDomSanity({...HEALTHY_SNAPSHOT, headingCount: 0});
+
+    expect(result.status).toBe('fail');
+    expect(result.checks.find((check) => check.id === 'has-heading')?.status).toBe('fail');
+  });
+
+  test('fails when a visible error banner is detected', () => {
+    const result = evaluateDomSanity({...HEALTHY_SNAPSHOT, hasVisibleErrorBanner: true});
+
+    expect(result.status).toBe('fail');
+    expect(result.checks.find((check) => check.id === 'no-visible-error-banner')?.status).toBe('fail');
+  });
+});

--- a/tests/unit/verify-page.test.ts
+++ b/tests/unit/verify-page.test.ts
@@ -1,0 +1,310 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {describe, expect, test, vi} from 'vitest';
+
+import {resolveProjectContext, type ProjectContext} from '../../src/core/config/project-context.js';
+import {createTempRepo} from '../../src/testing/temp-repo.js';
+import {
+  resolveVerifyTarget,
+  runVerifyPage,
+  type VerifyPageDependencies,
+} from '../../src/features/verify/verify-page.js';
+import type {
+  BrowserDomSnapshot,
+  BrowserLoginCredentials,
+  BrowserNavigationResult,
+  BrowserRunner,
+} from '../../src/features/verify/browser-runner-types.js';
+import type {PageEvidence} from '../../src/features/liferay/inventory/liferay-inventory-evidence-contract.js';
+
+const HEALTHY_SNAPSHOT: BrowserDomSnapshot = {
+  title: 'Guest Home',
+  bodyTextLength: 500,
+  headingCount: 2,
+  hasVisibleErrorBanner: false,
+};
+
+type FakeRunnerOverrides = Partial<{
+  login: (loginUrl: string, credentials: BrowserLoginCredentials) => Promise<BrowserNavigationResult>;
+  open: (url: string) => Promise<BrowserNavigationResult>;
+  getConsoleErrors: () => Promise<string[]>;
+  captureScreenshot: (path: string) => Promise<void>;
+  getDomSnapshot: () => Promise<BrowserDomSnapshot>;
+}>;
+
+function createFakeRunner(overrides?: FakeRunnerOverrides): {runner: BrowserRunner; calls: string[]} {
+  const calls: string[] = [];
+  const close = vi.fn(() => {
+    calls.push('close');
+    return Promise.resolve();
+  });
+
+  const runner: BrowserRunner = {
+    login:
+      overrides?.login ??
+      ((loginUrl, credentials) => {
+        calls.push(`login:${loginUrl}:${credentials.email}`);
+        return Promise.resolve({url: `${loginUrl}/../home`, title: 'Home', status: 200});
+      }),
+    open:
+      overrides?.open ??
+      ((url) => {
+        calls.push(`open:${url}`);
+        return Promise.resolve({url, title: 'Guest Home', status: 200});
+      }),
+    getConsoleErrors: overrides?.getConsoleErrors ?? (() => Promise.resolve([])),
+    captureScreenshot:
+      overrides?.captureScreenshot ??
+      ((screenshotPath) => {
+        calls.push(`screenshot:${screenshotPath}`);
+        return Promise.resolve();
+      }),
+    getDomSnapshot: overrides?.getDomSnapshot ?? (() => Promise.resolve(HEALTHY_SNAPSHOT)),
+    close,
+  };
+
+  return {runner, calls};
+}
+
+function createProject(): ProjectContext {
+  const repoRoot = createTempRepo();
+  fs.writeFileSync(path.join(repoRoot, 'docker', '.env'), ['BIND_IP=127.0.0.1', 'LIFERAY_HTTP_PORT=8080'].join('\n'));
+  return resolveProjectContext({cwd: repoRoot});
+}
+
+function noEvidenceDependencies(): VerifyPageDependencies {
+  return {
+    fetchPageEvidence: () => Promise.resolve([]),
+  };
+}
+
+describe('resolveVerifyTarget', () => {
+  test('joins the portal URL with a relative friendly URL', () => {
+    const target = resolveVerifyTarget('http://127.0.0.1:8080', '/web/guest/home');
+
+    expect(target).toEqual({fullUrl: 'http://127.0.0.1:8080/web/guest/home', friendlyPath: '/web/guest/home'});
+  });
+
+  test('adds a leading slash when missing', () => {
+    const target = resolveVerifyTarget('http://127.0.0.1:8080', 'web/guest/home');
+
+    expect(target.fullUrl).toBe('http://127.0.0.1:8080/web/guest/home');
+  });
+
+  test('passes through a full URL and extracts its path for evidence lookups', () => {
+    const target = resolveVerifyTarget('http://127.0.0.1:8080', 'https://example.com/web/guest/home?x=1');
+
+    expect(target.fullUrl).toBe('https://example.com/web/guest/home?x=1');
+    expect(target.friendlyPath).toBe('/web/guest/home?x=1');
+  });
+});
+
+describe('runVerifyPage', () => {
+  test('reports an overall pass when every step succeeds', async () => {
+    const project = createProject();
+    const {runner, calls} = createFakeRunner();
+
+    const report = await runVerifyPage(
+      project,
+      {url: '/web/guest/home', credentials: {email: 'test@liferay.com', password: 'test'}},
+      {createRunner: () => runner, ...noEvidenceDependencies()},
+    );
+
+    expect(report.ok).toBe(true);
+    expect(report.login.status).toBe('pass');
+    expect(report.navigation.status).toBe('pass');
+    expect(report.consoleErrors).toEqual({status: 'pass', errors: []});
+    expect(report.screenshot.status).toBe('pass');
+    expect(report.domSanity.status).toBe('pass');
+    expect(report.resourceCatalog.status).toBe('skipped');
+    expect(calls[0]).toMatch(/^login:/);
+    expect(calls[1]).toBe('open:http://localhost:8080/web/guest/home');
+    expect(calls).toContain('close');
+  });
+
+  test('skips login when --skip-login is set', async () => {
+    const project = createProject();
+    const {runner, calls} = createFakeRunner();
+
+    const report = await runVerifyPage(
+      project,
+      {url: '/web/guest/home', credentials: {email: 'test@liferay.com', password: 'test'}, skipLogin: true},
+      {createRunner: () => runner, ...noEvidenceDependencies()},
+    );
+
+    expect(report.login).toEqual({status: 'skipped', detail: 'Login skipped (--skip-login).'});
+    expect(calls.some((call) => call.startsWith('login:'))).toBe(false);
+    expect(report.navigation.status).toBe('pass');
+  });
+
+  test('marks the report as failed and still navigates when login throws', async () => {
+    const project = createProject();
+    const {runner} = createFakeRunner({
+      login: () => Promise.reject(new Error('invalid credentials')),
+    });
+
+    const report = await runVerifyPage(
+      project,
+      {url: '/web/guest/home', credentials: {email: 'bad@liferay.com', password: 'wrong'}},
+      {createRunner: () => runner, ...noEvidenceDependencies()},
+    );
+
+    expect(report.login.status).toBe('fail');
+    expect(report.login.detail).toContain('invalid credentials');
+    expect(report.navigation.status).toBe('pass');
+    expect(report.ok).toBe(false);
+  });
+
+  test('skips console/screenshot/dom checks and fails overall when navigation throws', async () => {
+    const project = createProject();
+    const {runner} = createFakeRunner({
+      open: () => Promise.reject(new Error('net::ERR_CONNECTION_REFUSED')),
+    });
+
+    const report = await runVerifyPage(
+      project,
+      {url: '/web/guest/home', credentials: {email: 'test@liferay.com', password: 'test'}},
+      {createRunner: () => runner, ...noEvidenceDependencies()},
+    );
+
+    expect(report.navigation.status).toBe('fail');
+    expect(report.consoleErrors.status).toBe('skipped');
+    expect(report.screenshot.status).toBe('skipped');
+    expect(report.domSanity.status).toBe('skipped');
+    expect(report.ok).toBe(false);
+  });
+
+  test('fails overall when console errors are captured', async () => {
+    const project = createProject();
+    const {runner} = createFakeRunner({
+      getConsoleErrors: () => Promise.resolve(['TypeError: something is not a function']),
+    });
+
+    const report = await runVerifyPage(
+      project,
+      {url: '/web/guest/home', credentials: {email: 'test@liferay.com', password: 'test'}},
+      {createRunner: () => runner, ...noEvidenceDependencies()},
+    );
+
+    expect(report.consoleErrors).toEqual({status: 'fail', errors: ['TypeError: something is not a function']});
+    expect(report.ok).toBe(false);
+  });
+
+  test('fails overall when the DOM sanity checks detect a visible error banner', async () => {
+    const project = createProject();
+    const {runner} = createFakeRunner({
+      getDomSnapshot: () => Promise.resolve({...HEALTHY_SNAPSHOT, hasVisibleErrorBanner: true}),
+    });
+
+    const report = await runVerifyPage(
+      project,
+      {url: '/web/guest/home', credentials: {email: 'test@liferay.com', password: 'test'}},
+      {createRunner: () => runner, ...noEvidenceDependencies()},
+    );
+
+    expect(report.domSanity.status).toBe('fail');
+    expect(report.ok).toBe(false);
+  });
+
+  test('always closes the runner even when a step throws', async () => {
+    const project = createProject();
+    const {runner, calls} = createFakeRunner({
+      getDomSnapshot: () => Promise.reject(new Error('page crashed')),
+    });
+
+    const report = await runVerifyPage(
+      project,
+      {url: '/web/guest/home', credentials: {email: 'test@liferay.com', password: 'test'}},
+      {createRunner: () => runner, ...noEvidenceDependencies()},
+    );
+
+    expect(report.domSanity.status).toBe('fail');
+    expect(calls).toContain('close');
+  });
+
+  test('writes the screenshot under the project cwd by default', async () => {
+    const project = createProject();
+    const {runner} = createFakeRunner();
+
+    const report = await runVerifyPage(
+      project,
+      {url: '/web/guest/home', credentials: {email: 'test@liferay.com', password: 'test'}},
+      {createRunner: () => runner, ...noEvidenceDependencies()},
+    );
+
+    expect(report.screenshot.path).toMatch(/\.tmp[\\/]verify[\\/]web-guest-home-\d+\.png$/);
+    expect(fs.existsSync(path.dirname(report.screenshot.path ?? ''))).toBe(true);
+  });
+
+  test('honors an explicit screenshot path', async () => {
+    const project = createProject();
+    const {runner} = createFakeRunner();
+    const screenshotPath = path.join(project.cwd, 'custom', 'shot.png');
+
+    const report = await runVerifyPage(
+      project,
+      {url: '/web/guest/home', credentials: {email: 'test@liferay.com', password: 'test'}, screenshotPath},
+      {createRunner: () => runner, ...noEvidenceDependencies()},
+    );
+
+    expect(report.screenshot.path).toBe(screenshotPath);
+  });
+
+  test('reports a resource catalog diff when rendered evidence is missing locally', async () => {
+    const project = createProject();
+    fs.mkdirSync(path.join(project.cwd, 'liferay', 'resources', 'journal', 'structures'), {recursive: true});
+    fs.writeFileSync(path.join(project.cwd, 'liferay', 'resources', 'journal', 'structures', 'article.json'), '{}');
+    const {runner} = createFakeRunner();
+    const evidence: PageEvidence[] = [
+      {
+        resourceType: 'structure',
+        key: 'missing-structure',
+        kind: 'contentStructure',
+        detail: 'structure missing-structure',
+        source: 'contentStructure',
+      },
+    ];
+
+    const report = await runVerifyPage(
+      project,
+      {url: '/web/guest/home', credentials: {email: 'test@liferay.com', password: 'test'}},
+      {createRunner: () => runner, fetchPageEvidence: () => Promise.resolve(evidence)},
+    );
+
+    expect(report.resourceCatalog.status).toBe('fail');
+    expect(report.resourceCatalog.diffs).toEqual([
+      expect.objectContaining({resourceType: 'structure', key: 'missing-structure'}),
+    ]);
+    expect(report.ok).toBe(false);
+  });
+
+  test('skips the resource catalog step when evidence cannot be fetched', async () => {
+    const project = createProject();
+    const {runner} = createFakeRunner();
+
+    const report = await runVerifyPage(
+      project,
+      {url: '/web/guest/home', credentials: {email: 'test@liferay.com', password: 'test'}},
+      {createRunner: () => runner, fetchPageEvidence: () => Promise.reject(new Error('offline'))},
+    );
+
+    expect(report.resourceCatalog.status).toBe('skipped');
+    expect(report.resourceCatalog.detail).toContain('offline');
+    expect(report.ok).toBe(true);
+  });
+
+  test('throws a clear error when no portal URL can be resolved', async () => {
+    const project = createProject();
+    const projectWithoutPortalUrl: ProjectContext = {...project, env: {...project.env, portalUrl: null}};
+    const {runner} = createFakeRunner();
+
+    await expect(
+      runVerifyPage(
+        projectWithoutPortalUrl,
+        {url: '/web/guest/home', credentials: {email: 'test@liferay.com', password: 'test'}},
+        {createRunner: () => runner, ...noEvidenceDependencies()},
+      ),
+    ).rejects.toThrow(/Cannot resolve a portal URL/);
+  });
+});

--- a/tests/unit/verify-resource-catalog.test.ts
+++ b/tests/unit/verify-resource-catalog.test.ts
@@ -36,15 +36,38 @@ describe('collectLocalResourceCatalog', () => {
     const repoRoot = createTempRepo();
     fs.mkdirSync(path.join(repoRoot, 'liferay', 'resources', 'journal', 'structures'), {recursive: true});
     fs.writeFileSync(path.join(repoRoot, 'liferay', 'resources', 'journal', 'structures', 'article.json'), '{}');
-    fs.mkdirSync(path.join(repoRoot, 'liferay', 'fragments', 'hero'), {recursive: true});
-    fs.writeFileSync(path.join(repoRoot, 'liferay', 'fragments', 'hero', 'hero-banner.html'), '<div></div>');
 
     const project = resolveProjectContext({cwd: repoRoot});
     const catalog = collectLocalResourceCatalog(project);
 
     expect(catalog.structure?.has('article')).toBe(true);
-    expect(catalog.fragment?.has('hero-banner')).toBe(true);
     expect(catalog.template).toBeUndefined();
+  });
+
+  test('collects fragment directory names, not the file basenames inside them', () => {
+    const repoRoot = createTempRepo();
+    const fragmentDir = path.join(
+      repoRoot,
+      'liferay',
+      'fragments',
+      'sites',
+      'global',
+      'src',
+      'hero-collection',
+      'fragments',
+      'hero-banner',
+    );
+    fs.mkdirSync(fragmentDir, {recursive: true});
+    fs.writeFileSync(path.join(fragmentDir, 'fragment.json'), '{}');
+    fs.writeFileSync(path.join(fragmentDir, 'configuration.json'), '{}');
+    fs.writeFileSync(path.join(fragmentDir, 'index.html'), '<div></div>');
+
+    const project = resolveProjectContext({cwd: repoRoot});
+    const catalog = collectLocalResourceCatalog(project);
+
+    expect(catalog.fragment?.has('hero-banner')).toBe(true);
+    expect(catalog.fragment?.has('index')).toBe(false);
+    expect(catalog.fragment?.has('configuration')).toBe(false);
   });
 });
 
@@ -85,5 +108,67 @@ describe('diffEvidenceAgainstCatalog', () => {
 
     expect(result.status).toBe('pass');
     expect(result.diffs).toEqual([]);
+  });
+
+  test('ignores fragments from Liferay out-of-the-box collections (e.g. Basic Components)', () => {
+    const result = diffEvidenceAgainstCatalog(
+      [buildEvidence({resourceType: 'fragment', key: 'BASIC_COMPONENT-image'})],
+      {fragment: new Set(['hero-banner'])},
+    );
+
+    expect(result.status).toBe('pass');
+    expect(result.diffs).toEqual([]);
+  });
+
+  test('strips the ddmTemplate_ prefix before matching adt evidence against the local catalog', () => {
+    const result = diffEvidenceAgainstCatalog(
+      [buildEvidence({resourceType: 'adt', key: 'ddmTemplate_UB_ADT_FOO', kind: 'widgetAdt'})],
+      {adt: new Set(['UB_ADT_FOO'])},
+    );
+
+    expect(result.status).toBe('pass');
+    expect(result.diffs).toEqual([]);
+  });
+
+  test('does not flag the numeric contentStructureId candidate when a sibling entry has the real key', () => {
+    // buildContentStructureEvidence emits both forms so `where-used` can match on either;
+    // for the catalog diff they're the same physical structure file.
+    const result = diffEvidenceAgainstCatalog(
+      [
+        buildEvidence({
+          resourceType: 'structure',
+          key: 'UB_STR_FOO',
+          kind: 'contentStructure',
+          context: {contentStructureId: 301, contentStructureName: 'Foo'},
+        }),
+        buildEvidence({
+          resourceType: 'structure',
+          key: '301',
+          kind: 'contentStructure',
+          context: {contentStructureId: 301, contentStructureName: 'Foo'},
+        }),
+      ],
+      {structure: new Set(['UB_STR_FOO'])},
+    );
+
+    expect(result.status).toBe('pass');
+    expect(result.diffs).toEqual([]);
+  });
+
+  test('still flags a numeric-only contentStructureId candidate that has no keyed sibling', () => {
+    const result = diffEvidenceAgainstCatalog(
+      [
+        buildEvidence({
+          resourceType: 'structure',
+          key: '301',
+          kind: 'contentStructure',
+          context: {contentStructureId: 301, contentStructureName: 'Foo'},
+        }),
+      ],
+      {structure: new Set(['UB_STR_OTHER'])},
+    );
+
+    expect(result.status).toBe('fail');
+    expect(result.diffs).toEqual([expect.objectContaining({resourceType: 'structure', key: '301'})]);
   });
 });

--- a/tests/unit/verify-resource-catalog.test.ts
+++ b/tests/unit/verify-resource-catalog.test.ts
@@ -1,0 +1,89 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {describe, expect, test} from 'vitest';
+
+import {resolveProjectContext} from '../../src/core/config/project-context.js';
+import {createTempRepo} from '../../src/testing/temp-repo.js';
+import {
+  collectLocalResourceCatalog,
+  diffEvidenceAgainstCatalog,
+} from '../../src/features/verify/verify-resource-catalog.js';
+import type {PageEvidence} from '../../src/features/liferay/inventory/liferay-inventory-evidence-contract.js';
+
+function buildEvidence(overrides: Partial<PageEvidence>): PageEvidence {
+  return {
+    resourceType: 'fragment',
+    key: 'hero-banner',
+    kind: 'fragmentEntry',
+    detail: 'fragment hero-banner',
+    source: 'fragmentEntryLink',
+    ...overrides,
+  };
+}
+
+describe('collectLocalResourceCatalog', () => {
+  test('returns an empty catalog when the repo has no resource directories', () => {
+    const repoRoot = createTempRepo();
+    const project = resolveProjectContext({cwd: repoRoot});
+
+    const catalog = collectLocalResourceCatalog(project);
+
+    expect(catalog).toEqual({});
+  });
+
+  test('collects file basenames per resource type when directories exist', () => {
+    const repoRoot = createTempRepo();
+    fs.mkdirSync(path.join(repoRoot, 'liferay', 'resources', 'journal', 'structures'), {recursive: true});
+    fs.writeFileSync(path.join(repoRoot, 'liferay', 'resources', 'journal', 'structures', 'article.json'), '{}');
+    fs.mkdirSync(path.join(repoRoot, 'liferay', 'fragments', 'hero'), {recursive: true});
+    fs.writeFileSync(path.join(repoRoot, 'liferay', 'fragments', 'hero', 'hero-banner.html'), '<div></div>');
+
+    const project = resolveProjectContext({cwd: repoRoot});
+    const catalog = collectLocalResourceCatalog(project);
+
+    expect(catalog.structure?.has('article')).toBe(true);
+    expect(catalog.fragment?.has('hero-banner')).toBe(true);
+    expect(catalog.template).toBeUndefined();
+  });
+});
+
+describe('diffEvidenceAgainstCatalog', () => {
+  test('marks the result as skipped when the project has no catalog for any evidence resource type', () => {
+    const result = diffEvidenceAgainstCatalog([buildEvidence({})], {});
+
+    expect(result.status).toBe('skipped');
+    expect(result.diffs).toEqual([]);
+  });
+
+  test('passes when every evidence entry has a matching local resource', () => {
+    const result = diffEvidenceAgainstCatalog([buildEvidence({resourceType: 'fragment', key: 'hero-banner'})], {
+      fragment: new Set(['hero-banner']),
+    });
+
+    expect(result.status).toBe('pass');
+    expect(result.diffs).toEqual([]);
+  });
+
+  test('reports a diff for evidence keys missing from the local catalog', () => {
+    const result = diffEvidenceAgainstCatalog([buildEvidence({resourceType: 'fragment', key: 'missing-fragment'})], {
+      fragment: new Set(['hero-banner']),
+    });
+
+    expect(result.status).toBe('fail');
+    expect(result.diffs).toEqual([expect.objectContaining({resourceType: 'fragment', key: 'missing-fragment'})]);
+  });
+
+  test('ignores evidence resource types that have no tracked local catalog', () => {
+    const result = diffEvidenceAgainstCatalog(
+      [
+        buildEvidence({resourceType: 'portlet', key: 'some-portlet'}),
+        buildEvidence({resourceType: 'fragment', key: 'hero-banner'}),
+      ],
+      {fragment: new Set(['hero-banner'])},
+    );
+
+    expect(result.status).toBe('pass');
+    expect(result.diffs).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `ldev verify page --url <friendlyUrl>` to run the full post-change visual verification sequence in one call: login, navigation, console error capture, screenshot, and DOM sanity checks, returning a structured pass/fail report (with `--json` support and a non-zero exit code on failure).
- Adds a resource catalog step: when the project has a local resource catalog (structures/templates/adts/fragments directories), it fetches the rendered page's evidence via the existing `portal inventory page` machinery and diffs it against the files tracked on disk, reporting missing resources.
- The browser runner is an injectable interface (`BrowserRunner`) so the orchestration, DOM sanity rules, and resource-catalog diffing are all unit-tested against a fake runner, with no real browser involved.
- Replaces the manual, multi-step flow previously only documented in the `automating-browser-tests` skill.

## Design notes

- `playwright` is intentionally **not** a `package.json` dependency. ldev is a globally-installed CLI; bundling Playwright (plus its Chromium download) would force every install to pull down a browser binary even for users who never run `verify page`. Instead, `createPlaywrightBrowserRunner` dynamically imports `playwright` at runtime and throws a clear, actionable `CliError` (with install instructions) when it's missing — the same "runtime-detected optional capability" pattern `doctor` already uses for `playwright-cli`.
- To keep typecheck/lint green without requiring `playwright` to be installed, a minimal ambient `.d.ts` declares only the surface the runner actually uses (`chromium.launch`, `Page`, `Browser`, `ConsoleMessage`).
- Verified end-to-end against a real local Liferay instance: login, navigation, console error capture, full-page screenshot, and DOM sanity checks all passed against a live logged-in admin session, and correctly reported console errors + a 404 on an invalid page path.

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:unit` (124 files / 1314 tests passed)
- [x] Manual end-to-end run against a running local Liferay instance with `playwright` installed (login, navigation, screenshot, console errors, DOM sanity, `--json` output all verified)

Fixes #172